### PR TITLE
ENH: Upgrade the compute_mean_atmos function

### DIFF
--- a/f90wrap/py_mod_names
+++ b/f90wrap/py_mod_names
@@ -29,6 +29,7 @@
 	"mw_atmos_statistic": "_mw_atmos_statistic",
 	"mw_interception_capacity": "_mw_interception_capacity",
 	"mw_mask": "_mw_mask",
+	"mwd_atmos_manipulation": "_mwd_atmos_manipulation",
 	"mwd_parameters_manipulation": "_mwd_parameters_manipulation",
 	"mwd_sparse_matrix_manipulation": "_mwd_sparse_matrix_manipulation",
 	"mw_prcp_indices": "_mw_prcp_indices",

--- a/makefile.dep
+++ b/makefile.dep
@@ -50,6 +50,7 @@ f90 : \
     obj/mw_atmos_statistic.o \
     obj/mw_interception_capacity.o \
     obj/mw_mask.o \
+    obj/mwd_atmos_manipulation.o \
     obj/mwd_parameters_manipulation.o \
     obj/mwd_sparse_matrix_manipulation.o \
     obj/mw_prcp_indices.o \
@@ -79,10 +80,10 @@ obj/md_stats.o : \
     obj/md_constant.o \
 
 obj/mwd_atmos_data.o : \
-    obj/mwd_setup.o \
     obj/md_constant.o \
-    obj/mwd_mesh.o \
+    obj/mwd_setup.o \
     obj/mwd_sparse_matrix.o \
+    obj/mwd_mesh.o \
 
 obj/mwd_common_options.o : \
 
@@ -90,92 +91,92 @@ obj/mwd_control.o : \
     obj/md_constant.o \
 
 obj/mwd_cost_options.o : \
-    obj/mwd_setup.o \
-    obj/mwd_mesh.o \
-    obj/mwd_bayesian_tools.o \
     obj/md_constant.o \
+    obj/mwd_setup.o \
+    obj/mwd_bayesian_tools.o \
+    obj/mwd_mesh.o \
 
 obj/mwd_input_data.o : \
     obj/mwd_setup.o \
+    obj/mwd_physio_data.o \
+    obj/mwd_u_response_data.o \
+    obj/md_constant.o \
     obj/mwd_response_data.o \
     obj/mwd_mesh.o \
     obj/mwd_atmos_data.o \
-    obj/mwd_physio_data.o \
-    obj/md_constant.o \
-    obj/mwd_u_response_data.o \
 
 obj/mwd_mesh.o : \
-    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_setup.o \
 
 obj/mwd_optimize_options.o : \
-    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_setup.o \
 
 obj/mwd_options.o : \
-    obj/mwd_setup.o \
-    obj/mwd_common_options.o \
-    obj/mwd_mesh.o \
     obj/mwd_optimize_options.o \
+    obj/mwd_setup.o \
+    obj/mwd_mesh.o \
+    obj/mwd_common_options.o \
     obj/mwd_cost_options.o \
 
 obj/mwd_output.o : \
     obj/mwd_setup.o \
-    obj/mwd_mesh.o \
-    obj/mwd_rr_states.o \
     obj/mwd_response.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/mwd_rr_states.o \
 
 obj/mwd_parameters.o : \
-    obj/mwd_setup.o \
     obj/mwd_rr_parameters.o \
-    obj/mwd_mesh.o \
-    obj/mwd_serr_mu_parameters.o \
-    obj/mwd_rr_states.o \
+    obj/mwd_setup.o \
     obj/mwd_serr_sigma_parameters.o \
+    obj/mwd_serr_mu_parameters.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
     obj/mwd_control.o \
+    obj/mwd_rr_states.o \
 
 obj/mwd_physio_data.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_response.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_response_data.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_returns.o : \
-    obj/mwd_setup.o \
-    obj/mwd_rr_states.o \
-    obj/mwd_mesh.o \
     obj/md_constant.o \
+    obj/mwd_rr_states.o \
+    obj/mwd_setup.o \
+    obj/mwd_mesh.o \
 
 obj/mwd_rr_parameters.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_rr_states.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_serr_mu_parameters.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_serr_sigma_parameters.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_setup.o : \
     obj/md_constant.o \
@@ -184,180 +185,189 @@ obj/mwd_sparse_matrix.o : \
     obj/md_constant.o \
 
 obj/mwd_u_response_data.o : \
+    obj/md_constant.o \
     obj/mwd_setup.o \
     obj/mwd_mesh.o \
-    obj/md_constant.o \
 
 obj/mwd_bayesian_tools.o : \
 
 obj/forward.o : \
-    obj/mwd_setup.o \
-    obj/mwd_cost.o \
-    obj/mwd_input_data.o \
-    obj/md_simulation.o \
-    obj/mwd_mesh.o \
     obj/mwd_parameters.o \
-    obj/md_constant.o \
+    obj/mwd_setup.o \
     obj/mwd_output.o \
-    obj/mwd_parameters_manipulation.o \
+    obj/md_simulation.o \
+    obj/mwd_input_data.o \
+    obj/mwd_cost.o \
     obj/mwd_options.o \
+    obj/md_constant.o \
+    obj/mwd_parameters_manipulation.o \
+    obj/mwd_mesh.o \
     obj/mwd_returns.o \
 
 obj/forward_db.o : \
+    obj/mwd_optimize_options.o \
     obj/mwd_setup.o \
     obj/mwd_input_data.o \
-    obj/mwd_common_options.o \
-    obj/mwd_mesh.o \
-    obj/mwd_optimize_options.o \
     obj/mwd_response.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/mwd_common_options.o \
     obj/mwd_sparse_matrix_manipulation.o \
 
 obj/md_simulation.o : \
