### PR TITLE
MAINT: update pyproject.toml for compatibility with numpy 2

### DIFF
--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -35,7 +35,7 @@ It will create a Conda environment called ``smash-dev`` that can be activated as
 
     conda activate smash-dev
 
-Once ``smash-dev`` is created, it is recomended to update pip and your Conda environment
+Once ``smash-dev`` is created, it is recommended to update pip and your Conda environment
 to ensure you have the latest package versions and to prevent any conflicts:
 
 .. code-block:: none

--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -19,7 +19,7 @@ System-level dependencies
 `smash` uses compiled code for speed, which means you need compilers and some other system-level
 (i.e, non-Python / non-PyPI) dependencies to build it on your system.
 
-Anaconda (recommanded)
+Anaconda (recommended)
 ''''''''''''''''''''''
 
 If you are using `Conda <https://www.anaconda.com/>`__, all the dependencies will be installed
@@ -34,6 +34,14 @@ It will create a Conda environment called ``smash-dev`` that can be activated as
 .. code-block:: none
 
     conda activate smash-dev
+
+Once ``smash-dev`` is created, it is recomended to update pip and your Conda environment
+to ensure you have the latest package versions and to prevent any conflicts:
+
+.. code-block:: none
+
+    (smash-dev) python3 -m pip install --upgrade pip
+    (smash-dev) conda update --all
 
 Linux
 '''''

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,12 +11,8 @@ dependencies:
     - meson
     - meson-python
     - ninja
-
-    # numpy requirement for wheel builds for distribution on PyPI - building
-    # against 2.x yields wheels that are also compatible with numpy 1.x at
-    # runtime.
-    - numpy>=2.0.0
-    - f90wrap>=0.2.15
+    - numpy
+    - f90wrap
     - versioneer[toml]
     - rasterio
     - pandas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [build-system]
 requires = [
     "meson-python",
-    "numpy>=1.24",
+    # numpy requirement for wheel builds for distribution on PyPI - building
+    # against 2.x yields wheels that are also compatible with numpy 1.x at
+    # runtime.
+    "numpy>=2.0.0",
     "f90wrap>=0.2.15",
     "versioneer[toml]"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,7 @@
 [build-system]
 requires = [
     "meson-python",
-
-    # numpy requirement for wheel builds for distribution on PyPI - building
-    # against 2.x yields wheels that are also compatible with numpy 1.x at
-    # runtime.
-    "numpy>=2.0.0",
+    "numpy>=1.24",
     "f90wrap>=0.2.15",
     "versioneer[toml]"
 ]
@@ -22,13 +18,13 @@ authors = [
 license = {text = "GPL-3.0"}
 requires-python = ">=3.9"
 dependencies = [
-    "numpy",
+    "numpy>=1.24",
     "f90wrap>=0.2.15",
-    "rasterio",
-    "pandas",
-    "h5py",
+    "rasterio>=1.3.10",
+    "pandas>=2.2.2",
+    "h5py>=3.11",
     "tqdm",
-    "scipy",
+    "scipy>=1.13",
     "pyyaml",
     "terminaltables",
 ]
@@ -62,7 +58,7 @@ doc = [
     "sphinxcontrib-bibtex",
     "sphinx-design",
     "sphinx-autosummary-accessors",
-    "matplotlib"
+    "matplotlib>=3.8.4"
 ]
 dev = [
     "ruff",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,12 +2,8 @@
 meson
 meson-python
 ninja
-
-# numpy requirement for wheel builds for distribution on PyPI - building
-# against 2.x yields wheels that are also compatible with numpy 1.x at
-# runtime.
-numpy>=2.0.0
-f90wrap>=0.2.15
+numpy
+f90wrap
 versioneer[toml]
 rasterio
 pandas


### PR DESCRIPTION
- Add lower bounds to several packages in pyproject for the compatibility with numpy 2.0.
- Remove version bounds in requirement.txt and environment-dev.yml (developers are required to update their pip and conda to ensure that they have the latest package versions).
- Add a reminder in contributor guide (detail development process) for pip and conda update before compiling smash. 