### PR TITLE
DOC: Remove conda usage

### DIFF
--- a/doc/source/user_guide/classical_uses/lez_regionalization.rst
+++ b/doc/source/user_guide/classical_uses/lez_regionalization.rst
@@ -65,20 +65,14 @@ Six physical descriptors are considered in this example, which are:
 
 .. TODO: Add descriptor explanation
 
-We can open a Python interface in the **conda environment**. The current working directory will be assumed to be the directory where 
+We can open a Python interface. The current working directory will be assumed to be the directory where
 the ``Lez-dataset`` is located.
-
-Activate the environment:
-
-.. code-block:: shell
-
-    conda activate smash
 
 Open a Python interface:
 
 .. code-block:: shell
 
-    (smash) python3
+    python3
 
 .. ipython:: python
     :suppress:

--- a/doc/source/user_guide/quickstart/cance_first_simulation.rst
+++ b/doc/source/user_guide/quickstart/cance_first_simulation.rst
@@ -111,20 +111,14 @@ the data is the observed discharge in **cubic meter per second** and any negativ
     It is not necessary to restrict the observed discharge series to the simulation period. It is possible to provide a time series covering a larger time window over which `smash`
     will only read the lines corresponding to dates after the starting date provided in the header.
 
-Now that a brief tour of the necessary data has been done, we can open a Python interface in the **conda environment**. The current working directory 
+Now that a brief tour of the necessary data has been done, we can open a Python interface. The current working directory
 will be assumed to be the directory where the ``Cance-dataset`` is located.
-
-Activate the environment:
-
-.. code-block:: shell
-
-    conda activate smash
 
 Open a Python interface:
 
 .. code-block:: shell
 
-    (smash) python3
+    python3
 
 .. ipython:: python
     :suppress:

--- a/doc/source/user_guide/quickstart/france_large_domain_simulation.rst
+++ b/doc/source/user_guide/quickstart/france_large_domain_simulation.rst
@@ -42,20 +42,14 @@ Now a folder called ``France-dataset`` should be accessible and contain the foll
 In this dataset, there are no gauge attributes or observed discharge, we are only interested in performing a forward run on a domain without 
 optimization beforehand.
 
-We can open a Python interface in the **conda environment**. The current working directory will be assumed to be the directory where 
+We can open a Python interface. The current working directory will be assumed to be the directory where
 the ``France-dataset`` is located.
-
-Activate the environment:
-
-.. code-block:: shell
-
-    conda activate smash
 
 Open a Python interface:
 
 .. code-block:: shell
 
-    (smash) python3
+    python3
 
 .. ipython:: python
     :suppress:

--- a/doc/source/user_guide/quickstart/lez_split_sample_test.rst
+++ b/doc/source/user_guide/quickstart/lez_split_sample_test.rst
@@ -46,20 +46,14 @@ Now a folder called ``Lez-dataset`` should be accessible and contain the followi
 - ``descriptor``
     A directory containing physiographic descriptors in GeoTiff format.
 
-We can open a Python interface in the **conda environment**. The current working directory will be assumed to be the directory where 
+We can open a Python interface. The current working directory will be assumed to be the directory where
 the ``Lez-dataset`` is located.
-
-Activate the environment:
-
-.. code-block:: shell
-
-    conda activate smash
 
 Open a Python interface:
 
 .. code-block:: shell
 
-    (smash) python3
+    python3
 
 .. ipython:: python
     :suppress:


### PR DESCRIPTION
The use of a conda env is deprecated since v1.0. The conda usage has been removed from user guide