### PR TITLE
FIX: Min Max computation for physiographic descriptor

### DIFF
--- a/doc/source/release/1.0.0-notes.rst
+++ b/doc/source/release/1.0.0-notes.rst
@@ -705,3 +705,9 @@ Error in projected gradient value with ANN mapping
 
 There was an error in the values of the projected gradient when using ANN mapping. The current iteration was
 printing the projected gradient of the next iteration.
+
+Error when computing min and max of physiograhic descriptor
+***********************************************************
+
+There was an error when computing the min and max of a physiograhic descriptor if there is no data (i.e., 
+sea in the domain). No data from tif file are converted to -99 which leads to a wrong minimal value.


### PR DESCRIPTION
This commits resolves an issue when computing min and max value of a physiographic descriptor when there are missing values that are converted to -99.
It fixes the issue #155 