### PR TITLE
FIX: Remove Fortran warnings

### DIFF
--- a/smash/fcore/external/mwd_bayesian_tools.f90
+++ b/smash/fcore/external/mwd_bayesian_tools.f90
@@ -102,7 +102,6 @@ contains
         real(mrk),intent(out)::logPrior
         logical,intent(out)::feas,isnull
         ! locals
-        integer(mik)::i
         real(mrk)::pdf
         real(mrk)::dummyTheta(size(theta),1)
         type(PriorType)::dummyTheta_prior(size(theta_prior),1)
@@ -631,7 +630,6 @@ contains
     ! locals
     integer(mik)::i,j,err
     character(250)::mess
-    character(250),parameter::procname='SigmaFunk_vect'
 
     res=undefRN
 
@@ -672,7 +670,6 @@ contains
     ! locals
     integer(mik)::i,j,err
     character(250)::mess
-    character(250),parameter::procname='MuFunk_vect'
 
     res=undefRN
 

--- a/smash/fcore/operator/md_routing_operator.f90
+++ b/smash/fcore/operator/md_routing_operator.f90
@@ -199,7 +199,7 @@ contains
         real(sp), dimension(mesh%nrow, mesh%ncol), intent(inout) :: hlr
         real(sp), dimension(mesh%nrow, mesh%ncol, zq), intent(inout) :: q
 
-        integer :: i, j, row, col, ncpu
+        integer :: i, j, row, col
         real(sp) :: qup
 
         q(:, :, zq) = qt(:, :, zq)

--- a/smash/fcore/optimize/mwd_cost.f90
+++ b/smash/fcore/optimize/mwd_cost.f90
@@ -74,7 +74,6 @@ contains
         character(lchar), intent(in) :: tfm
         real(sp), dimension(:), intent(inout) :: qo, qs
 
-        integer :: i
         real(sp) :: mean_qo, e
         logical, dimension(size(qo)) :: mask
 
@@ -164,18 +163,18 @@ contains
         & sigma_funk, sigma_gamma, sigma_gamma_prior, log_post, log_prior, log_lkh, log_h, feas, isnull)
 
         ! TODO: Should be count(obs .ge. 0._sp .and. uobs .ge. 0._sp)
-        output%cost = -1._sp*log_post/size(obs)
+        output%cost = -1._sp*real(log_post, sp)/size(obs)
 
         !$AD start-exclude
         if (returns%cost_flag) returns%cost = output%cost
-        if (returns%log_lkh_flag) returns%log_lkh = log_lkh
-        if (returns%log_prior_flag) returns%log_prior = log_prior
-        if (returns%log_h_flag) returns%log_h = log_h
+        if (returns%log_lkh_flag) returns%log_lkh = real(log_lkh, sp)
+        if (returns%log_prior_flag) returns%log_prior = real(log_prior, sp)
+        if (returns%log_h_flag) returns%log_h = real(log_h, sp)
         !$AD end-exclude
 
     end subroutine bayesian_compute_cost
 
-    subroutine classical_compute_jobs(setup, mesh, input_data, output, options, returns, jobs)
+    subroutine classical_compute_jobs(setup, mesh, input_data, output, options, jobs)
 
         implicit none
 
@@ -184,7 +183,6 @@ contains
         type(Input_DataDT), intent(in) :: input_data
         type(OutputDT), intent(in) :: output
         type(OptionsDT), intent(in) :: options
-        type(ReturnsDT), intent(inout) :: returns
         real(sp), intent(inout) :: jobs
 
         integer :: i, j, k, n_computed_event
@@ -428,7 +426,7 @@ contains
 
     end subroutine classical_compute_jobs
 
-    subroutine classical_compute_jreg(setup, mesh, input_data, parameters, options, returns, jreg)
+    subroutine classical_compute_jreg(setup, mesh, input_data, parameters, options, jreg)
 
         implicit none
 
@@ -437,7 +435,6 @@ contains
         type(Input_DataDT), intent(in) :: input_data
         type(ParametersDT), intent(in) :: parameters
         type(OptionsDT), intent(in) :: options
-        type(ReturnsDT), intent(in) :: returns
         real(sp), intent(inout) :: jreg
 
         integer :: i
@@ -492,9 +489,9 @@ contains
         jobs = 0._sp
         jreg = 0._sp
 
-        call classical_compute_jobs(setup, mesh, input_data, output, options, returns, jobs)
+        call classical_compute_jobs(setup, mesh, input_data, output, options, jobs)
 
-        call classical_compute_jreg(setup, mesh, input_data, parameters, options, returns, jreg)
+        call classical_compute_jreg(setup, mesh, input_data, parameters, options, jreg)
 
         output%cost = jobs + options%cost%wjreg*jreg
 

--- a/smash/fcore/routine/mwd_parameters_manipulation.f90
+++ b/smash/fcore/routine/mwd_parameters_manipulation.f90
@@ -785,7 +785,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j
+        integer :: i, j
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 
         ac_mask = (mesh%active_cell(:, :) .eq. 1)
@@ -818,7 +818,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j
+        integer :: i, j
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 
         ac_mask = (mesh%active_cell(:, :) .eq. 1)
@@ -852,7 +852,7 @@ contains
         type(OptionsDT), intent(in) :: options
 
         character(lchar) :: name
-        integer :: n, i, j, row, col
+        integer :: i, j, row, col
 
         ! RR parameters is first control kind
         j = 0
@@ -894,7 +894,7 @@ contains
         type(OptionsDT), intent(in) :: options
 
         character(lchar) :: name
-        integer :: n, i, j, row, col
+        integer :: i, j, row, col
 
         ! RR initial states is second control kind
         j = parameters%control%nbk(1)
@@ -935,7 +935,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j, k
+        integer :: i, j, k
         real(sp) :: y, l, u
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 
@@ -984,7 +984,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j, k
+        integer :: i, j, k
         real(sp) :: y, l, u
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 
@@ -1033,7 +1033,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j, k
+        integer :: i, j, k
         real(sp) :: y, l, u
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 
@@ -1089,7 +1089,7 @@ contains
         type(ParametersDT), intent(inout) :: parameters
         type(OptionsDT), intent(in) :: options
 
-        integer :: n, i, j, k
+        integer :: i, j, k
         real(sp) :: y, l, u
         logical, dimension(mesh%nrow, mesh%ncol) :: ac_mask
 


### PR DESCRIPTION
Remove maximum of warnings. A bunch of warnings are still here in forward_db.f90. need to check if we can rewrite the direct model to remove some