### PR TITLE
Fix fortran char array

### DIFF
--- a/smash/fcore/_f90wrap_decorator.py
+++ b/smash/fcore/_f90wrap_decorator.py
@@ -30,7 +30,11 @@ def f90wrap_getter_char_array(func):
     @functools.wraps(func)
     def wrapper(self):
         value = func(self)
-        return np.array(value.tobytes(order="F").decode().split())
+        shape = value.shape
+        arr = np.empty(shape=shape[1:], dtype=f"U{shape[0]}")
+        for idx in np.ndindex(shape[1:]):
+            arr[idx] = value[:, *idx].tobytes(order="F").decode().strip()
+        return arr
 
     return wrapper
 
@@ -48,23 +52,31 @@ def f90wrap_setter_char_array(func):
 
         shape = tuple(s for i, s in enumerate(array_shape) if i < array_ndim)
 
-        if isinstance(value, (list, tuple)):
+        if isinstance(value, (str, list, tuple)):
             value = np.array(value)
 
         elif isinstance(value, np.ndarray):
             value = value.astype("U")
 
         else:
-            raise TypeError(f"{func_name} attribute must be list-like object, not {type(value)}")
+            raise TypeError(f"{func_name} attribute must be str or ListLike object, not {type(value)}")
 
-        if value.size != shape[1]:
-            raise ValueError(f"could not broadcast input array from shape {value.shape} into {(shape[1],)}")
+        if value.shape != shape[1:] and value.size != 1:
+            raise ValueError(f"could not broadcast input array from shape {value.shape} into {shape[1:]}")
 
         else:
-            arr = np.zeros(shape, dtype="uint8") + np.uint8(32)
+            arr = np.empty(shape, dtype=np.uint8)
+            arr.fill(np.uint8(32))
 
-            for i, el in enumerate(value):
-                arr[0 : len(el), i] = [ord(char) for char in el]
+            if value.size == 1:
+                item = list(value.item().encode("ascii"))
+                litem = len(item)
+                for idx in np.ndindex(shape[1:]):
+                    arr[:litem, *idx] = item
+            else:
+                for idx in np.ndindex(shape[1:]):
+                    item = list(value[idx].encode("ascii"))
+                    arr[: len(item), *idx] = item
 
         if array_handle in self._arrays:
             ptr = self._arrays[array_handle]

--- a/smash/fcore/derived_type/mwd_mesh.f90
+++ b/smash/fcore/derived_type/mwd_mesh.f90
@@ -77,7 +77,7 @@ module mwd_mesh
 
         integer :: ng
         integer, dimension(:, :), allocatable :: gauge_pos !$F90W index-array
-        character(20), dimension(:), allocatable :: code !$F90W char-array
+        character(lchar), dimension(:), allocatable :: code !$F90W char-array
         real(sp), dimension(:), allocatable :: area
         real(sp), dimension(:), allocatable :: area_dln
 

--- a/smash/fcore/derived_type/mwd_setup.f90
+++ b/smash/fcore/derived_type/mwd_setup.f90
@@ -125,7 +125,7 @@ module mwd_setup
         logical :: read_descriptor = .false.
         character(lchar) :: descriptor_format = "..." !$F90W char
         character(lchar) :: descriptor_directory = "..." !$F90W char
-        character(20), allocatable, dimension(:) :: descriptor_name !$F90W char-array
+        character(lchar), allocatable, dimension(:) :: descriptor_name !$F90W char-array
 
         ! Post processed variables
         character(lchar) :: structure = "..." !$F90W char

--- a/smash/tests/fcore/test_f90wrap_decorator.py
+++ b/smash/tests/fcore/test_f90wrap_decorator.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+from smash.fcore._mwd_mesh import MeshDT
+from smash.fcore._mwd_setup import SetupDT
+
+# TODO (FC): These are the minimum tests that can be performed without creating specific test cases with
+# Fortran files to be compiled for the tests.
+
+
+def test_char():
+    setup = SetupDT(0)
+    snow_module = "Picsou"
+    setup.snow_module = snow_module
+    assert setup.snow_module == snow_module, "char.value"
+
+
+def test_char_array():
+    nd = 2
+    setup = SetupDT(nd)
+
+    descriptor_name = "Donald"
+    setup.descriptor_name = descriptor_name
+    assert np.array_equal(setup.descriptor_name, np.array(nd * [descriptor_name])), "char_array.str_value"
+
+    descriptor_name = ["Donald"]
+    setup.descriptor_name = descriptor_name
+    assert np.array_equal(setup.descriptor_name, np.array(nd * descriptor_name)), "char_array.list_1_value"
+
+    descriptor_name = nd * ["Donald"]
+    setup.descriptor_name = descriptor_name
+    assert np.array_equal(setup.descriptor_name, np.array(descriptor_name)), "char_array.list_nd_value"
+
+    descriptor_name = np.array(nd * ["Donald"])
+    setup.descriptor_name = descriptor_name
+    assert np.array_equal(setup.descriptor_name, descriptor_name), "char_array.ndarray_nd_value"
+
+    with pytest.raises(ValueError, match="could not broadcast"):
+        descriptor_name = np.array(42 * ["Donald"])
+        setup.descriptor_name = descriptor_name
+
+    with pytest.raises(TypeError, match="attribute must be str or ListLike object"):
+        descriptor_name = 42
+        setup.descriptor_name = descriptor_name
+
+
+def test_index_array():
+    setup = SetupDT(0)
+    mesh = MeshDT(setup, 10, 10, 2, 1)
+
+    # % Initialized to -99 in Fortan. Should get Fortran value minus 1 in Python
+    assert np.all(mesh.gauge_pos == -100), "index_array.fortran_value"
+
+    mesh.gauge_pos = 0
+    assert np.all(mesh.gauge_pos == 0), "index_array.python_value"


### PR DESCRIPTION
This commit addresses problems with Fortran character arrays passed to Python. The first was that the length of the character string was too short (20). The second was that only 1D arrays were managed and if the length of the character string is equal to the limit then the values in the array are not split correctly.

The max length has been increased from 20 to 128 and the associated decorator to handle character arrays has been modified to managed any nD arrays and max character length.

A few tests have been added, but they don't allow you to check all the decorators correctly. It would be necessary to create a Fortran file specific to the test case.