-    obj/mwd_setup.o \
-    obj/mwd_input_data.o \
-    obj/mwd_mesh.o \
-    obj/md_snow_operator.o \
-    obj/mwd_parameters.o \
-    obj/md_vic3l_operator.o \
     obj/md_gr_operator.o \
-    obj/mwd_sparse_matrix_manipulation.o \
-    obj/md_constant.o \
+    obj/mwd_parameters.o \
+    obj/mwd_setup.o \
     obj/mwd_output.o \
+    obj/md_vic3l_operator.o \
+    obj/mwd_input_data.o \
+    obj/md_snow_operator.o \
     obj/mwd_parameters_manipulation.o \
-    obj/md_routing_operator.o \
     obj/mwd_options.o \
+    obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/md_routing_operator.o \
     obj/mwd_returns.o \
+    obj/mwd_sparse_matrix_manipulation.o \
 
 obj/mw_forward.o : \
+    obj/mwd_parameters.o \
     obj/mwd_setup.o \
+    obj/mwd_output.o \
     obj/mwd_input_data.o \
+    obj/mwd_options.o \
+    obj/md_constant.o \
     obj/m_screen_display.o \
     obj/mwd_mesh.o \
-    obj/mwd_parameters.o \
-    obj/md_constant.o \
-    obj/mwd_output.o \
-    obj/mwd_options.o \
     obj/mwd_returns.o \
 
 obj/md_gr_operator.o : \
-    obj/mwd_setup.o \
-    obj/mwd_mesh.o \
     obj/mwd_options.o \
+    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
 
 obj/md_routing_operator.o : \
-    obj/mwd_setup.o \
-    obj/mwd_mesh.o \
     obj/mwd_options.o \
+    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
 
 obj/md_snow_operator.o : \
-    obj/mwd_setup.o \
-    obj/mwd_mesh.o \
     obj/mwd_options.o \
+    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
 
 obj/md_vic3l_operator.o : \
-    obj/mwd_setup.o \
-    obj/mwd_mesh.o \
     obj/mwd_options.o \
+    obj/mwd_setup.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
 
 obj/md_regularization.o : \
+    obj/mwd_parameters.o \
     obj/mwd_setup.o \
     obj/mwd_input_data.o \
-    obj/mwd_mesh.o \
-    obj/mwd_parameters.o \
-    obj/md_constant.o \
     obj/mwd_parameters_manipulation.o \
     obj/mwd_options.o \
+    obj/md_constant.o \
+    obj/mwd_mesh.o \
 
 obj/mw_optimize.o : \
-    obj/mwd_setup.o \
-    obj/mw_forward.o \
-    obj/mwd_input_data.o \
     obj/m_array_manipulation.o \
+    obj/mwd_parameters.o \
+    obj/mwd_setup.o \
+    obj/mwd_output.o \
+    obj/mwd_input_data.o \
+    obj/mw_forward.o \
+    obj/mwd_parameters_manipulation.o \
+    obj/mwd_options.o \
+    obj/md_constant.o \
     obj/m_screen_display.o \
     obj/mwd_mesh.o \
-    obj/mwd_parameters.o \
-    obj/md_constant.o \
-    obj/mwd_output.o \
-    obj/mwd_parameters_manipulation.o \
-    obj/mwd_control.o \
-    obj/mwd_options.o \
     obj/mwd_returns.o \
+    obj/mwd_control.o \
 
 obj/mwd_cost.o : \
-    obj/mwd_setup.o \
+    obj/md_regularization.o \
+    obj/mwd_parameters.o \
     obj/mwd_signatures.o \
+    obj/mwd_output.o \
+    obj/mwd_metrics.o \
+    obj/mwd_setup.o \
     obj/mwd_input_data.o \
     obj/mwd_bayesian_tools.o \
-    obj/mwd_mesh.o \
-    obj/mwd_metrics.o \
-    obj/mwd_parameters.o \
-    obj/md_regularization.o \
-    obj/md_stats.o \
-    obj/md_constant.o \
-    obj/mwd_output.o \
     obj/mwd_options.o \
+    obj/md_constant.o \
+    obj/mwd_mesh.o \
     obj/mwd_returns.o \
+    obj/md_stats.o \
 
 obj/mw_atmos_statistic.o : \
     obj/mwd_setup.o \
     obj/mwd_input_data.o \
-    obj/mwd_mesh.o \
+    obj/mwd_atmos_manipulation.o \
     obj/mw_mask.o \
-    obj/mwd_sparse_matrix_manipulation.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/mwd_sparse_matrix_manipulation.o \
 
 obj/mw_interception_capacity.o : \
-    obj/mwd_setup.o \
-    obj/m_array_creation.o \
-    obj/mwd_input_data.o \
-    obj/mwd_mesh.o \
     obj/md_gr_operator.o \
-    obj/mwd_sparse_matrix_manipulation.o \
+    obj/mwd_setup.o \
+    obj/mwd_input_data.o \
+    obj/mwd_atmos_manipulation.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/mwd_sparse_matrix_manipulation.o \
+    obj/m_array_creation.o \
 
 obj/mw_mask.o : \
-    obj/mwd_mesh.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
 
-obj/mwd_parameters_manipulation.o : \
+obj/mwd_atmos_manipulation.o : \
     obj/mwd_setup.o \
     obj/mwd_input_data.o \
-    obj/mwd_bayesian_tools.o \
-    obj/mwd_rr_parameters.o \
-    obj/mwd_mesh.o \
-    obj/mwd_parameters.o \
-    obj/mwd_rr_states.o \
-    obj/mwd_serr_mu_parameters.o \
-    obj/mwd_serr_sigma_parameters.o \
     obj/md_constant.o \
+    obj/mwd_mesh.o \
+    obj/mwd_sparse_matrix_manipulation.o \
+
+obj/mwd_parameters_manipulation.o : \
+    obj/mwd_parameters.o \
+    obj/mwd_rr_parameters.o \
+    obj/mwd_setup.o \
     obj/mwd_output.o \
