### PR TITLE
FIX: Check that there is available observed discharge at optimized gauge

### DIFF
--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -790,10 +790,10 @@ DEFAULT_SIMULATION_COST_OPTIONS = {
         "jobs_cmpt": "nse",
         "wjobs_cmpt": "mean",
         "jobs_cmpt_tfm": "keep",
+        "end_warmup": None,
         "gauge": "dws",
         "wgauge": "mean",
         "event_seg": dict(zip(EVENT_SEG_KEYS[:2], [PEAK_QUANT, MAX_DURATION])),
-        "end_warmup": None,
     },
     "optimize": {
         "jobs_cmpt": "nse",
@@ -802,15 +802,15 @@ DEFAULT_SIMULATION_COST_OPTIONS = {
         "wjreg": 0,
         "jreg_cmpt": "prior",
         "wjreg_cmpt": "mean",
+        "end_warmup": None,
         "gauge": "dws",
         "wgauge": "mean",
         "event_seg": dict(zip(EVENT_SEG_KEYS[:2], [PEAK_QUANT, MAX_DURATION])),
-        "end_warmup": None,
     },
     "bayesian_optimize": {
+        "end_warmup": None,
         "gauge": "dws",
         "control_prior": None,
-        "end_warmup": None,
     },
 }
 

--- a/smash/core/model/_read_input_data.py
+++ b/smash/core/model/_read_input_data.py
@@ -143,18 +143,21 @@ def _read_qobs(setup: SetupDT, mesh: MeshDT, input_data: Input_DataDT):
 
             # % Check if observed discharge file contains data for corresponding simulation period
             if start_time > file_end_time or end_time < file_start_time:
-                raise ValueError(
+                warnings.warn(
                     f"The provided observed discharge file for catchment '{c}' does not contain data for the "
                     f"selected simulation period ['{start_time}', '{end_time}']. The file covers the period "
-                    f"['{file_start_time}', '{file_end_time}']"
+                    f"['{file_start_time}', '{file_end_time}']",
+                    stacklevel=2,
                 )
+            else:
+                ind_start_dat = max(0, start_diff)
+                ind_end_dat = min(dat.index.max(), end_diff)
+                ind_start_arr = max(0, -start_diff)
+                ind_end_arr = ind_start_arr + ind_end_dat - ind_start_dat
 
-            ind_start_dat = max(0, start_diff)
-            ind_end_dat = min(dat.index.max(), end_diff)
-            ind_start_arr = max(0, -start_diff)
-            ind_end_arr = ind_start_arr + ind_end_dat - ind_start_dat
-
-            input_data.response_data.q[i, ind_start_arr:ind_end_arr] = dat.iloc[ind_start_dat:ind_end_dat, 0]
+                input_data.response_data.q[i, ind_start_arr:ind_end_arr] = dat.iloc[
+                    ind_start_dat:ind_end_dat, 0
+                ]
         else:
             miss.append(c)
 

--- a/smash/core/simulation/_doc.py
+++ b/smash/core/simulation/_doc.py
@@ -316,6 +316,25 @@ COST_OPTIONS_BASE_DOC = {
         }
         """,
     ),
+    "end_warmup": (
+        """
+        `str`, `pandas.Timestamp` or None, default None
+        """,
+        """
+        The end of the warm-up period, which must be between the start time and the end time defined in
+        `Model.setup`.
+
+        >>> cost_options = {
+            "end_warmup": "1997-12-21",
+        }
+        >>> cost_options = {
+            "end_warmup": pd.Timestamp("19971221"),
+        }
+
+        .. note::
+            If not given, it is set to be equal to the `Model.setup` start time.
+        """,
+    ),
     "gauge": (
         """
         `str` or `list[str, ...]`, default 'dws'
@@ -411,25 +430,6 @@ COST_OPTIONS_BASE_DOC = {
             See the `hydrograph_segmentation <smash.hydrograph_segmentation>` function and
             :ref:`math_num_documentation.hydrograph_segmentation` section.
 
-        """,
-    ),
-    "end_warmup": (
-        """
-        `str`, `pandas.Timestamp` or None, default None
-        """,
-        """
-        The end of the warm-up period, which must be between the start time and the end time defined in
-        `Model.setup`.
-
-        >>> cost_options = {
-            "end_warmup": "1997-12-21",
-        }
-        >>> cost_options = {
-            "end_warmup": pd.Timestamp("19971221"),
-        }
-
-        .. note::
-            If not given, it is set to be equal to the `Model.setup` start time.
         """,
     ),
 }


### PR DESCRIPTION
- Switch from error to warning the reading of observed dicharge file
- Switch order of check for end_warmup cost_options. It must be done before gauge
- Switch cost_options element order
- Add a raise Error if there is no observed discharge available at any optimized gauge. Only for optimization, will still run in forward_run