### PR TITLE
DOC: Add notes to explain smash dates convention

### DIFF
--- a/doc/source/user_guide/quickstart/cance_first_simulation.rst
+++ b/doc/source/user_guide/quickstart/cance_first_simulation.rst
@@ -185,6 +185,11 @@ To get into more details, this ``setup`` is composed of:
 - ``dt``
     The simulation time step in **second**,
 
+.. note::
+    The convention of `smash` is that ``start_time`` is the date used to initialize the model's states. All 
+    the modeled state-flux variables (i.e. discharge, states, internal fluxes) will be computed over the
+    period ``start_time + 1dt`` and ``end_time``
+
 - ``hydrological_module``
     The hydrological module, to be chosen from [``gr4``, ``gr5``, ``grd``, ``loieau``, ``vic3l``],
 
@@ -389,7 +394,7 @@ An important step after generating the ``mesh`` is to check that the stations ha
 
     (mesh["area"] - mesh["area_dln"]) / mesh["area"] * 100 # Relative error in %
 
-For this ``mesh``, we have a negative relative error on the simulated drainage area that varies from -0.3% for the most downstrea gauge to -10% for the most upstream one
+For this ``mesh``, we have a negative relative error on the simulated drainage area that varies from -0.3% for the most downstream gauge to -10% for the most upstream one
 (which can be explained by the fact that small upstream catchments are more sensitive to the relatively coarse ``mesh`` resolution).
 
 .. TODO FC link to automatic meshing
@@ -398,7 +403,7 @@ Save setup and mesh
 *******************
 
 Before constructing the `smash.Model` object, we can save (serialize) the ``setup`` and the ``mesh`` to avoid having to do it every time you want to run a simulation on the same case,
-with the two following functions, `smash.io.save_setup` and `smash.io.save_mesh`. It will save the ``setup`` in `YAML <https://yaml.org/>`__ format and the `mesh` in `HDF5 <https://www.hdfgroup.org/solutions/hdf5>`__ format.
+with the two following functions, `smash.io.save_setup` and `smash.io.save_mesh`. It will save the ``setup`` in `YAML <https://yaml.org/>`__ format and the ``mesh`` in `HDF5 <https://www.hdfgroup.org/solutions/hdf5>`__ format.
 
 .. ipython:: python
 

--- a/doc/source/user_guide/quickstart/france_large_domain_simulation.rst
+++ b/doc/source/user_guide/quickstart/france_large_domain_simulation.rst
@@ -103,7 +103,7 @@ simulation period is different.
 Model mesh creation
 *******************
 
-For the ``mesh``, we only need the flow direction file and the mainland France bouding box ``bbox`` to pass to the `smash.factory.generate_mesh`
+For the ``mesh``, we only need the flow direction file and the mainland France bounding box ``bbox`` to pass to the `smash.factory.generate_mesh`
 function. A bouding box in `smash` is a list of 4 values (``xmin``, ``xmax``, ``ymin``, ``ymax``), each of which corresponds respectively to 
 the x minimum value, the x maximum value, the y mimimum value and the y maximum value. The values must be in the same unit and projection as the 
 flow direction.

--- a/smash/core/model/model.py
+++ b/smash/core/model/model.py
@@ -172,6 +172,11 @@ class Model:
         end_time : `str`, `datetime.date` or `pandas.Timestamp`
             End time date. **end_time** must be later than **start_time**
 
+        .. note::
+            The convention of `smash` is that **start_time** is the date used to initialize the model's
+            states. All the modeled state-flux variables :math:`\\boldsymbol{U}(x,t)` (i.e. discharge, states,
+            internal fluxes) will be computed over the period **start_time + 1dt** and **end_time**
+
         adjust_interception : `bool`, default True
             Whether or not to adjust the maximum capacity of the interception reservoir.
             This option is only applicable if **hydrological_module** is set to ``'gr4'`` or ``'gr5'`` and

--- a/smash/tests/core/test_read_input_data.py
+++ b/smash/tests/core/test_read_input_data.py
@@ -56,6 +56,7 @@ def test_missing_read_input_data():
     # % Check no data for missing files
     assert np.all(model.atmos_data.prcp < 0), "missing_read_input_data.prcp_totally_no_data"
 
+
 def test_resolution_read_input_data():
     setup, _ = smash.factory.load_dataset("france")
 


### PR DESCRIPTION
Two notes has been added. One in the Model docstring and one in the Cance User Guide to explain the smash convention on ``start_time`` and ``end_time``. This PR should close #161 