-    obj/mwd_control.o \
+    obj/mwd_input_data.o \
+    obj/mwd_serr_sigma_parameters.o \
+    obj/mwd_bayesian_tools.o \
+    obj/mwd_serr_mu_parameters.o \
     obj/mwd_options.o \
+    obj/md_constant.o \
+    obj/mwd_mesh.o \
     obj/mwd_returns.o \
+    obj/mwd_control.o \
+    obj/mwd_rr_states.o \
 
 obj/mwd_sparse_matrix_manipulation.o : \
     obj/md_constant.o \
-    obj/mwd_mesh.o \
     obj/mwd_sparse_matrix.o \
+    obj/mwd_mesh.o \
 
 obj/mw_prcp_indices.o : \
     obj/mwd_setup.o \
     obj/mwd_input_data.o \
-    obj/mwd_mesh.o \
     obj/mw_mask.o \
+    obj/md_constant.o \
+    obj/mwd_mesh.o \
     obj/md_stats.o \
     obj/mwd_sparse_matrix_manipulation.o \
-    obj/md_constant.o \
 
 obj/mwd_metrics.o : \
     obj/md_constant.o \
 
 obj/mwd_signatures.o : \
-    obj/md_stats.o \
     obj/md_constant.o \
+    obj/md_stats.o \
 

