### PR TITLE
MAINT: Switch from gdal to rasterio

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -33,8 +33,8 @@ jobs:
 
         - name: Install dependencies
           run: |
-            sudo apt-get update -y
-            sudo apt-get install build-essential make openjdk-11-jre-headless
+            sudo apt-get update
+            sudo apt-get install build-essential openjdk-11-jre-headless
             python -m venv test
             . test/bin/activate
             python -m pip install --upgrade pip

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -33,14 +33,11 @@ jobs:
 
         - name: Install dependencies
           run: |
-            sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
             sudo apt-get update
-            sudo apt-get install build-essential make gcc gfortran gdal-bin libgdal-dev
+            sudo apt-get install build-essential gfortran
             python -m venv test
             . test/bin/activate
             python -m pip install --upgrade pip
-            pip install wheel numpy
-            pip install gdal==$(gdal-config --version)
             pip install -r requirements-dev.txt
 
         - name: Build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -33,14 +33,11 @@ jobs:
 
         - name: Install dependencies
           run: |
-            sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
             sudo apt-get update
-            sudo apt-get install build-essential make gcc gfortran gdal-bin libgdal-dev
+            sudo apt-get install build-essential gfortran
             python -m venv test
             . test/bin/activate
             python -m pip install --upgrade pip
-            pip install wheel numpy
-            pip install gdal==$(gdal-config --version)
             pip install -r requirements-dev.txt
 
         - name: Build

--- a/doc/source/release/1.0.0-notes.rst
+++ b/doc/source/release/1.0.0-notes.rst
@@ -59,8 +59,11 @@ This release was made possible thanks to the contributions of:
 Compatibilities
 ---------------
 
-- The `wheel <https://wheel.readthedocs.io/en/stable/>`__ package has been added to the list of dependencies
-  to build GDAL.
+- the `gdal <https://gdal.org/api/python_bindings.html>`__ package has been replaced by
+  `rasterio <https://rasterio.readthedocs.io/en/stable/>`__. This change has been made purely to improve
+  the distribution of `smash`. Despite the better performance in terms of raster reading time, gdal does
+  not provide a binary wheel directly, unlike rasterio
+  (see `discussion <https://github.com/OSGeo/gdal/issues/3060>`__).
 
 - The `pytest-cov <https://pytest-cov.readthedocs.io/en/latest/>`__ plugin has been added to the list of
   dependencies to perform test coverage.

--- a/doc/source/release/1.0.0-notes.rst
+++ b/doc/source/release/1.0.0-notes.rst
@@ -59,7 +59,7 @@ This release was made possible thanks to the contributions of:
 Compatibilities
 ---------------
 
-- the `gdal <https://gdal.org/api/python_bindings.html>`__ package has been replaced by
+- The `gdal <https://gdal.org/api/python_bindings.html>`__ package has been replaced by
   `rasterio <https://rasterio.readthedocs.io/en/stable/>`__. This change has been made purely to improve
   the distribution of `smash`. Despite the better performance in terms of raster reading time, gdal does
   not provide a binary wheel directly, unlike rasterio

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,10 +11,9 @@ dependencies:
     - gfortran
 
     # required dependencies
-    - wheel
     - numpy>=1.13
     - f90wrap
-    - gdal
+    - rasterio
     - pandas
     - h5py
     - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -11,10 +11,9 @@ dependencies:
     - gfortran
 
     # required dependencies
-    - wheel
     - numpy>=1.13
     - f90wrap
-    - gdal
+    - rasterio
     - pandas
     - h5py
     - tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # required dependencies
-wheel
 numpy >= 1.13
 f90wrap
-gdal
+rasterio
 pandas
 h5py
 tqdm

