### PR TITLE
FIX: parameter order in bounds defined in scaling layer of net

### DIFF
--- a/smash/core/simulation/_standardize.py
+++ b/smash/core/simulation/_standardize.py
@@ -311,11 +311,12 @@ def _standardize_simulation_optimize_options_descriptor(
 
 
 def _standardize_simulation_optimize_options_net(
-    model: Model, bounds: dict, net: Net | None, **kwargs
+    model: Model, parameters: np.ndarray, bounds: dict, net: Net | None, **kwargs
 ) -> Net:
+    bounds = {key: bounds[key] for key in parameters}  # reorder bounds by parameters
     bound_values = list(bounds.values())
-    ncv = len(bound_values)
 
+    ncv = len(parameters)
     nd = model.setup.nd
 
     active_mask = np.where(model.mesh.active_cell == 1)
@@ -387,7 +388,7 @@ def _standardize_simulation_optimize_options_net(
 
             diff = np.not_equal(net_bounds, bound_values)
 
-            for i, name in enumerate(bounds.keys()):
+            for i, name in enumerate(parameters):
                 if diff[i].any():
                     warnings.warn(
                         f"net optimize_options: Inconsistent value(s) between the bound in scaling layer and "

--- a/smash/core/simulation/_standardize.py
+++ b/smash/core/simulation/_standardize.py
@@ -250,6 +250,8 @@ def _standardize_simulation_optimize_options_bounds(
                 f"included in the feasible domain ]{low}, {upp}[ in bounds optimize_options"
             )
 
+    bounds = {key: bounds[key] for key in parameters}
+
     return bounds
 
 
@@ -311,13 +313,12 @@ def _standardize_simulation_optimize_options_descriptor(
 
 
 def _standardize_simulation_optimize_options_net(
-    model: Model, parameters: np.ndarray, bounds: dict, net: Net | None, **kwargs
+    model: Model, bounds: dict, net: Net | None, **kwargs
 ) -> Net:
-    bounds = {key: bounds[key] for key in parameters}  # reorder bounds by parameters
-    bound_values = list(bounds.values())
-
-    ncv = len(parameters)
     nd = model.setup.nd
+
+    bound_values = list(bounds.values())
+    ncv = len(bound_values)
 
     active_mask = np.where(model.mesh.active_cell == 1)
     ntrain = active_mask[0].shape[0]
@@ -388,7 +389,7 @@ def _standardize_simulation_optimize_options_net(
 
             diff = np.not_equal(net_bounds, bound_values)
 
-            for i, name in enumerate(parameters):
+            for i, name in enumerate(bounds.keys()):
                 if diff[i].any():
                     warnings.warn(
                         f"net optimize_options: Inconsistent value(s) between the bound in scaling layer and "


### PR DESCRIPTION
This PR would fix the issue arising in the scaling layer of **net** when the keys of **bounds** are not in the same order as **parameters** when the **bounds** argument is specified within the **optimize_options**. This discrepancy occurs because the standardize function for **net** does not appropriately adjust the order of **bounds** according to the order of **parameters**.