--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -511,6 +511,7 @@ DEFAULT_MODEL_SETUP = {
     "start_time": None,
     "end_time": None,
     "adjust_interception": True,
+    "compute_mean_atmos": True,
     "read_qobs": False,
     "qobs_directory": None,
     "read_prcp": False,

--- a/smash/core/model/_build_model.py
+++ b/smash/core/model/_build_model.py
@@ -35,7 +35,7 @@ from smash.fcore._mw_interception_capacity import (
     adjust_interception_capacity as wrap_adjust_interception_capacity,
 )
 from smash.fcore._mwd_sparse_matrix_manipulation import (
-    compute_rowcol_to_ind_sparse as wrap_compute_rowcol_to_ind_sparse,
+    compute_rowcol_to_ind_ac as wrap_compute_rowcol_to_ind_ac,
 )
 
 if TYPE_CHECKING:
@@ -76,8 +76,7 @@ def _map_dict_to_fortran_derived_type(dct: dict, fdt: FortranDerivedType, skip: 
 
 
 def _build_mesh(setup: SetupDT, mesh: MeshDT):
-    if setup.sparse_storage:
-        wrap_compute_rowcol_to_ind_sparse(mesh)  # % Fortran subroutine
+    wrap_compute_rowcol_to_ind_ac(mesh)  # % Fortran subroutine
     mesh.local_active_cell = mesh.active_cell.copy()
 
 
@@ -103,8 +102,9 @@ def _build_input_data(setup: SetupDT, mesh: MeshDT, input_data: Input_DataDT):
     if setup.read_descriptor:
         _read_descriptor(setup, mesh, input_data)
 
-    print("</> Computing mean atmospheric data")
-    wrap_compute_mean_atmos(setup, mesh, input_data)  # % Fortran subroutine
+    if setup.compute_mean_atmos:
+        print("</> Computing mean atmospheric data")
+        wrap_compute_mean_atmos(setup, mesh, input_data)  # % Fortran subroutine
 
 
 def _build_parameters(

--- a/smash/core/model/_read_input_data.py
+++ b/smash/core/model/_read_input_data.py
@@ -61,6 +61,8 @@ def _find_index_files_containing_date(
     return ind
 
 
+# FIXME UnboundLocalError: cannot access local variable 'ind' where it is not associated with a value. It
+# happens when there is no files associated to the date range is access method is defined.
 def _get_atmos_files(
     dir: str,
     fmt: str,

--- a/smash/core/model/_standardize.py
+++ b/smash/core/model/_standardize.py
@@ -235,6 +235,10 @@ def _standardize_model_setup_adjust_interception(adjust_interception: bool, **kw
     return _standardize_model_setup_bool("adjust_interception", adjust_interception)
 
 
+def _standardize_model_setup_compute_mean_atmos(compute_mean_atmos: bool, **kwrags) -> bool:
+    return _standardize_model_setup_bool("compute_mean_atmos", compute_mean_atmos)
+
+
 def _standardize_model_setup_read_qobs(read_qobs: bool, **kwrags) -> bool:
     return _standardize_model_setup_bool("read_qobs", read_qobs)
 

--- a/smash/core/model/model.py
+++ b/smash/core/model/model.py
@@ -177,6 +177,9 @@ class Model:
             This option is only applicable if **hydrological_module** is set to ``'gr4'`` or ``'gr5'`` and
             for a sub-daily simulation time step **dt**.
 
+        compute_mean_atmos : `bool`, default True
+            Whether or not to compute mean atmospheric data for each gauge.
+
         read_qobs : `bool`, default False
             Whether or not to read observed discharge file(s).
 
@@ -395,7 +398,7 @@ class Model:
         rr_parameters: ['keys', 'values']
         serr_mu_parameters: ['keys', 'values']
         serr_sigma_parameters: ['keys', 'values']
-        setup: ['adjust_interception', 'daily_interannual_pet', '...', 'temp_access', 'temp_directory']
+        setup: ['adjust_interception', 'compute_mean_atmos', '...', 'temp_access', 'temp_directory']
         u_response_data: ['q_stdev']
     """
 
@@ -487,7 +490,7 @@ class Model:
         >>> model.setup
         SetupDT
             adjust_interception: 1
-            daily_interannual_pet: 1
+            compute_mean_atmos: 1
             ...
             temp_directory: '...'
             temp_format: 'tif'
@@ -500,7 +503,8 @@ class Model:
         If you are using IPython, tab completion allows you to visualize all the attributes and methods
 
         >>> model.setup.<TAB>
-        model.setup.adjust_interception     model.setup.prcp_partitioning
+        model.setup.adjust_interception     model.setup.prcp_format
+        model.setup.compute_mean_atmos      model.setup.prcp_partitioning
         model.setup.copy()                  model.setup.qobs_directory
         model.setup.daily_interannual_pet   model.setup.read_descriptor
         model.setup.descriptor_directory    model.setup.read_pet
@@ -523,7 +527,6 @@ class Model:
         model.setup.prcp_access             model.setup.temp_access
         model.setup.prcp_conversion_factor  model.setup.temp_directory
         model.setup.prcp_directory          model.setup.temp_format
-        model.setup.prcp_format
         """
 
         return self._setup
@@ -580,7 +583,7 @@ class Model:
         model.mesh.cpar_to_rowcol        model.mesh.ng
         model.mesh.cscpar                model.mesh.npar
         model.mesh.dx                    model.mesh.nrow
-        model.mesh.dy                    model.mesh.rowcol_to_ind_sparse
+        model.mesh.dy                    model.mesh.rowcol_to_ind_ac
         model.mesh.flwacc                model.mesh.xmin
         model.mesh.flwdir                model.mesh.xres
         model.mesh.flwdst                model.mesh.ymax

--- a/smash/fcore/derived_type/mwd_mesh.f90
+++ b/smash/fcore/derived_type/mwd_mesh.f90
@@ -32,7 +32,7 @@
 !%          ``code``                 Gauge code
 !%          ``area``                 Drained area at gauge position                                [m2]
 !%          ``area_dln``             Drained area at gauge position delineated                     [m2]
-!%          ``rowcol_to_ind_sparse`` Matrix linking (row, col) couple to sparse storage indice (k)
+!%          ``rowcol_to_ind_ac``     Matrix linking (row, col) couple to active cell indice (k)
 !%          ``local_active_cell``    Mask of local active cells
 !%
 !%      Subroutine
@@ -81,7 +81,7 @@ module mwd_mesh
         real(sp), dimension(:), allocatable :: area
         real(sp), dimension(:), allocatable :: area_dln
 
-        integer, dimension(:, :), allocatable :: rowcol_to_ind_sparse
+        integer, dimension(:, :), allocatable :: rowcol_to_ind_ac
         integer, dimension(:, :), allocatable :: local_active_cell
 
     end type MeshDT
@@ -149,12 +149,8 @@ contains
         allocate (this%area_dln(this%ng))
         this%area_dln = -99._sp
 
-        if (setup%sparse_storage) then
-
-            allocate (this%rowcol_to_ind_sparse(this%nrow, this%ncol))
-            this%rowcol_to_ind_sparse = -99
-
-        end if
+        allocate (this%rowcol_to_ind_ac(this%nrow, this%ncol))
+        this%rowcol_to_ind_ac = -99
 
         allocate (this%local_active_cell(this%nrow, this%ncol))
         this%local_active_cell = -99

--- a/smash/fcore/derived_type/mwd_setup.f90
+++ b/smash/fcore/derived_type/mwd_setup.f90
@@ -18,6 +18,7 @@
 !%          ``start_time``             Simulation start time   [%Y%m%d%H%M]
 !%          ``end_time``               Simulation end time     [%Y%m%d%H%M]
 !%          ``adjust_interception``    Adjust interception reservoir capacity
+!%          ``compute_mean_atmos``     Compute mean atmospheric data for each gauge
 !%          ``read_qobs``              Read observed discharge
 !%          ``qobs_directory``         Observed discharge directory path
 !%          ``read_prcp``              Read precipitation
@@ -87,6 +88,7 @@ module mwd_setup
         character(lchar) :: end_time = "..." !$F90W char
 
         logical :: adjust_interception = .true.
+        logical :: compute_mean_atmos = .true.
 
         logical :: read_qobs = .false.
         character(lchar) :: qobs_directory = "..." !$F90W char

--- a/smash/fcore/routine/mw_atmos_statistic.f90
+++ b/smash/fcore/routine/mw_atmos_statistic.f90
@@ -3,7 +3,9 @@
 !%      Subroutine
 !%      ----------
 !%
-!%      - compute_mean_forcing
+!%      - get_mean_gauge_atmos_data
+!%      - compute_mean_atmos
+!%      - compute_prcp_partitioning
 
 module mw_atmos_statistic
 
@@ -11,6 +13,7 @@ module mw_atmos_statistic
     use mwd_setup, only: SetupDT
     use mwd_mesh, only: MeshDT
     use mwd_input_data, only: Input_DataDT
+    use mwd_atmos_manipulation, only: get_atmos_data_timestep, set_atmos_data_timestep
     use mwd_sparse_matrix_manipulation, only: sparse_matrix_to_matrix, matrix_to_sparse_matrix
     use mw_mask, only: mask_upstream_cells
 
@@ -18,6 +21,44 @@ module mw_atmos_statistic
 
 contains
 
+    subroutine get_mean_gauge_atmos_data(mesh, mask_gauge, mask_atmos, mat_atmos, mean_gauge_atmos)
+
+        implicit none
+
+        type(MeshDT), intent(in) :: mesh
+        logical, dimension(mesh%nrow, mesh%ncol), intent(in) :: mask_gauge
+        logical, dimension(mesh%nrow, mesh%ncol), intent(in) :: mask_atmos
+        real(sp), dimension(mesh%nrow, mesh%ncol), intent(in) :: mat_atmos
+        real(sp), intent(inout) :: mean_gauge_atmos
+
+        integer :: row, col, n_gauge_atmos
+
+        mean_gauge_atmos = 0._sp
+        n_gauge_atmos = 0
+
+        do col = 1, mesh%ncol
+            do row = 1, mesh%nrow
+
+                if (.not. mask_gauge(row, col) .or. .not. mask_atmos(row, col)) cycle
+
+                mean_gauge_atmos = mean_gauge_atmos + mat_atmos(row, col)
+                n_gauge_atmos = n_gauge_atmos + 1
+
+            end do
+        end do
+
+        if (n_gauge_atmos .gt. 0) then
+            mean_gauge_atmos = mean_gauge_atmos/n_gauge_atmos
+
+        else
+            mean_gauge_atmos = -99._sp
+
+        end if
+
+    end subroutine get_mean_gauge_atmos_data
+
+    ! TODO: All the atmospheric data variables are hard-coded. This subroutine might need to be rewritten if
+    ! the total number of atmospheric data increase.
     subroutine compute_mean_atmos(setup, mesh, input_data)
 
         implicit none
@@ -26,10 +67,12 @@ contains
         type(MeshDT), intent(in) :: mesh
         type(Input_DataDT), intent(inout) :: input_data
 
+        integer :: i, t
         logical, dimension(mesh%nrow, mesh%ncol, mesh%ng) :: mask_gauge
-        logical, dimension(mesh%nrow, mesh%ncol) :: mask_prcp, mask_pet, mask_snow, mask_temp
-        real(sp), dimension(mesh%nrow, mesh%ncol) :: matrix_prcp, matrix_pet, matrix_snow, matrix_temp
-        integer :: i, j, n_prcp, n_pet, n_snow, n_temp
+        real(sp), dimension(mesh%nrow, mesh%ncol) :: mat_prcp, mat_pet
+        logical, dimension(mesh%nrow, mesh%ncol) :: mask_prcp, mask_pet
+        real(sp), dimension(:, :), allocatable :: mat_snow, mat_temp
+        logical, dimension(:, :), allocatable :: mask_snow, mask_temp
 
         mask_gauge = .false.
 
@@ -40,56 +83,42 @@ contains
 
         end do
 
-        do i = 1, setup%ntime_step
+        !% Only allocate snow and temp variables if a snow module has been choosen
+        if (setup%snow_module_present) then
+            allocate (mat_snow(mesh%nrow, mesh%ncol), mat_temp(mesh%nrow, mesh%ncol))
+            allocate (mask_snow(mesh%nrow, mesh%ncol), mask_temp(mesh%nrow, mesh%ncol))
+        end if
 
-            if (setup%sparse_storage) then
+        do t = 1, setup%ntime_step
 
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_prcp(i), matrix_prcp)
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_pet(i), matrix_pet)
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "prcp", mat_prcp)
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "pet", mat_pet)
 
-                if (setup%snow_module_present) then
-
-                    call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_snow(i), matrix_snow)
-                    call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_temp(i), matrix_temp)
-
-                end if
-
-            else
-
-                matrix_prcp = input_data%atmos_data%prcp(:, :, i)
-                matrix_pet = input_data%atmos_data%pet(:, :, i)
-
-                if (setup%snow_module_present) then
-
-                    matrix_snow = input_data%atmos_data%snow(:, :, i)
-                    matrix_temp = input_data%atmos_data%temp(:, :, i)
-
-                end if
-
+            if (setup%snow_module_present) then
+                call get_atmos_data_timestep(setup, mesh, input_data, t, "snow", mat_snow)
+                call get_atmos_data_timestep(setup, mesh, input_data, t, "temp", mat_temp)
             end if
 