--- a/smash/core/model/_build_model.py
+++ b/smash/core/model/_build_model.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+import rasterio
 
 from f90wrap.runtime import FortranDerivedType
 from smash._constant import (
@@ -84,23 +85,24 @@ def _build_input_data(setup: SetupDT, mesh: MeshDT, input_data: Input_DataDT):
     if setup.read_qobs:
         _read_qobs(setup, mesh, input_data)
 
-    if setup.read_prcp:
-        _read_prcp(setup, mesh, input_data)
+    with rasterio.Env():
+        if setup.read_prcp:
+            _read_prcp(setup, mesh, input_data)
 
-    if setup.read_pet:
-        _read_pet(setup, mesh, input_data)
+        if setup.read_pet:
+            _read_pet(setup, mesh, input_data)
 
-    if setup.read_snow:
-        _read_snow(setup, mesh, input_data)
+        if setup.read_snow:
+            _read_snow(setup, mesh, input_data)
 
-    if setup.read_temp:
-        _read_temp(setup, mesh, input_data)
+        if setup.read_temp:
+            _read_temp(setup, mesh, input_data)
+
+        if setup.read_descriptor:
+            _read_descriptor(setup, mesh, input_data)
 
     if setup.prcp_partitioning:
         wrap_compute_prcp_partitioning(setup, mesh, input_data)  # % Fortran subroutine
-
-    if setup.read_descriptor:
-        _read_descriptor(setup, mesh, input_data)
 
     if setup.compute_mean_atmos:
         print("</> Computing mean atmospheric data")

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -6,7 +6,7 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
-from osgeo import gdal
+import rasterio
 
 from smash.factory.mesh._tools import _get_transform
 
@@ -28,7 +28,7 @@ def _standardize_generate_mesh_flwdir_path(flwdir_path: FilePath) -> str:
     return flwdir_path
 
 
-def _standardize_generate_mesh_bbox(flwdir_dataset: gdal.Dataset, bbox: ListLike) -> np.ndarray:
+def _standardize_generate_mesh_bbox(flwdir_dataset: rasterio.DatasetReader, bbox: ListLike) -> np.ndarray:
     # % Bounding Box (xmin, xmax, ymin, ymax)
 
     if not isinstance(bbox, (list, tuple, np.ndarray)):
@@ -91,7 +91,7 @@ def _standardize_generate_mesh_bbox(flwdir_dataset: gdal.Dataset, bbox: ListLike
 
 
 def _standardize_generate_mesh_x_y_area(
-    flwdir_dataset: gdal.Dataset,
+    flwdir_dataset: rasterio.DatasetReader,
     x: Numeric | ListLike,
     y: Numeric | ListLike,
     area: Numeric | ListLike,
@@ -183,11 +183,9 @@ def _standardize_generate_mesh_args(
     max_depth: Numeric,
     epsg: AlphaNumeric | None,
 ) -> AnyTuple:
-    gdal.UseExceptions()
-
     flwdir_path = _standardize_generate_mesh_flwdir_path(flwdir_path)
 
-    flwdir_dataset = gdal.Open(flwdir_path)
+    flwdir_dataset = rasterio.open(flwdir_path)
 
     if x is None and bbox is None:
         raise ValueError("bbox argument or (x, y, area) arguments must be defined")

--- a/smash/tests/test_define_global_vars.py
+++ b/smash/tests/test_define_global_vars.py
@@ -17,6 +17,9 @@ pytest.model = smash.Model(setup, mesh)
 setup["sparse_storage"] = True
 pytest.sparse_model = smash.Model(setup, mesh)
 
+# Do not need to read prcp and pet again
+setup["read_prcp"] = False
+setup["read_pet"] = False
 pytest.model_structure = []
 pytest.sparse_model_structure = []
 
@@ -26,10 +29,24 @@ for structure in STRUCTURE:
         setup["hydrological_module"],
         setup["routing_module"],
     ) = structure.split("-")
+
     setup["sparse_storage"] = False
-    pytest.model_structure.append(smash.Model(setup, mesh))
+    model = smash.Model(setup, mesh)
+    model.atmos_data.prcp = pytest.model.atmos_data.prcp
+    model.atmos_data.pet = pytest.model.atmos_data.pet
+
     setup["sparse_storage"] = True
-    pytest.sparse_model_structure.append(smash.Model(setup, mesh))
+    sparse_model = smash.Model(setup, mesh)
+    for i in range(sparse_model.setup.ntime_step):
+        sparse_model.atmos_data.sparse_prcp[i] = pytest.sparse_model.atmos_data.sparse_prcp[i]
+        sparse_model.atmos_data.sparse_pet[i] = pytest.sparse_model.atmos_data.sparse_pet[i]
+
+    if "ci" in model.rr_parameters.keys:
+        model.set_rr_parameters("ci", pytest.model.get_rr_parameters("ci"))
+        sparse_model.set_rr_parameters("ci", pytest.sparse_model.get_rr_parameters("ci"))
+
+    pytest.model_structure.append(model)
+    pytest.sparse_model_structure.append(sparse_model)
 
 pytest.baseline = h5py.File(os.path.join(os.path.dirname(__file__), "baseline.hdf5"), "r")
 


### PR DESCRIPTION
This commit addresses the problem of distributing smash with gdal. gdal doesn't provide binary wheels directly, so you need to install the gdal library on your system before you can install gdal bindings in Python. One way of working with gdal simply in Python is conda, but in order to facilitate the distribution of smash on different OS (linux, maxos and windows), it is simpler to use rasterio to read raster (rasterio provides a binary wheel directly which include gdal). This change is not neutral and leads to performance losses in terms of raster calculation time (rain, etp, descriptors, etc). Generally speaking, reading the input data is a relatively quick process compared with a calibration. However, if the calculation time for reading becomes too great a concern, it can be parallelized.

2 other minor changes have been made:
- Date regular expression match only on the file name and not the entire path. This can cause problems, for example, if the path is something like this (``/home/2020930920/data/prcp/rain_202001010000.tif``)
- Update tests to avoid reading rasters ``N`` times and instead copy arrays

NOTE: A future commit will be made to integrate meson to manage the smash build system. A number of changes will be made to the way smash is installed.