### PR TITLE
MAINT: update make doc - prevent rebuilding doc in case of bugs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,4 +1,4 @@
-# Minimal makefile for Sphinx documentation
+# Makefile for Sphinx documentation
 #
 
 # You can set these variables from the command line, and also
@@ -15,12 +15,17 @@ help:
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+# "make mode" option. $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@mkdir $(BUILDDIR)_tmp 
+	@cp -r $(BUILDDIR)/* $(BUILDDIR)_tmp 2>/dev/null || true
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) || \
+    (echo "An error occurred while generating the documentation. Returning to previous version." && \
+	rm -rf $(BUILDDIR) && mv $(BUILDDIR)_tmp $(BUILDDIR) && false)
+	@rm -rf $(BUILDDIR)_tmp
 	
 clean:
-	@rm -rf build
-	@rm -rf source/savefig
+	@rm -rf $(BUILDDIR)
+	@rm -rf $(SOURCEDIR)/savefig
 	@rm -rf *.hdf5 *yaml
-	@rm -rf source/api_reference/smash
+	@rm -rf $(SOURCEDIR)/api_reference/smash

--- a/doc/source/release/0.4.1-notes.rst
+++ b/doc/source/release/0.4.1-notes.rst
@@ -1,0 +1,49 @@
+.. _release.0.4.1-notes:
+
+.. currentmodule:: smash
+
+=========================
+smash 0.4.1 Release Notes
+=========================
+
+The smash 0.4.1 release continues the ongoing work to improve the handling, fix possible bugs, clarify the documentation. The highlights are:
+
+------------
+Contributors
+------------
+
+This release was made possible thanks to the contributions of:
+
+---------------
+Compatibilities
+---------------
+
+------------
+Deprecations
+------------
+
+------------
+Improvements
+------------
+
+Generating documentation
+************************
+
+The command ``make doc`` has been updated to prevent rebuilding the entire documentation in case of errors. 
+The updated command will return to the previous version of the documentation if an error occurs, without requiring developers to rebuild the entire documentation from scratch.
+
+For example, if a bug occurs when running the ``make doc`` command, it will result in the following message:
+
+.. code-block:: bash
+
+    An error occurred while generating the documentation. Returning to previous version.
+
+This ensures that developers do not need to rebuild the entire documentation during subsequent generation processes.
+
+------------
+New Features
+------------
+
+-----
+Fixes
+-----

--- a/doc/source/release/index.rst
+++ b/doc/source/release/index.rst
@@ -7,6 +7,7 @@ Release notes
 .. toctree::
     :maxdepth: 3
 
+    0.4.1 <0.4.1-notes>
     0.4.0 <0.4.0-notes>
     0.3.1 <0.3.1-notes>
     0.3.0 <0.3.0-notes>


### PR DESCRIPTION
Create build_tmp directory and reverse previous version of the documentation in case of errors.