### PR TITLE
ENC/MAINT: add regio operators and clean math/num documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **smash** is a Python library, that provides a variety of user-friendly routines for hydrological data preprocessing and numerical analysis, specifically high-dimensional optimization tools interfacing with an efficient Fortran solver.
 
-**smash** offers a range of advanced optimization techniques, including Variational Data Assimilation (VDA), Bayesian estimation, and Artificial Neural Network (ANN) approaches, using an adjoint model based on **Tapenade** Automatic Differentiation Engine.
+**smash** offers a range of advanced optimization techniques, including Variational Data Assimilation (VDA), Bayesian estimation, and Artificial Neural Network (ANN) approaches, using an adjoint model based on the **Tapenade** Automatic Differentiation Engine.
 
 - **Tapenade** article: https://doi.org/10.1145/2450153.2450158
 - **Tapenade** source code: https://gitlab.inria.fr/tapenade/tapenade.git

--- a/doc/source/math_num_documentation/forward/forward_problem_statement.rst
+++ b/doc/source/math_num_documentation/forward/forward_problem_statement.rst
@@ -12,18 +12,18 @@ The **computational domain** (catchment) :math:`\Omega \in \mathbb{R}^2` is a 2D
 The **hydrological model** is a dynamic operator :math:`\mathcal{M}` mapping observed input fields of rainfall, evapotranspiration and eventually snow and temperature :math:`\boldsymbol{P}(x, t'), \; \boldsymbol{E}(x, t'), \; \boldsymbol{S}(x, t'), \; \boldsymbol{T}(x, t'), \; \forall (x, t') \in \Omega \times [0, t]` onto discharge field :math:`Q(x, t)` such that:
 
 .. math::
-   :name: eq:1
-
-	    Q\left(x,t\right)=\mathcal{M}\left[\boldsymbol{P}\left(x,t'\right),\boldsymbol{E}\left(x,t'\right),\boldsymbol{h}\left(x,0\right),\boldsymbol{\theta}\left(x\right)\right]\,\forall x\in\Omega, t'\in\left[0,t\right]
+   :name: eq:forward-model
+   
+      Q\left(x,t\right)=\mathcal{M}\left[\boldsymbol{P}\left(x,t'\right),\boldsymbol{E}\left(x,t'\right),\boldsymbol{h}\left(x,0\right),\boldsymbol{\theta}\left(x\right)\right]\,\forall x\in\Omega, t'\in\left[0,t\right]
     
 with :math:`\boldsymbol{h}(x, t)` the :math:`N_s`-dimensional vector of model states 2D fields and :math:`\boldsymbol{\theta}` the :math:`N_p`-dimensional vector of model parameters 2D fields.
 
 Note that a pre-regionalization function :math:`\mathcal{F}_{R}` can be considered in the forward model to link model parameters to physiographic descriptors :math:`\boldsymbol{D}` (see section :ref:`Regionalization operators <math_num_documentation.forward.regionalization_operators>`) such that:
 
 .. math::
-   :name: eq:2
+   :name: eq:regio-mapping
    
-   \boldsymbol{\theta}(x)=\mathcal{F}_{R}(\boldsymbol{D}(x),\boldsymbol{\rho}(x)),\,\forall\left(x\right)\in\Omega
+      \boldsymbol{\theta}(x)=\mathcal{F}_{R}(\boldsymbol{D}(x),\boldsymbol{\rho}(x)),\,\forall\left(x\right)\in\Omega
    
 with :math:`\boldsymbol{\rho}` the tunable parameters that is regionalization control vector. In that case the forward model is a composed function :math:`\mathcal{M}\left(\mathcal{F}_{R}\left(\rho\right)\right)` depending on :math:`\boldsymbol{\rho}`.
 

--- a/doc/source/math_num_documentation/forward/regionalization_operators.rst
+++ b/doc/source/math_num_documentation/forward/regionalization_operators.rst
@@ -4,8 +4,46 @@
 Regionalization operators
 =========================
 
-.. warning::
+Here we introduce a pre-regionalization operator :math:`\mathcal{F}_{R}` enabling us to hypothesize a relationship between physiographic descriptors :math:`\boldsymbol{D}` and the hydrological model parameters :math:`\boldsymbol{\theta}` such that:
 
-    Section in development 
+.. math::
+    :name: eq:regio-mapping-intro
+    
+        \boldsymbol{\theta}(x)=\mathcal{F}_{R}(\boldsymbol{D}(x),\boldsymbol{\rho}(x)),\,\forall\left(x\right)\in\Omega
 
