### PR TITLE
FIX: Fix generate baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-coverage:
 
 #% Generate baseline for test with args (see argparser in gen_baseline.py)
 test-baseline:
-	cd smash/tests ; python3 gen_baseline.py
+	cd smash/tests ; python3 generate_baseline.py
 
 #% Format Python files with ruff and Fortran files with fprettify
 format:


### PR DESCRIPTION
Since the switch to meson to build smash. The import things made when generating the baseline did not work anymore.
I also cleaned the collecting step to avoid reading precipitation and potential evapotranspiration for each model structure.