### PR TITLE
ENC: Add coverage to tests with pytest-cov plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,55 @@
-**/__pycache__
-__pycache__
+# https://github.com/github/gitignore/blob/main/Python.gitignore
 
-**/.f2py*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# f2py files
 .f2py*
 
+# Tapenade files
 tapenade/*.msg*
 tapenade/*.f90*
 tapenade/*~
 
-**/tmp*
+# Temporary files
 tmp*

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,6 +34,7 @@ dependencies:
 
     # test
     - pytest
+    - pytest-cov
 
     # format
     - black

--- a/makefile
+++ b/makefile
@@ -122,6 +122,10 @@ doc-clean:
 test:
 	cd $(TESTS_DIR) ; pytest
 
+#% Testing code with pytest and coverage
+test-coverage:
+	cd $(TESTS_DIR) ; pytest --cov-report term --cov-report html --cov=smash
+
 #% Generate baseline for test with args (see argparser in gen_baseline.py)
 test-baseline:
 	cd $(TESTS_DIR) ; python3 gen_baseline.py $(args)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ sphinx-autosummary-accessors
 
 # test
 pytest
+pytest-cov
 
 # format
 black


### PR DESCRIPTION
- Add pytest-cov as dev dependency
- Add makefile target test-coverage to run test and coverage report (term and html)
- Update .gitignore