### PR TITLE
MAINT: Add key to trigger or not the GR interception capacity adjustment

### DIFF
--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -96,7 +96,7 @@ STRUCTURE_RR_STATES = dict(
 )
 
 # % Following STRUCTURE_NAME order
-STRUCTURE_COMPUTE_CI = dict(
+STRUCTURE_ADJUST_CI = dict(
     zip(
         STRUCTURE_NAME,
         ["ci" in v for v in STRUCTURE_RR_PARAMETERS.values()],

--- a/smash/core/model/_standardize.py
+++ b/smash/core/model/_standardize.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from smash.fcore._mwd_setup import SetupDT
 
 
+# % TODO: rewrite this standardize with type checking
 def _standardize_setup(setup: SetupDT):
     if setup.structure.lower() in STRUCTURE_NAME:
         setup.structure = setup.structure.lower()

--- a/smash/fcore/derived_type/mwd_setup.f90
+++ b/smash/fcore/derived_type/mwd_setup.f90
@@ -10,11 +10,12 @@
 !%          `Variables`                Description
 !%          ========================== =====================================
 !%          ``structure``              Hydrological model structure                           (default: 'gr4-lr')
-!%          ``serr_mu_mapping``        Mapping for structural error model                     (default: 'zero')
-!%          ``serr_sigma_mapping``     Mapping for structural error model                     (default: 'linear')
+!%          ``serr_mu_mapping``        Mapping for structural error model                     (default: 'Zero')
+!%          ``serr_sigma_mapping``     Mapping for structural error model                     (default: 'Linear')
 !%          ``dt``                     Solver time step        [s]                            (default: 3600)
 !%          ``start_time``             Simulation start time   [%Y%m%d%H%M]                   (default: '...')
 !%          ``end_time``               Simulation end time     [%Y%m%d%H%M]                   (default: '...')
+!%          ``adjust_interception``    Adjust interception reservoir capacity                 (default: .true.)
 !%          ``read_qobs``              Read observed discharge                                (default: .false.)
 !%          ``qobs_directory``         Observed discharge directory path                      (default: '...')
 !%          ``read_prcp``              Read precipitation                                     (default: .false.)
@@ -57,13 +58,15 @@ module mwd_setup
         !% SetupDT Derived Type.
 
         character(lchar) :: structure = "gr4-lr" !$F90W char
-        character(lchar) :: serr_mu_mapping = "zero" !$F90W char
-        character(lchar) :: serr_sigma_mapping = "linear" !$F90W char
+        character(lchar) :: serr_mu_mapping = "Zero" !$F90W char
+        character(lchar) :: serr_sigma_mapping = "Linear" !$F90W char
 
         real(sp) :: dt = 3600._sp
 
         character(lchar) :: start_time = "..." !$F90W char
         character(lchar) :: end_time = "..." !$F90W char
+
+        logical :: adjust_interception = .true.
 
         logical :: read_qobs = .false.
         character(lchar) :: qobs_directory = "..." !$F90W char

--- a/smash/fcore/routine/mw_interception_capacity.f90
+++ b/smash/fcore/routine/mw_interception_capacity.f90
@@ -3,7 +3,7 @@
 !%      Subroutine
 !%      ----------
 !%
-!%      - compute_interception_capacity
+!%      - adjust_interception_capacity
 
 module mw_interception_capacity
 
@@ -19,7 +19,7 @@ module mw_interception_capacity
 
 contains
 
-    subroutine compute_interception_capacity(setup, mesh, input_data, day_index, nday, ci)
+    subroutine adjust_interception_capacity(setup, mesh, input_data, day_index, nday, ci)
 
         implicit none
 
@@ -86,7 +86,7 @@ contains
         !% =========================================================================================================== %!
 
         stt = 0.1_sp
-        stp = 5._sp
+        stp = 3._sp
         step = 0.1_sp
         n = ceiling((stp - stt)/step)
 
@@ -148,6 +148,6 @@ contains
 
         end do
 
-    end subroutine compute_interception_capacity
+    end subroutine adjust_interception_capacity
 
 end module mw_interception_capacity


### PR DESCRIPTION
- Add "adjust_interception" key in SetupDT
- Rename "compute_ci" to "adjust_ci"
- Lower the upper bound of interception capacity values (5 to 3)