-            do j = 1, mesh%ng
+            mask_prcp = (mat_prcp .ge. 0._sp)
+            mask_pet = (mat_pet .ge. 0._sp)
 
-                mask_prcp = (matrix_prcp .ge. 0._sp .and. mask_gauge(:, :, j))
-                n_prcp = count(mask_prcp)
-                mask_pet = (matrix_pet .ge. 0._sp .and. mask_gauge(:, :, j))
-                n_pet = count(mask_pet)
+            if (setup%snow_module_present) then
+                mask_snow = (mat_snow .ge. 0._sp)
+                mask_temp = (mat_temp .gt. -99._sp)
+            end if
 
-                ! Will be -99 if n is equal to 0
-                if (n_prcp .gt. 0) input_data%atmos_data%mean_prcp(j, i) = sum(matrix_prcp, mask=mask_prcp)/n_prcp
-                if (n_pet .gt. 0) input_data%atmos_data%mean_pet(j, i) = sum(matrix_pet, mask=mask_pet)/n_pet
+            do i = 1, mesh%ng
+
+                call get_mean_gauge_atmos_data(mesh, mask_gauge(:, :, i), mask_prcp, mat_prcp, &
+                & input_data%atmos_data%mean_prcp(i, t))
+                call get_mean_gauge_atmos_data(mesh, mask_gauge(:, :, i), mask_pet, mat_pet, &
+                & input_data%atmos_data%mean_pet(i, t))
 
                 if (setup%snow_module_present) then
-
-                    mask_snow = (matrix_snow .ge. 0._sp .and. mask_gauge(:, :, j))
-                    n_snow = count(mask_snow)
-                    mask_temp = (matrix_temp .gt. -99._sp .and. mask_gauge(:, :, j))
-                    n_temp = count(mask_temp)
-
-                    ! Will be -99 if n is equal to 0
-                    if (n_snow .gt. 0) input_data%atmos_data%mean_snow(j, i) = sum(matrix_snow, mask=mask_snow)/n_snow
-                    if (n_temp .gt. 0) input_data%atmos_data%mean_temp(j, i) = sum(matrix_temp, mask=mask_temp)/n_temp
-
+                    call get_mean_gauge_atmos_data(mesh, mask_gauge(:, :, i), mask_snow, mat_snow, &
+                    & input_data%atmos_data%mean_snow(i, t))
+                    call get_mean_gauge_atmos_data(mesh, mask_gauge(:, :, i), mask_temp, mat_temp, &
+                    & input_data%atmos_data%mean_temp(i, t))
                 end if
 
             end do