-:math:`\boldsymbol{\theta}(x)=\mathcal{F}_{R}(\boldsymbol{D}(x),\boldsymbol{\rho}(x)),\,\forall\left(x\right)\in\Omega`
+with :math:`\boldsymbol{D}` the :math:`N_D`-dimensional vector of physiographic descriptor maps covering :math:`\Omega`, and :math:`\boldsymbol{\rho}` the vector of tunable regionalization parameters that is defined depending upon the following two types of pre-regionalization operators.
+
+Multivariate polynomial regression
+**********************************
+A multivariate polynomial regression operator :math:`\mathcal{P}` that for the :math:`k^{th}`-parameter of the forward hydrological model writes:
+
+.. math::
+    :name: eq:polynom-regio
+
+       \theta_{k}(x;\boldsymbol{D};\boldsymbol{\rho}) = s_{k}\left(\alpha_{k,0}+\sum_{d=1}^{N_{D}}\alpha_{k,d}D_{d}^{\beta_{k,d}}(x)\right),\,\forall\left(k,x\right)\in[1..N_{\theta}]\times\Omega
+
+with :math:`s_{k}(z)=l_{k}+(u_{k}-l_{k})/\left(1+e^{- z}\right),\,\forall z\in\mathbb{R}`, a transformation based on a sigmoid function with values in :math:`\left]l_k;u_k\right[`, thus imposing bound constrains in the direct hydrological model such that  :math:`l_{k}<\theta_{k}(x)<u_{k},\,\forall x\in\Omega`. 
+The regional control vector in this case is:
+   
+.. math::
+    :name: eq:polynom-control-vec
+
+    \boldsymbol{\rho} := \left[\alpha_{k,0},\left(\alpha_{k,d},\beta_{k,d}\right)\right]^{T},\forall(k,d)\in[1..N_{\theta}]\times[1..N_{D}]
+
+Artificial neural network
+*************************
+An artificial neural network (ANN) denoted :math:`\mathcal{N}`, consisting of multilayer perceptron, aims to learn the descriptors to parameters mapping such that:
+
+.. math::
+    :name: eq-ann-regio
+
+        \boldsymbol{\theta}(x;\boldsymbol{D};\boldsymbol{\rho}) = \mathcal{N}\left(\boldsymbol{D}(x), \boldsymbol{W}, \boldsymbol{b}\right),\forall x \in \Omega
+
+where :math:`\boldsymbol{W}` and :math:`\boldsymbol{b}` are respectively weights and biases of the neural network composed of :math:`N_L` dense layers.   
+Note that an output layer consisting in a sigmoid function enables to impose :math:`l_{k}<\theta_{k}(x)<u_{k},\,\forall x\in\Omega`, i.e. bounds constrains on the :math:`k^{th}`-hydrological parameters. 
+The regional control vector in this case is:  
+
+.. math::
+    :name: eq-ann-control-vec
+    
+        \boldsymbol{\rho} := \left[\boldsymbol{W}, \boldsymbol{b}\right]^T

--- a/doc/source/math_num_documentation/index.rst
+++ b/doc/source/math_num_documentation/index.rst
@@ -4,14 +4,10 @@
 Math / Num Documentation
 ========================
 
-.. warning::
-
-    Section in development
-
 `smash` is a computational software framework dedicated to **S**\patially distributed **M**\odelling and **AS**\similation for **H**\ydrology, enabling to tackle flexible spatially distributed hydrological modeling, signatures and sensitivity analysis, as well as high dimensional inverse problems using multi-source observations. This model is designed to simulate discharge hydrographs and hydrological states at any spatial location within a basin and reproduce the hydrological response of contrasted catchments, both for operational forecasting of floods :cite:p:`javelle_setting_2016` and low flows :cite:p:`Folton_2020`, by taking advantage of spatially distributed meteorological forcings, physiographic data and hydrometric observations.
 
