### PR TITLE
ENC: Dark Theme rendering and fix hyper linear/polynomial verbose

### DIFF
--- a/doc/source/_static/css/smash.css
+++ b/doc/source/_static/css/smash.css
@@ -1,3 +1,4 @@
+/* much of this file is derived from NumPy */
 @import url('https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700;1,900&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
 
 .navbar-brand img {
@@ -15,9 +16,15 @@
    max-width: 20%;
 }
 
+code.literal{
+    background-color: transparent;
+    border: 0px;
+    padding: 0rem;
+}
+
 body {
   font-family: 'Open Sans', sans-serif;
-  color:#4A4A4A; /* numpy.org body color */
+  color: #1B262C;
 }
 
 pre, code {
@@ -27,29 +34,23 @@ pre, code {
 
 h1 {
   font-family: "Lato", sans-serif;
-  color: #013243; /* warm black */
+  color: #1B262C;
 }
 
 h2 {
-  color: #4d77cf; /* han blue */
+  color: #0F4C75;
   letter-spacing: -.03em;
 }
 
 h3 {
-  color: #013243; /* warm black */
+  color: #3282B8;
   letter-spacing: -.03em;
 }
 
-/* Style the active version button.
-- dev: orange
-- stable: green
-- old, PR: red
-Colors from:
-Wong, B. Points of view: Color blindness.
-Nat Methods 8, 441 (2011). https://doi.org/10.1038/nmeth.1618
-*/
-
-/* Main page overview cards */
+h4 {
+  color: #1B262C;
+  letter-spacing: -.03em;
+}
 
 .sd-card {
   background: #fff;
@@ -116,10 +117,22 @@ html[data-theme=dark] .sd-card .sd-card-footer {
   background-color: transparent;
 }
 
+html[data-theme=dark] body {
+  color: #F6F1F1;
+}
+
 html[data-theme=dark] h1 {
-  color: var(--pst-color-primary);
+  color: #F6F1F1;
+}
+
+html[data-theme=dark] h2 {
+  color: #AFD3E2;
 }
 
 html[data-theme=dark] h3 {
-  color: var(--pst-color-primary);
+  color: #146C94;
+}
+
+html[data-theme=dark] h4 {
+  color: #F6F1F1;
 }

--- a/doc/source/math_num_documentation/forward/hydrological_operators.rst
+++ b/doc/source/math_num_documentation/forward/hydrological_operators.rst
@@ -4,12 +4,12 @@
 Hydrological operators
 ======================
 
-This section details fluxes and states computation for a given cell :math:`x\in\Omega` also denoted :math:`x \in \mathcal{T}_\Omega` and for a given time step :math:`t\in[1..N_t]` considering a regular temporal grid of time step :math:`\Delta t`. For this cell at time step t, we denote by :math:`P(t)` and :math:`E(t)` the local total rainfall and evapotranspiration.
+This section details fluxes and states computation for a given cell :math:`x\in\Omega` also denoted :math:`x \in \mathcal{T}_\Omega` and for a given time step :math:`t\in[1..N_t]` considering a regular temporal grid of time step :math:`\Delta t`. For this cell at time step :math:`t`, we denote by :math:`P(t)` and :math:`E(t)` the local total rainfall and evapotranspiration.
 
 .. _math_num_documentation.forward.hydrological_operators.gr:
 
-GR like
-*******
+GR
+**
 
 The operators used here come from GR (Génie Rural) lumped and semi-lumped models of the literature (**TODO** ref).
 
@@ -230,49 +230,7 @@ With flux :math:`Q_t` inflowing the routing part equal to:
     
     Q_t(t) = Q_{ft}(t) + Q_{st}(t) + Q_d(t)
     
-    \end{eqnarray}        
-
-
-VIC like
-********
-
-HBV like
-********
-
-State-space models
-******************
-
-ODE formulation
----------------
-
-.. math::
-    :nowrap:
-    
-    \begin{eqnarray}
-    
-        \begin{cases}
-        \frac{\mathrm{d}}{\mathrm{dt}}\boldsymbol{h}\left(x,t'\right) & =f\left(\boldsymbol{h}\left(x,t'\right);\boldsymbol{I}\left(x,t'\right),\boldsymbol{d}\left(x,t'\right);\boldsymbol{h_{0}}\left(x\right),\boldsymbol{\theta}_{rr}\left(x\right)\right)\\
-        Q\left(x,t\right) & =g\left(\boldsymbol{h}\left(x,t'\right);\boldsymbol{I}\left(x,t'\right),\boldsymbol{d}\left(x,t'\right);\boldsymbol{h_{0}}\left(x\right),\boldsymbol{\theta}_{rr}\left(x\right)\right)\\
-        \boldsymbol{h_{0}}\left(x\right) & =\boldsymbol{h}\left(x,0\right)
-        \end{cases}\,\,\,,\forall x\in\Omega,t'\in\left]0,t\right]
-
-     \end{eqnarray}
-         
-
-Neural ODE formulation
-----------------------
-
-.. math::
-    :nowrap:
-    
-    \begin{eqnarray}
-    
-        \left(\frac{d\boldsymbol{h}}{dt}\right)=\left(\boldsymbol{S}_{det}(\boldsymbol{h},t)+\boldsymbol{S}_{NN}(\boldsymbol{h},t)\right)
-
-     \end{eqnarray}
-
-ODE Solver
-----------
+    \end{eqnarray}
 
 Generic
 *******
@@ -304,7 +262,7 @@ With for a given upstream cell :math:`k`:
     
     \begin{eqnarray}
     
-    Q(k,t) = h_r(k,t) \left[ 1 - \exp \left( - \frac{\Delta t}{60 \; lr} \right) \right] + Q_{up}(k,t) + Q_t(k,t)
+    Q(k,t) = h_{lr}(k,t) \left[ 1 - \exp \left( - \frac{\Delta t}{60 \; lr} \right) \right] + Q_{up}(k,t) + Q_t(k,t)
     
     \end{eqnarray}
     
@@ -316,18 +274,6 @@ Updating the level in the routing storage:
     
     \begin{eqnarray}
     
-    h_r(k,t) = h_r(k,t-1) - Q(k,t)
+    h_{lr}(k,t) = h_{lr}(k,t-1) - Q(k,t)
     
     \end{eqnarray}
-            
-
-Non-linear conceptual - Igamma
-------------------------------
-
-            
-Kinematic wave
---------------
-   
-
-Sub-surface routing
-*******************

--- a/doc/source/release/0.4.2-notes.rst
+++ b/doc/source/release/0.4.2-notes.rst
@@ -64,6 +64,8 @@ Improve the Math/Num Documentation section, including:
 
 - :ref:`Regionalization operators <math_num_documentation.forward.regionalization_operators>`
 
+Improvement of the dark theme rendering
+
 ------------
 New Features
 ------------
@@ -79,3 +81,14 @@ This command generates a new file named ``makefile.dep`` with the targets of the
 -----
 Fixes
 -----
+
+Documentation
+*************
+
+Correction of the name of the routing storage state in the Math/Num section: :math:`hr` becomes :math:`hlr`
+
+Hyper-Linear/Polynomial verbose
+*******************************
+
+There was a display problem when optimizing in hyper linear/polynomial. The ``Jobs`` value was not correctly updated at each iteration. 
+**The problem only affects the display**.

--- a/smash/solver/forward/forward_db.f90
+++ b/smash/solver/forward/forward_db.f90
@@ -3407,6 +3407,7 @@ CONTAINS
     jreg = 0._sp
     cost = jobs + setup%optimize%wjreg*jreg
     output%cost = cost
+    output%cost_jobs = jobs
   END SUBROUTINE HYPER_COMPUTE_COST
 
 !  Differentiation of nse in forward (tangent) mode (with options fixinterface noISIZE):

--- a/smash/solver/optimize/mwd_cost.f90
+++ b/smash/solver/optimize/mwd_cost.f90
@@ -334,6 +334,7 @@ contains
 
         cost = jobs + setup%optimize%wjreg*jreg
         output%cost = cost
+        output%cost_jobs = jobs
 
     end subroutine hyper_compute_cost
 


### PR DESCRIPTION
* The rendering of the dark theme should be better by adjusting the smash.css file
* Pass jobs to output%cost_jobs in hyper_compute_cost to avoid verbose issue
* remove non coded things in the documentation
* Fix in math/num section the name of the routing store state (hr to hlr)