@@ -105,33 +134,21 @@ contains
         type(MeshDT), intent(in) :: mesh
         type(Input_DataDT), intent(inout) :: input_data
 
-        integer :: i
-        real(sp), dimension(mesh%nrow, mesh%ncol) :: matrix_prcp, matrix_snow, matrix_temp, ratio
+        integer :: t
+        real(sp), dimension(mesh%nrow, mesh%ncol) :: mat_prcp, mat_snow, mat_temp, ratio
 
-        do i = 1, setup%ntime_step
+        do t = 1, setup%ntime_step
 
-            if (setup%sparse_storage) then
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "prcp", mat_prcp)
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "snow", mat_snow)
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "temp", mat_temp)
 
-                ! Do not check for snow module because this subroutine should be only called when a snow module
-                ! has been selected
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_prcp(i), matrix_prcp)
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_snow(i), matrix_snow)
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_temp(i), matrix_temp)
-
-            else
-
-                matrix_prcp = input_data%atmos_data%prcp(:, :, i)
-                matrix_snow = input_data%atmos_data%snow(:, :, i)
-                matrix_temp = input_data%atmos_data%temp(:, :, i)
-
-            end if
-
-            where (matrix_snow .ge. 0._sp) matrix_prcp = matrix_prcp + matrix_snow
+            where (mat_snow .ge. 0._sp) mat_prcp = mat_prcp + mat_snow
 
             ! If there is no temperature data, precipitation is assumed to be only liquid
-            where (matrix_temp .gt. -99._sp)
+            where (mat_temp .gt. -99._sp)
 
-                ratio = 1._sp - 1._sp/(1._sp + exp(10._sp/4._sp*matrix_temp - 1._sp))
+                ratio = 1._sp - 1._sp/(1._sp + exp(10._sp/4._sp*mat_temp - 1._sp))
 
             else where
 
@@ -139,28 +156,19 @@ contains
 
             end where
 
-            where (matrix_prcp .ge. 0._sp)
+            where (mat_prcp .ge. 0._sp)
 
-                matrix_snow = (1._sp - ratio)*matrix_prcp
-                matrix_prcp = matrix_prcp - matrix_snow
+                mat_snow = (1._sp - ratio)*mat_prcp
+                mat_prcp = mat_prcp - mat_snow
 
             else where
 
-                matrix_snow = -99._sp
+                mat_snow = -99._sp
 
             end where
 
-            if (setup%sparse_storage) then
-
-                call matrix_to_sparse_matrix(mesh, matrix_prcp, 0._sp, input_data%atmos_data%sparse_prcp(i))
-                call matrix_to_sparse_matrix(mesh, matrix_snow, 0._sp, input_data%atmos_data%sparse_snow(i))
-
-            else
-
-                input_data%atmos_data%prcp(:, :, i) = matrix_prcp
-                input_data%atmos_data%snow(:, :, i) = matrix_snow
-
-            end if
+            call set_atmos_data_timestep(setup, mesh, input_data, t, "prcp", mat_prcp)
+            call set_atmos_data_timestep(setup, mesh, input_data, t, "snow", mat_snow)
 
         end do
 

--- a/smash/fcore/routine/mw_interception_capacity.f90
+++ b/smash/fcore/routine/mw_interception_capacity.f90
@@ -14,6 +14,7 @@ module mw_interception_capacity
     use mwd_sparse_matrix_manipulation, only: sparse_matrix_to_matrix
     use md_gr_operator, only: gr_interception
     use m_array_creation, only: arange
+    use mwd_atmos_manipulation, only: get_atmos_data_timestep
 
     implicit none
 
@@ -31,11 +32,11 @@ contains
         real(sp), dimension(mesh%nrow, mesh%ncol), intent(inout) :: ci
 
         real(sp), dimension(mesh%nrow, mesh%ncol, nday) :: daily_prcp, daily_pet
-        real(sp), dimension(mesh%nrow, mesh%ncol) :: matrix_prcp, matrix_pet, h, daily_cumulated, sub_daily_cumulated
+        real(sp), dimension(mesh%nrow, mesh%ncol) :: mat_prcp, mat_pet, h, daily_cumulated, sub_daily_cumulated
         real(sp), dimension(:), allocatable :: cmax
         real(sp), dimension(:, :, :), allocatable :: diff
         real(sp) :: stt, stp, step, pn, en, ei
-        integer :: i, j, ind, row, col, n
+        integer :: t, i, ind, row, col, n
 
         !% =========================================================================================================== %!
         !%   Daily aggregation of precipitation and evapotranspiration
@@ -44,39 +45,28 @@ contains
         daily_prcp = 0._sp
         daily_pet = 0._sp
 
-        do i = 1, setup%ntime_step
+        do t = 1, setup%ntime_step
 
-            if (setup%sparse_storage) then
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "prcp", mat_prcp)
+            call get_atmos_data_timestep(setup, mesh, input_data, t, "pet", mat_pet)
 
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_prcp(i), matrix_prcp)
-                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_pet(i), matrix_pet)
+            ind = day_index(t)
 
-            else
-
-                matrix_prcp = input_data%atmos_data%prcp(:, :, i)
-                matrix_pet = input_data%atmos_data%pet(:, :, i)
-
-            end if
-
-            ind = day_index(i)
-
-            daily_prcp(:, :, ind) = daily_prcp(:, :, ind) + matrix_prcp
-            daily_pet(:, :, ind) = daily_pet(:, :, ind) + matrix_pet
+            daily_prcp(:, :, ind) = daily_prcp(:, :, ind) + mat_prcp
+            daily_pet(:, :, ind) = daily_pet(:, :, ind) + mat_pet
 
         end do
 
         daily_cumulated = 0._sp
 
-        do i = 1, nday
+        do t = 1, nday
 
             do col = 1, mesh%ncol
-
                 do row = 1, mesh%nrow
 