-`smash` is a modular platform that contains conceptual representations and numerical approximations of dominant hydrological processes while aiming to maintain a relative parsimony. It also contains several algorithms for signal analysis, model optimization and data assimilation over large datasets. It originally enables to use variational data assimilation and hybrid methods based on statistical/machine learning. 
-`smash` contains Fortran source code interfaced in Python using f90wrap :cite:p:`Kermode2020-f90wrap` to achieve computational efficiency for meshing, solver, optimization etc. The adjoint code of the forward model is automatically generated using the differentiation tool Tapenade :cite:p:`hascoet2013tapenade` and some final tricks. The adjoint is used in the variational data assimilation algorithm presented in :cite:`jay2019potential`. `smash` enables to work at multiple spatio-temporal resolutions, with heterogeneous data in nature and sampling.
+`smash` is a modular platform that contains conceptual representations and numerical approximations of dominant hydrological processes while aiming to maintain a relative parsimony. It also contains several algorithms for signal analysis, model optimization and data assimilation over large datasets. It originally enables to use variational data assimilation and hybrid methods based on statistical/machine learning approaches. 
+`smash` contains Fortran source code interfaced in Python using f90wrap :cite:p:`Kermode2020-f90wrap` to achieve computational efficiency for meshing, solver, optimization, etc.. The adjoint code of the forward model is automatically generated using the differentiation tool Tapenade :cite:p:`hascoet2013tapenade` and some final tricks. The adjoint is used in the variational data assimilation algorithm presented in :cite:`jay2019potential`. `smash` enables to work at multiple spatio-temporal resolutions, with heterogeneous data in nature and sampling.
 
 This documentation details the available forward model operators, signal and sensitivity analysis tools, and optimization algorithms.
 
@@ -46,8 +42,5 @@ Inverse Algorithms
     
     inverse/inverse_problem_statement
     inverse/algorithms
-
-Data Preprocessing
-******************
 
 .. recup / preproc dem ; data sat ; NN for descriptors and other data preproc/filtering/selection...

--- a/doc/source/math_num_documentation/inverse/inverse_problem_statement.rst
+++ b/doc/source/math_num_documentation/inverse/inverse_problem_statement.rst
@@ -5,13 +5,13 @@ Inverse problem statement
 =========================
 
 .. warning::
-   To be extended/generalized vs proba cost func, bayesian, mcmc, ...
+   Section in development
 
 Hydrological optimization problems generally consist in fitting catchment model response to the available observations, that is potentially multi-source and multi-site heterogeneous data used to inform the model. The misfit between observations and model response is measured with a cost function :math:`J` (see section :ref:`Cost functions <math_num_documentation.signal_analysis.cost_functions>`) that depends on hydrological parameters :math:`\theta` through the forward hydrological model :math:`\mathcal{M}` composed of hydrological operators that can include a pre-regionalization (see section :ref:`Forward problem statement <math_num_documentation.forward.forward_problem_statement>`). The inverse problem consists in searching an optimal parameter set :math:`\hat{\boldsymbol{\theta}}` such that:
 
 .. math::
-   :name: eq:3
+   :name: eq:inverse-prl
    
    \hat{\boldsymbol{\theta}}=\arg\min_{\boldsymbol{\theta}}J\left(\boldsymbol{\theta}\right).
 
-**TODO**. add control vectors hyperparam ... 
+.. **TODO**. extend/generalize vs proba cost func, bayesian, mcmc, etc.; add control vectors hyperparam...

--- a/doc/source/math_num_documentation/signal_analysis/cost_functions.rst
+++ b/doc/source/math_num_documentation/signal_analysis/cost_functions.rst
@@ -111,4 +111,4 @@ Then, for each signature type :math:`i`, the corresponding SOF is computed depen
 
 where :math:`S_{i,e}^{s},S_{i,e}^{o}` are the simulated and observed signature of event number :math:`e\in\left[1..N_{E}\right]`.
 
-Regularization term :math:`J_{reg}` (**TODO**: à compléter)
+.. Regularization term :math:`J_{reg}` (**TODO**: à compléter)

--- a/doc/source/release/0.4.2-notes.rst
+++ b/doc/source/release/0.4.2-notes.rst
@@ -57,6 +57,13 @@ The search is automatic by looking at the prefix of the Fortran files:
 - ``md``: differentiated module
 - ``mwd``: wrapped and differentiated module
 
+Documentation
+*************
+
+Improve the Math/Num Documentation section, including:
+
+- :ref:`Regionalization operators <math_num_documentation.forward.regionalization_operators>`
+
 ------------
 New Features
 ------------


### PR DESCRIPTION
Enhance and clean Math/Num Documentation.

Modified:
- forward_problem_statement.rst, forward/index.rst, inverse_problem_statement.rst, cost_functions.rst: clean
- pregionalization_operators.rst: enhance
- 0.4.2-notes.rst: update release notes
- README: fix typos