### PR TITLE
FIX: Handle missing values for interception capacity calculation

### DIFF
--- a/doc/source/release/1.0.0-notes.rst
+++ b/doc/source/release/1.0.0-notes.rst
@@ -745,3 +745,11 @@ Error when computing min and max of physiograhic descriptor
 
 There was an error when computing the min and max of a physiograhic descriptor if there is no data (i.e., 
 sea in the domain). No data from tif file are converted to -99 which leads to a wrong minimal value.
+
+Interception reservoir capacity calculation
+*******************************************
+
+Missing values were not properly taken into account in the calculation of the interception reservoir. Missing
+values in Fortran for precipitation and potential evapotranspiration are stored as -99, resulting in
+erroneous values. This was fixed simply by not incorporating these values into the calculation.
+

--- a/smash/fcore/routine/mw_interception_capacity.f90
+++ b/smash/fcore/routine/mw_interception_capacity.f90
@@ -52,8 +52,8 @@ contains
 
             ind = day_index(t)
 
-            daily_prcp(:, :, ind) = daily_prcp(:, :, ind) + mat_prcp
-            daily_pet(:, :, ind) = daily_pet(:, :, ind) + mat_pet
+            where (mat_prcp .ge. 0._sp) daily_prcp(:, :, ind) = daily_prcp(:, :, ind) + mat_prcp
+            where (mat_pet .ge. 0._sp) daily_pet(:, :, ind) = daily_pet(:, :, ind) + mat_pet
 
         end do
 


### PR DESCRIPTION
Missing values were not properly taken into account in the calculation of the interception reservoir. Missing values in Fortran for precipitation and potential evapotranspiration are stored as ``-99``, resulting in erroneous values. This was fixed simply by not incorporating these values into the calculation.