-                    daily_cumulated(row, col) = daily_cumulated(row, col) + min(daily_prcp(row, col, i), daily_pet(row, col, i))
+                    daily_cumulated(row, col) = daily_cumulated(row, col) + min(daily_prcp(row, col, t), daily_pet(row, col, t))
 
                 end do
-
             end do
 
         end do
@@ -99,31 +89,21 @@ contains
             h = 0._sp
             sub_daily_cumulated = 0._sp
 
-            do j = 1, setup%ntime_step
+            do t = 1, setup%ntime_step
 
-                if (setup%sparse_storage) then
-
-                    call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_prcp(j), matrix_prcp)
-                    call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_pet(j), matrix_pet)
-
-                else
-
-                    matrix_prcp = input_data%atmos_data%prcp(:, :, j)
-                    matrix_pet = input_data%atmos_data%pet(:, :, j)
-
-                end if
+                call get_atmos_data_timestep(setup, mesh, input_data, t, "prcp", mat_prcp)
+                call get_atmos_data_timestep(setup, mesh, input_data, t, "pet", mat_pet)
 
                 do col = 1, mesh%ncol
-
                     do row = 1, mesh%nrow
 
                         if (mesh%active_cell(row, col) .eq. 0 .or. mesh%local_active_cell(row, col) .eq. 0) cycle
 
-                        if (matrix_prcp(row, col) .ge. 0._sp .and. matrix_pet(row, col) .ge. 0._sp) then
+                        if (mat_prcp(row, col) .ge. 0._sp .and. mat_pet(row, col) .ge. 0._sp) then
 
-                            call gr_interception(matrix_prcp(row, col), matrix_pet(row, col), cmax(i), &
+                            call gr_interception(mat_prcp(row, col), mat_pet(row, col), cmax(i), &
                             & h(row, col), pn, en)
-                            ei = matrix_pet(row, col) - en
+                            ei = mat_pet(row, col) - en
 
                         else
 
@@ -134,7 +114,6 @@ contains
                         sub_daily_cumulated(row, col) = sub_daily_cumulated(row, col) + ei
 
                     end do
-
                 end do
 
             end do
@@ -144,7 +123,6 @@ contains
         end do
 
         do col = 1, mesh%ncol
-
             do row = 1, mesh%nrow
 
                 if (mesh%active_cell(row, col) .eq. 0 .or. mesh%local_active_cell(row, col) .eq. 0) cycle
@@ -155,7 +133,6 @@ contains
                 ci(row, col) = cmax(ind)
 
             end do
-
         end do
 
     end subroutine adjust_interception_capacity

--- a/smash/fcore/routine/mwd_atmos_manipulation.f90
+++ b/smash/fcore/routine/mwd_atmos_manipulation.f90
@@ -1,0 +1,141 @@
+!%      (MW) Module Wrapped and Differentiated.
+!%
+!%      Subroutine
+!%      ----------
+!%
+!%      - get_atmos_data_timestep
+!%      - set_atmos_data_timestep
+!%      - get_ac_atmos_data_timestep
+!%      - set_ac_atmos_data_timestep
+
+module mwd_atmos_manipulation
+
+    use md_constant
+    use mwd_setup
+    use mwd_mesh
+    use mwd_input_data
+    use mwd_sparse_matrix_manipulation
+
+    implicit none
+
+contains
+
+    subroutine get_atmos_data_timestep(setup, mesh, input_data, timestep, key, vle)
+
+        implicit none
+
+        type(SetupDT), intent(in) :: setup
+        type(MeshDT), intent(in) :: mesh
+        type(Input_DataDT), intent(in) :: input_data
+        integer, intent(in) :: timestep
+        character(*), intent(in) :: key
+        real(sp), dimension(mesh%nrow, mesh%ncol), intent(inout) :: vle
+
+        select case (trim(key))
+
+        case ("prcp")
+
+            if (setup%sparse_storage) then
+                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_prcp(timestep), vle)
+
+            else
+                vle = input_data%atmos_data%prcp(:, :, timestep)
+
+            end if
+
+        case ("pet")
+
+            if (setup%sparse_storage) then
+                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_pet(timestep), vle)
+
+            else
+                vle = input_data%atmos_data%pet(:, :, timestep)
+
+            end if
+
+        case ("snow")
+
+            !% assert (setup%snow_module_present)
+            if (setup%sparse_storage) then
+                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_snow(timestep), vle)
+
+            else
+                vle = input_data%atmos_data%snow(:, :, timestep)
+
+            end if
+
+        case ("temp")
+
+            !% assert (setup%snow_module_present)
+            if (setup%sparse_storage) then
+                call sparse_matrix_to_matrix(mesh, input_data%atmos_data%sparse_temp(timestep), vle)
+
+            else
+                vle = input_data%atmos_data%temp(:, :, timestep)
+
+            end if
+
+        end select
+
+    end subroutine get_atmos_data_timestep
+
+    subroutine set_atmos_data_timestep(setup, mesh, input_data, timestep, key, vle)
+
+        implicit none
+
+        type(SetupDT), intent(in) :: setup
+        type(MeshDT), intent(in) :: mesh
+        type(Input_DataDT), intent(inout) :: input_data
+        integer, intent(in) :: timestep
+        character(*), intent(in) :: key
+        real(sp), dimension(mesh%nrow, mesh%ncol), intent(in) :: vle
+
+        select case (trim(key))
+
+        case ("prcp")
+
+            if (setup%sparse_storage) then
+                call matrix_to_sparse_matrix(mesh, vle, 0._sp, input_data%atmos_data%sparse_prcp(timestep))
+
+            else
+                input_data%atmos_data%prcp(:, :, timestep) = vle
+
+            end if
+
+        case ("pet")
+
+            if (setup%sparse_storage) then
+                call matrix_to_sparse_matrix(mesh, vle, 0._sp, input_data%atmos_data%sparse_pet(timestep))
+
+            else
+                input_data%atmos_data%pet(:, :, timestep) = vle
+
+            end if
+
+        case ("snow")
+
+            !% assert (setup%snow_module_present)
+            if (setup%sparse_storage) then
+                call matrix_to_sparse_matrix(mesh, vle, 0._sp, input_data%atmos_data%sparse_snow(timestep))
+
+            else
+                input_data%atmos_data%snow(:, :, timestep) = vle
+
+            end if
+
+        case ("temp")
+
+            !% assert (setup%snow_module_present)
+            if (setup%sparse_storage) then
+                call matrix_to_sparse_matrix(mesh, vle, 0._sp, input_data%atmos_data%sparse_temp(timestep))
+
+            else
+                input_data%atmos_data%temp(:, :, timestep) = vle
+
+            end if
+
+        end select
+
+    end subroutine set_atmos_data_timestep
+
+end module mwd_atmos_manipulation

