### PR TITLE
FIX: Missing keys for returned states

### DIFF
--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -16912,7 +16912,7 @@ END MODULE MD_VIC3L_OPERATOR_DIFF
 !%      Subroutine
 !%      ----------
 !%
-!%      - roll_checkpoint_discharge
+!%      - roll_discharge
 !%      - store_time_step
 !%      - simulation_checkpoint
 !%      - simulation

--- a/smash/fcore/forward/md_simulation.f90
+++ b/smash/fcore/forward/md_simulation.f90
@@ -3,7 +3,7 @@
 !%      Subroutine
 !%      ----------
 !%
-!%      - roll_checkpoint_discharge
+!%      - roll_discharge
 !%      - store_time_step
 !%      - simulation_checkpoint
 !%      - simulation
@@ -82,6 +82,7 @@ contains
 
                         call ac_vector_to_matrix(mesh, checkpoint_variable%ac_rr_states(:, i), &
                         & returns%rr_states(time_step_returns)%values(:, :, i))
+                        returns%rr_states(time_step_returns)%keys = output%rr_final_states%keys
 
                     end do
 


### PR DESCRIPTION
The implementation of the time step checkpoints changed the way the states are stored between each time step. Therefore, only the values were assigned to the returned states and not the keys.
This commit fixes the issue #152 