### PR TITLE
MAINT/FIX: enable transfer/continuous learning with initialized net

### DIFF
--- a/smash/factory/net/_layers.py
+++ b/smash/factory/net/_layers.py
@@ -201,9 +201,11 @@ class Dense(Layer):
 
     # TODO TYPE HINT: replace function by Callable
     def _initialize(self, optimizer: function):  # noqa: F821
-        # Initialize weights and biases
-        _wb_initialization(self, "weight")
-        _wb_initialization(self, "bias")
+        # Initialize weights and biases if not initialized
+        if self.weight is None:
+            _wb_initialization(self, "weight")
+        if self.bias is None:
+            _wb_initialization(self, "bias")
 
         # Set optimizer
         self._weight_opt = copy.copy(optimizer)
@@ -226,9 +228,9 @@ class Dense(Layer):
             grad_w = self.layer_input.T.dot(accum_grad)
             grad_w0 = np.sum(accum_grad, axis=0, keepdims=True)
 
-        # Update the layer weights
-        self.weight = self._weight_opt.update(self.weight, grad_w)
-        self.bias = self._bias_opt.update(self.bias, grad_w0)
+            # Update the layer weights
+            self.weight = self._weight_opt.update(self.weight, grad_w)
+            self.bias = self._bias_opt.update(self.bias, grad_w0)
 
         # Return accumulated gradient for next layer
         # Calculated based on the weights used during the forward pass


### PR DESCRIPTION
- Fix initialize method for net: only initialize weight and bias if it is None, enabling transfer/continuous learning. This feature is already possible in the previous version since net.compile method was previously separated. In this version, it can be used as follows:
```python
model = smash.Model(*smash.factory.load_dataset("lez"))
ret = model.optimize("ann", 
                      optimize_options={"termination_crit": dict(epochs=10), "random_state":11}, 
                      return_options={"net": True})  # pre-train the neural network
net = ret.net.copy()  # net is now the pre-trained model
net.set_trainable([0,0,0,0,1,0,0])  # set trainable layers
ret2 = model.optimize("ann", 
                      optimize_options={"net": net, "termination_crit": dict(epochs=50)}, 
                      return_options={"net": True})  # continuous learning
```
- Fix set_trainable method: do not update weight and bias when trainable is set to False.