--- a/smash/fcore/routine/mwd_sparse_matrix_manipulation.f90
+++ b/smash/fcore/routine/mwd_sparse_matrix_manipulation.f90
@@ -4,7 +4,7 @@
 !%      ----------
 !%
 !%      - binary_search
-!%      - compute_rowcol_to_ind_sparse
+!%      - compute_rowcol_to_ind_ac
 !%      - get_matrix_nnz
 !%      - coo_fill_sparse_matrix
 !%      - ac_fill_sparse_matrix
@@ -25,7 +25,7 @@ module mwd_sparse_matrix_manipulation
 
     implicit none
 
-    public :: compute_rowcol_to_ind_sparse, matrix_to_sparse_matrix, &
+    public :: compute_rowcol_to_ind_ac, matrix_to_sparse_matrix, &
     & sparse_matrix_to_matrix, get_sparse_matrix_dat
 
 contains
@@ -66,7 +66,7 @@ contains
 
     end subroutine binary_search
 
-    subroutine compute_rowcol_to_ind_sparse(mesh)
+    subroutine compute_rowcol_to_ind_ac(mesh)
 
         !% Notes
         !% -----
@@ -86,13 +86,13 @@ contains
                 if (mesh%active_cell(row, col) .eq. 0) cycle
 
                 i = i + 1
-                mesh%rowcol_to_ind_sparse(row, col) = i
+                mesh%rowcol_to_ind_ac(row, col) = i
 
             end do
 
         end do
 
-    end subroutine compute_rowcol_to_ind_sparse
+    end subroutine compute_rowcol_to_ind_ac
 
     subroutine get_matrix_nnz(mesh, matrix, zvalue, nnz)
 
@@ -140,7 +140,7 @@ contains
 
                 i = i + 1
 
-                sparse_matrix%indices(i) = mesh%rowcol_to_ind_sparse(row, col)
+                sparse_matrix%indices(i) = mesh%rowcol_to_ind_ac(row, col)
                 sparse_matrix%values(i) = matrix(row, col)
 
             end do
@@ -321,7 +321,7 @@ contains
 
         integer :: k, ind
 
-        k = mesh%rowcol_to_ind_sparse(row, col)
+        k = mesh%rowcol_to_ind_ac(row, col)
 
         call binary_search(sparse_matrix%n, sparse_matrix%indices, k, ind)
 
@@ -340,7 +340,7 @@ contains
 
         integer :: k
 
-        k = mesh%rowcol_to_ind_sparse(row, col)
+        k = mesh%rowcol_to_ind_ac(row, col)
 
         res = sparse_matrix%values(k)
 

--- a/smash/io/model.py
+++ b/smash/io/model.py
@@ -59,7 +59,7 @@ def save_model(model: Model, path: FilePath):
         atmos_data: ['mean_pet', 'mean_prcp', '...', 'sparse_prcp', 'sparse_snow']
         mesh: ['active_cell', 'area', '...', 'xres', 'ymax']
         ...
-        setup: ['adjust_interception', 'daily_interannual_pet', '...', 'structure', 'temp_directory']
+        setup: ['adjust_interception', 'compute_mean_atmos', '...', 'structure', 'temp_directory']
         u_response_data: ['q_stdev']
     >>> model.setup.hydrological_module, model.setup.routing_module
     ('gr4', 'lr')
@@ -114,7 +114,7 @@ def read_model(path: FilePath) -> Model:
         atmos_data: ['mean_pet', 'mean_prcp', '...', 'sparse_prcp', 'sparse_snow']
         mesh: ['active_cell', 'area', '...', 'xres', 'ymax']
         ...
-        setup: ['adjust_interception', 'daily_interannual_pet', '...', 'structure', 'temp_directory']
+        setup: ['adjust_interception', 'compute_mean_atmos', '...', 'structure', 'temp_directory']
         u_response_data: ['q_stdev']
     >>> model.setup.hydrological_module, model.setup.routing_module
     ('gr4', 'lr')
@@ -131,7 +131,7 @@ def read_model(path: FilePath) -> Model:
         atmos_data: ['mean_pet', 'mean_prcp', '...', 'sparse_prcp', 'sparse_snow']
         mesh: ['active_cell', 'area', '...', 'xres', 'ymax']
         ...
-        setup: ['adjust_interception', 'daily_interannual_pet', '...', 'structure', 'temp_directory']
+        setup: ['adjust_interception', 'compute_mean_atmos', '...', 'structure', 'temp_directory']
         u_response_data: ['q_stdev']
     >>> model.setup.hydrological_module, model.setup.routing_module
     ('gr4', 'lr')


### PR DESCRIPTION
- Add a new file mwd_atmos_manipulation to get and set atmos data matrix
- Rewrite the compute_mean_atmos Fortran function to gain computation time
- Add a new setup option to trigger or not the mean atmos computation
- Add compute_mean_atmos options to documentation
- Rename mesh variable rowcol_to_ind_sparse to rowcol_to_ind_ac