### PR TITLE
MAINT: Sphinx v7.4 compatibility

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -19,7 +19,7 @@ help:
 %: Makefile
 	@mkdir $(BUILDDIR)_tmp 
 	@cp -r $(BUILDDIR)/* $(BUILDDIR)_tmp 2>/dev/null || true
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) || \
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) --fail-on-warning || \
     (echo "An error occurred while generating the documentation. Returning to previous version." && \
 	rm -rf $(BUILDDIR) && mv $(BUILDDIR)_tmp $(BUILDDIR) && false)
 	@rm -rf $(BUILDDIR)_tmp

--- a/doc/source/_ext/custom_options_directive.py
+++ b/doc/source/_ext/custom_options_directive.py
@@ -210,7 +210,10 @@ def wrap_mangling_directive(base_directive):
 
                 else:
                     new_lines.append(line)
-            self.content = ViewList(new_lines, self.content.parent)
+            if sphinx.__version__ >= "7.4":
+                self.content = "\n".join(new_lines)
+            else:
+                self.content = ViewList(new_lines, self.content.parent)
             return base_directive.run(self)
 
         option_spec = dict(base_directive.option_spec)

--- a/doc/source/release/0.2.4-notes.rst
+++ b/doc/source/release/0.2.4-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.2.4-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.2.4 Release Notes
 =========================

--- a/doc/source/release/0.3.0-notes.rst
+++ b/doc/source/release/0.3.0-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.3.0-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.3.0 Release Notes
 =========================
@@ -116,7 +114,7 @@ It can be used as follows:
 Save a sample of the Model object data
 **************************************
 
-Two new methods `smash.save_model_ddt` and `smash.read_model_ddt` had been added to avoid to save all the data of the Model object (i.e. all precipitation data) but
+Two new methods :meth:`smash.save_model_ddt` and :meth:`smash.read_model_ddt` had been added to avoid to save all the data of the Model object (i.e. all precipitation data) but
 only the main data. A set of default has been chosen in order to facilitate the use of the method but any kind of data can be extra saved.
 
 It can be used as follows:

--- a/doc/source/release/0.3.1-notes.rst
+++ b/doc/source/release/0.3.1-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.3.1-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.3.1 Release Notes
 =========================

--- a/doc/source/release/0.4.0-notes.rst
+++ b/doc/source/release/0.4.0-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.4.0-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.4.0 Release Notes
 =========================

--- a/doc/source/release/0.4.1-notes.rst
+++ b/doc/source/release/0.4.1-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.4.1-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.4.1 Release Notes
 =========================

--- a/doc/source/release/0.4.2-notes.rst
+++ b/doc/source/release/0.4.2-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.4.2-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.4.2 Release Notes
 =========================

--- a/doc/source/release/0.5.0-notes.rst
+++ b/doc/source/release/0.5.0-notes.rst
@@ -1,7 +1,5 @@
 .. _release.0.5.0-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 0.5.0 Release Notes
 =========================

--- a/doc/source/release/1.0.0-notes.rst
+++ b/doc/source/release/1.0.0-notes.rst
@@ -1,7 +1,5 @@
 .. _release.1.0.0-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 1.0.0 Release Notes
 =========================

--- a/doc/source/release/1.0.1-notes.rst
+++ b/doc/source/release/1.0.1-notes.rst
@@ -1,7 +1,5 @@
 .. _release.1.0.1-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash 1.0.1 Release Notes
 =========================

--- a/doc/source/release/template-notes.rst
+++ b/doc/source/release/template-notes.rst
@@ -1,7 +1,5 @@
 .. _release.template-notes:
 
-.. currentmodule:: smash
-
 =========================
 smash x.y.z Release Notes
 =========================

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,7 @@ dependencies:
     - numpydoc
     - pydata-sphinx-theme
     - ipython
+    - pickleshare
     - sphinxcontrib-bibtex
     - sphinx-design
     - sphinx-autosummary-accessors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ doc = [
     "numpydoc",
     "pydata-sphinx-theme",
     "ipython",
+    "pickleshare",
     "sphinxcontrib-bibtex",
     "sphinx-design",
     "sphinx-autosummary-accessors",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,7 @@ sphinx
 numpydoc
 pydata-sphinx-theme
 ipython
+pickleshare
 sphinxcontrib-bibtex
 sphinx-design
 sphinx-autosummary-accessors

--- a/smash/core/model/model.py
+++ b/smash/core/model/model.py
@@ -353,7 +353,7 @@ class Model:
         Model initialization mesh dictionary.
 
         .. note::
-            The elements are described in the `smash.factory.generate_mesh` method.
+            The elements are described in the `smash.factory.generate_mesh <factory.generate_mesh>` method.
 
     See Also
     --------
@@ -481,7 +481,7 @@ class Model:
 
         Returns
         -------
-        setup : `SetupDT <smash.fcore._mwd_setup.SetupDT>`
+        setup : `SetupDT <fcore._mwd_setup.SetupDT>`
             It returns a Fortran derived type containing the variables relating to the setup.
 
         Examples
@@ -547,7 +547,7 @@ class Model:
 
         Returns
         -------
-        mesh : `MeshDT <smash.fcore._mwd_mesh.MeshDT>`
+        mesh : `MeshDT <fcore._mwd_mesh.MeshDT>`
             It returns a Fortran derived type containing the variables relating to the mesh.
 
         Examples
@@ -609,7 +609,7 @@ class Model:
 
         Returns
         -------
-        response_data : `Response_DataDT <smash.fcore._mwd_response_data.Response_DataDT>`
+        response_data : `Response_DataDT <fcore._mwd_response_data.Response_DataDT>`
             It returns a Fortran derived type containing the variables relating to the response data.
 
         Examples
@@ -657,7 +657,7 @@ class Model:
 
         Returns
         -------
-        u_response_data : `U_Response_DataDT <smash.fcore._mwd_u_response_data.U_Response_DataDT>`
+        u_response_data : `U_Response_DataDT <fcore._mwd_u_response_data.U_Response_DataDT>`
             It returns a Fortran derived type containing the variables relating to the response data
             uncertainties.
 
@@ -715,7 +715,7 @@ class Model:
 
         Returns
         -------
-        physio_data : `Physio_DataDT <smash.fcore._mwd_physio_data.Physio_DataDT>`
+        physio_data : `Physio_DataDT <fcore._mwd_physio_data.Physio_DataDT>`
             It returns a Fortran derived type containing the variables relating to the physiographic data.
 
         Examples
@@ -771,7 +771,7 @@ class Model:
 
         Returns
         -------
-        atmos_data : `Atmos_DataDT <smash.fcore._mwd_atmos_data.Atmos_DataDT>`
+        atmos_data : `Atmos_DataDT <fcore._mwd_atmos_data.Atmos_DataDT>`
             It returns a Fortran derived type containing the variables relating to the atmospheric data.
 
         Examples
@@ -801,7 +801,7 @@ class Model:
 
         .. warning::
             If the Model object has been initialised with the ``sparse_storage`` option in setup
-            (see `smash.Model`), the variables ``prcp``, ``pet`` (``snow`` and ``temp``, optionally) are
+            (see `Model`), the variables ``prcp``, ``pet`` (``snow`` and ``temp``, optionally) are
             unavailable and replaced by ``sparse_prcp``, ``sparse_pet`` (``sparse_snow`` and ``sparse_temp``,
             optionally) and vice versa if the sparse_storage option has not been chosen.
 
@@ -852,7 +852,7 @@ class Model:
 
         Returns
         -------
-        rr_parameters : `RR_ParametersDT <smash.fcore._mwd_rr_parameters.RR_ParametersDT>`
+        rr_parameters : `RR_ParametersDT <fcore._mwd_rr_parameters.RR_ParametersDT>`
             It returns a Fortran derived type containing the variables relating to the rainfall-runoff
             parameters.
 
@@ -917,7 +917,7 @@ class Model:
 
         Returns
         -------
-        rr_initial_states : `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>`
+        rr_initial_states : `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>`
             It returns a Fortran derived type containing the variables relating to the rainfall-runoff
             initial states.
 
@@ -982,7 +982,7 @@ class Model:
 
         Returns
         -------
-        serr_mu_parameters : `SErr_Mu_ParametersDT <smash.fcore._mwd_serr_mu_parameters.SErr_Mu_ParametersDT>`
+        serr_mu_parameters : `SErr_Mu_ParametersDT <fcore._mwd_serr_mu_parameters.SErr_Mu_ParametersDT>`
             It returns a Fortran derived type containing the variables relating to the structural error mu
             parameters.
 
@@ -996,7 +996,7 @@ class Model:
         >>> from smash.factory import load_dataset
         >>> setup, mesh = load_dataset("cance")
 
-        Set the structural error mu mapping to ``'Linear'`` (see `smash.Model`). Default value in the
+        Set the structural error mu mapping to ``'Linear'`` (see `Model`). Default value in the
         ``Cance`` dataset is ``'Zero'`` (equivalent to no mu mapping)
 
         >>> setup["serr_mu_mapping"] = "Linear"
@@ -1053,7 +1053,7 @@ class Model:
 
         Returns
         -------
-        serr_sigma_parameters : `SErr_Sigma_ParametersDT <smash.fcore._mwd_serr_sigma_parameters.SErr_Sigma_ParametersDT>`
+        serr_sigma_parameters : `SErr_Sigma_ParametersDT <fcore._mwd_serr_sigma_parameters.SErr_Sigma_ParametersDT>`
             It returns a Fortran derived type containing the variables relating to the structural error sigma
             parameters.
 
@@ -1109,7 +1109,7 @@ class Model:
 
         Returns
         -------
-        response : `ResponseDT <smash.fcore._mwd_response.ResponseDT>`
+        response : `ResponseDT <fcore._mwd_response.ResponseDT>`
             It returns a Fortran derived type containing the variables relating to the response.
 
         Examples
@@ -1162,7 +1162,7 @@ class Model:
 
         Returns
         -------
-        rr_final_states : `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>`
+        rr_final_states : `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>`
             It returns a Fortran derived type containing the variables relating to the rainfall-runoff final
             states.
 
@@ -1681,7 +1681,7 @@ class Model:
         >>> from smash.factory import load_dataset
         >>> setup, mesh = load_dataset("cance")
 
-        Set the structural error mu mapping to ``'Linear'`` (see `smash.Model`). Default value in the
+        Set the structural error mu mapping to ``'Linear'`` (see `Model`). Default value in the
         ``Cance`` dataset is ``'Zero'`` (equivalent to no mu mapping)
 
         >>> setup["serr_mu_mapping"] = "Linear"
@@ -1744,7 +1744,7 @@ class Model:
         >>> from smash.factory import load_dataset
         >>> setup, mesh = load_dataset("cance")
 
-        Set the structural error mu mapping to ``'Linear'`` (see `smash.Model`). Default value in the
+        Set the structural error mu mapping to ``'Linear'`` (see `Model`). Default value in the
         ``Cance`` dataset is ``'Zero'`` (equivalent to no mu mapping)
 
         >>> setup["serr_mu_mapping"] = "Linear"
@@ -2122,7 +2122,7 @@ class Model:
         >>> from smash.factory import load_dataset
         >>> setup, mesh = load_dataset("cance")
 
-        Set the structural error mu mapping to ``'Linear'`` (see `smash.Model`). Default value in the
+        Set the structural error mu mapping to ``'Linear'`` (see `Model`). Default value in the
         ``Cance`` dataset is ``'Zero'`` (equivalent to no mu mapping).
 
         >>> setup["serr_mu_mapping"] = "Linear"
@@ -2191,7 +2191,7 @@ class Model:
         >>> from smash.factory import load_dataset
         >>> setup, mesh = load_dataset("cance")
 
-        Set the structural error mu mapping to ``'Linear'`` (see `smash.Model`). Default value in the
+        Set the structural error mu mapping to ``'Linear'`` (see `Model`). Default value in the
         ``Cance`` dataset is ``'Zero'`` (equivalent to no mu mapping)
 
         >>> setup["serr_mu_mapping"] = "Linear"

--- a/smash/core/signal_analysis/metrics/metrics.py
+++ b/smash/core/signal_analysis/metrics/metrics.py
@@ -23,7 +23,7 @@ def metrics(model: Model, metric: str = "nse", end_warmup: str | Timestamp | Non
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     metric : `str`, default 'nse'

--- a/smash/core/signal_analysis/prcp_indices/prcp_indices.py
+++ b/smash/core/signal_analysis/prcp_indices/prcp_indices.py
@@ -132,12 +132,12 @@ def precipitation_indices(
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     Returns
     -------
-    precipitation_indices : `PrecipitationIndices <smash.PrecipitationIndices>`
+    precipitation_indices : `PrecipitationIndices`
         It returns an object containing the results of the precipitation indices computation.
 
     See Also

--- a/smash/core/signal_analysis/segmentation/segmentation.py
+++ b/smash/core/signal_analysis/segmentation/segmentation.py
@@ -31,7 +31,7 @@ def hydrograph_segmentation(
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     peak_quant : `float`, default 0.995

--- a/smash/core/signal_analysis/signatures/signatures.py
+++ b/smash/core/signal_analysis/signatures/signatures.py
@@ -99,7 +99,7 @@ def signatures(
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     sign : `str`, `list[str, ...]` or None, default None
@@ -120,14 +120,14 @@ def signatures(
         .. note::
             If not given, default values will be set for all elements.
             If a specific element is not given in the dictionary, a default value will be set for that
-            element. See `smash.hydrograph_segmentation` for more.
+            element. See `hydrograph_segmentation` for more.
 
     domain : `str`, default 'obs'
         Compute observed (``'obs'``) or simulated (``'sim'``) signatures.
 
     Returns
     -------
-    signatures : `Signatures <smash.Signatures>`
+    signatures : `Signatures`
         It returns an object containing the results of the signatures computation.
 
     See Also

--- a/smash/core/simulation/_doc.py
+++ b/smash/core/simulation/_doc.py
@@ -108,14 +108,14 @@ OPTIMIZE_OPTIONS_BASE_DOC = {
     ),
     "net": (
         """
-        `Net <smash.factory.Net>` or None, default None
+        `Net <factory.Net>` or None, default None
         """,
         """
         The neural network used to learn the descriptors-to-parameters mapping.
 
         .. note::
             If not given, a default neural network will be used. This option is only used when **mapping** is
-            ``'ann'``. See `Net <smash.factory.Net>` to learn how to create a customized neural network for
+            ``'ann'``. See `Net <factory.Net>` to learn how to create a customized neural network for
             training.
         """,
     ),
@@ -384,7 +384,7 @@ COST_OPTIONS_BASE_DOC = {
         Prior applied to the control vector.
         A dictionary containing the type of prior to link to control vector. The keys are any control
         parameter name (i.e. ``'cp0'``, ``'cp1-1'``, ``'cp-slope-a'``, etc.), see
-        `bayesian_optimize_control_info <smash.bayesian_optimize_control_info>` to retrieve control parameters
+        `bayesian_optimize_control_info` to retrieve control parameters
         names. The values are list of length 2 containing distribution information (i.e. distribution name and
         parameters). Below, the set of available distributions and the associated number of parameters:
 
@@ -427,7 +427,7 @@ COST_OPTIONS_BASE_DOC = {
         }
 
         .. hint::
-            See the `hydrograph_segmentation <smash.hydrograph_segmentation>` function and
+            See the `hydrograph_segmentation` function and
             :ref:`math_num_documentation.hydrograph_segmentation` section.
 
         """,
@@ -532,7 +532,7 @@ RETURN_OPTIONS_BASE_DOC = {
         """,
         """
         Whether to return control vector at end of optimization. In case of optimization with ``'ann'``
-        **mapping**, the control vector is represented in `Net.layers <smash.factory.Net.layers>` instead.
+        **mapping**, the control vector is represented in `Net.layers <factory.Net.layers>` instead.
         """,
     ),
     "net": (
@@ -540,7 +540,7 @@ RETURN_OPTIONS_BASE_DOC = {
         `bool`, default False
         """,
         """
-        Whether to return the trained neural network `Net <smash.factory.Net>`. Only used with ``'ann'``
+        Whether to return the trained neural network `Net <factory.Net>`. Only used with ``'ann'``
         **mapping**.
         """,
     ),
@@ -681,7 +681,7 @@ return_options : `dict[str, Any]` or None, default None
 Returns
 -------
 %(model_return)s
-forward_run : `ForwardRun <smash.ForwardRun>` or None, default None
+forward_run : `ForwardRun` or None, default None
     It returns an object containing the intermediate variables defined in **return_options**.
     If no intermediate variables are defined, it returns None.
 
@@ -804,7 +804,7 @@ return_options : `dict[str, Any]` or None, default None
 Returns
 -------
 %(model_return)s
-optimize : `Optimize <smash.Optimize>` or None, default None
+optimize : `Optimize` or None, default None
     It returns an object containing the intermediate variables defined in **return_options**.
     If no intermediate variables are defined, it returns None.
 
@@ -853,10 +853,9 @@ Parameters
 ----------
 %(model_parameter)s
 
-multiset : `MultipleForwardRun <smash.MultipleForwardRun>` or `MultipleOptimize <smash.MultipleOptimize>`
-    The returned object created by `multiple_forward_run <smash.multiple_forward_run>` or
-    `multiple_optimize <smash.multiple_optimize>` method containing information about multiple sets of
-    rainfall-runoff parameters or initial states.
+multiset : `MultipleForwardRun` or `MultipleOptimize`
+    The returned object created by `multiple_forward_run` or `multiple_optimize` method containing
+    information about multiple sets of rainfall-runoff parameters or initial states.
 
 alpha : `float`, `list[float, ...]`, or None, default None
     A regularization parameter that controls the decay rate of the likelihood function.
@@ -890,7 +889,7 @@ Returns
 -------
 %(model_return)s
 
-multiset_estimate : `MultisetEstimate <smash.MultisetEstimate>` or None, default None
+multiset_estimate : `MultisetEstimate` or None, default None
     It returns an object containing the intermediate variables defined in **return_options**. If no
     intermediate variables are defined, it returns None.
 
@@ -1025,7 +1024,7 @@ return_options : `dict[str, Any]` or None, default None
 Returns
 -------
 %(model_return)s
-bayesian_optimize : `BayesianOptimize <smash.BayesianOptimize>` or None, default None
+bayesian_optimize : `BayesianOptimize` or None, default None
     It returns an object containing the intermediate variables defined in **return_options**.
     If no intermediate variables are defined, it returns None.
 
@@ -1071,10 +1070,10 @@ Run the forward Model with multiple sets of parameters.
 
 Parameters
 ----------
-model : `Model <smash.Model>`
+model : `Model`
     Primary data structure of the hydrological model `smash`.
 
-samples : `Samples <smash.Samples>`
+samples : `Samples`
     Represents the generated samples result.
 
 cost_options : `dict[str, Any]` or None, default None
@@ -1098,7 +1097,7 @@ common_options : `dict[str, Any]` or None, default None
 
 Returns
 -------
-multiple_forward_run : `MultipleForwardRun <smash.MultipleForwardRun>`
+multiple_forward_run : `MultipleForwardRun`
     It returns an object containing the results of the multiple forward run.
 
 See Also
@@ -1143,10 +1142,10 @@ solutions.
 
 Parameters
 ----------
-model : `Model <smash.Model>`
+model : `Model`
     Primary data structure of the hydrological model `smash`.
 
-samples : `Samples <smash.Samples>`
+samples : `Samples`
     Represents the generated samples result.
 
 mapping : `str`, default 'uniform'
@@ -1216,7 +1215,7 @@ common_options : `dict[str, Any]` or None, default None
 
 Returns
 -------
-multiple_optimize : `MultipleOptimize <smash.MultipleOptimize>`
+multiple_optimize : `MultipleOptimize`
     It returns an object containing the results of the multiple optimize.
 
 See Also
@@ -1263,7 +1262,7 @@ Information on the optimization control vector of Model.
 
 Parameters
 ----------
-model : `Model <smash.Model>`
+model : `Model`
     Primary data structure of the hydrological model `smash`.
 
 mapping : `str`, default 'uniform'
@@ -1439,7 +1438,7 @@ Information on the bayesian optimization control vector of Model.
 
 Parameters
 ----------
-model : `Model <smash.Model>`
+model : `Model`
     Primary data structure of the hydrological model `smash`.
 
 mapping : `str`, default 'uniform'
@@ -1622,7 +1621,7 @@ Retrieving information from the control vector is particularly useful for defini
 During a bayesian optimization, it is possible to define these priors in the **cost_options** argument within
 the ``'control_prior'`` key. The problem is that we don't know the control vector in advance until we've
 filled in all the optimization options. This is why we can define all the optimization options in the
-`bayesian_optimize_control_info <smash.bayesian_optimize_control_info>` method, retrieve the names of the
+`bayesian_optimize_control_info` method, retrieve the names of the
 parameters that make up the control vector and then call the optimization function, assigning the priors we
 want to.
 
@@ -1647,9 +1646,9 @@ uniform optimization
 
 _forward_run_doc_appender = DocAppender(_forward_run_doc, indents=0)
 _smash_forward_run_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model <smash.Model>`\n\tPrimary data structure of the hydrological model "
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
     "`smash`.",
-    model_return="model : `Model <smash.Model>`\n\t It returns an updated copy of the initial Model object.",
+    model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_fwd = smash.forward_run()",
     model_example_response="model_fwd",
     percent="%",
@@ -1664,21 +1663,21 @@ _model_forward_run_doc_substitution = DocSubstitution(
 
 _optimize_doc_appender = DocAppender(_optimize_doc, indents=0)
 _smash_optimize_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model <smash.Model>`\n\tPrimary data structure of the hydrological model "
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
     "`smash`.",
-    default_optimize_options_func="default_optimize_options <smash.default_optimize_options>",
+    default_optimize_options_func="default_optimize_options",
     parameters_serr_mu_parameters="",
     parameters_serr_sigma_parameters="",
     parameters_note_serr_parameters="",
     bounds_get_serr_parameters_bounds="",
-    model_return="model : `Model <smash.Model>`\n\t It returns an updated copy of the initial Model object.",
+    model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_opt = smash.optimize()",
     model_example_response="model_opt",
     percent="%",
 )
 _model_optimize_doc_substitution = DocSubstitution(
     model_parameter="",
-    default_optimize_options_func="default_optimize_options <smash.default_optimize_options>",
+    default_optimize_options_func="default_optimize_options",
     parameters_serr_mu_parameters="",
     parameters_serr_sigma_parameters="",
     parameters_note_serr_parameters="",
@@ -1691,9 +1690,9 @@ _model_optimize_doc_substitution = DocSubstitution(
 
 _multiset_estimate_doc_appender = DocAppender(_multiset_estimate_doc, indents=0)
 _smash_multiset_estimate_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model <smash.Model>`\n\tPrimary data structure of the hydrological model "
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
     "`smash`.",
-    model_return="model : `Model <smash.Model>`\n\t It returns an updated copy of the initial Model object.",
+    model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_estim = smash.multiset_estimate(model, multiset=mfr)",
     model_example_response="model_estim",
     percent="%",
@@ -1708,24 +1707,22 @@ _model_multiset_estimate_doc_substitution = DocSubstitution(
 
 _bayesian_optimize_doc_appender = DocAppender(_bayesian_optimize_doc, indents=0)
 _smash_bayesian_optimize_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model <smash.Model>`\n\tPrimary data structure of the hydrological model "
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
     "`smash`.",
-    default_optimize_options_func="default_bayesian_optimize_options "
-    "<smash.default_bayesian_optimize_options>",
+    default_optimize_options_func="default_bayesian_optimize_options",
     parameters_serr_mu_parameters="- `Model.serr_mu_parameters`",
     parameters_serr_sigma_parameters="- `Model.serr_sigma_parameters`",
     parameters_note_serr_parameters=", `Model.serr_mu_parameters` and `Model.serr_sigma_parameters`",
     bounds_get_serr_parameters_bounds=", `Model.get_serr_mu_parameters_bounds` and "
     "`Model.get_serr_sigma_parameters_bounds`",
-    model_return="model : `Model <smash.Model>`\n\t It returns an updated copy of the initial Model object.",
+    model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_bayes_opt = smash.bayesian_optimize()",
     model_example_response="model_bayes_opt",
     percent="%",
 )
 _model_bayesian_optimize_doc_substitution = DocSubstitution(
     model_parameter="",
-    default_optimize_options_func="default_bayesian_optimize_options "
-    "<smash.default_bayesian_optimize_options>",
+    default_optimize_options_func="default_bayesian_optimize_options",
     parameters_serr_mu_parameters="- `Model.serr_mu_parameters`",
     parameters_serr_sigma_parameters="- `Model.serr_sigma_parameters`",
     parameters_note_serr_parameters=", `Model.serr_mu_parameters` and `Model.serr_sigma_parameters`",
@@ -1741,7 +1738,7 @@ _multiple_forward_run_doc_appender = DocAppender(_multiple_forward_run_doc, inde
 
 _multiple_optimize_doc_appender = DocAppender(_multiple_optimize_doc, indents=0)
 _smash_multiple_optimize_doc_substitution = DocSubstitution(
-    default_optimize_options_func="default_optimize_options <smash.default_optimize_options>",
+    default_optimize_options_func="default_optimize_options",
     parameters_serr_mu_parameters="",
     parameters_serr_sigma_parameters="",
     parameters_note_serr_parameters="",
@@ -1751,7 +1748,7 @@ _smash_multiple_optimize_doc_substitution = DocSubstitution(
 
 _optimize_control_info_doc_appender = DocAppender(_optimize_control_info_doc, indents=0)
 _smash_optimize_control_info_doc_substitution = DocSubstitution(
-    default_optimize_options_func="default_optimize_options <smash.default_optimize_options>",
+    default_optimize_options_func="default_optimize_options",
     parameters_serr_mu_parameters="",
     parameters_serr_sigma_parameters="",
     parameters_note_serr_parameters="",
@@ -1760,8 +1757,7 @@ _smash_optimize_control_info_doc_substitution = DocSubstitution(
 
 _bayesian_optimize_control_info_doc_appender = DocAppender(_bayesian_optimize_control_info_doc, indents=0)
 _smash_bayesian_optimize_control_info_doc_substitution = DocSubstitution(
-    default_optimize_options_func="default_bayesian_optimize_options "
-    "<smash.default_bayesian_optimize_options>",
+    default_optimize_options_func="default_bayesian_optimize_options",
     parameters_serr_mu_parameters="- `Model.serr_mu_parameters`",
     parameters_serr_sigma_parameters="- `Model.serr_sigma_parameters`",
     parameters_note_serr_parameters=", `Model.serr_mu_parameters` and `Model.serr_sigma_parameters`",

--- a/smash/core/simulation/estimate/estimate.py
+++ b/smash/core/simulation/estimate/estimate.py
@@ -35,7 +35,7 @@ class MultisetEstimate:
         A list of length *n* containing the returned time steps.
 
     rr_states : `FortranDerivedTypeArray`
-        A list of length *n* of `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
+        A list of length *n* of `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
 
     q_domain : `numpy.ndarray`
         An array of shape *(nrow, ncol, n)* representing simulated discharges on the domain for each
@@ -65,7 +65,7 @@ class MultisetEstimate:
     Notes
     -----
     The object's available attributes depend on what is requested by the user during a call to
-    `smash.multiset_estimate`.
+    `multiset_estimate`.
 
     See Also
     --------

--- a/smash/core/simulation/optimize/optimize.py
+++ b/smash/core/simulation/optimize/optimize.py
@@ -106,7 +106,7 @@ class Optimize:
         A list of length *n* containing the returned time steps.
 
     rr_states : `FortranDerivedTypeArray`
-        A list of length *n* of `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
+        A list of length *n* of `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
 
     q_domain : `numpy.ndarray`
         An array of shape *(nrow, ncol, n)* representing simulated discharges on the domain for each
@@ -122,7 +122,7 @@ class Optimize:
     control_vector : `numpy.ndarray`
         An array of shape *(k,)* representing the control vector at end of optimization.
 
-    net : `Net <smash.factory.Net>`
+    net : `Net <factory.Net>`
         The trained neural network.
 
     cost : `float`
@@ -159,7 +159,7 @@ class Optimize:
     Notes
     -----
     The object's available attributes depend on what is requested by the user during a call to
-    `smash.optimize` in **return_options**.
+    `optimize` in **return_options**.
 
     See Also
     --------
@@ -194,7 +194,7 @@ class BayesianOptimize:
         A list of length *n* containing the returned time steps.
 
     rr_states : `FortranDerivedTypeArray`
-        A list of length *n* of `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
+        A list of length *n* of `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
 
     q_domain : `numpy.ndarray`
         An array of shape *(nrow, ncol, n)* representing simulated discharges on the domain for each
@@ -233,7 +233,7 @@ class BayesianOptimize:
     Notes
     -----
     The object's available attributes depend on what is requested by the user during a call to
-    `smash.bayesian_optimize` in **return_options**.
+    `bayesian_optimize` in **return_options**.
 
     See Also
     --------

--- a/smash/core/simulation/options.py
+++ b/smash/core/simulation/options.py
@@ -26,7 +26,7 @@ def default_optimize_options(
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     mapping : `str`, default 'uniform'
@@ -68,7 +68,7 @@ def default_optimize_options(
     optimize_options : `dict[str, Any]`
         Dictionary containing optimization options for fine-tuning the optimization process. The specific keys
         returned depend on the chosen **mapping** and **optimizer**. This dictionary can be directly pass to
-        the **optimize_options** argument of the optimize method `smash.optimize` (or `Model.optimize`).
+        the **optimize_options** argument of the optimize method `optimize` (or `Model.optimize`).
 
     See Also
     --------
@@ -97,7 +97,7 @@ def default_optimize_options(
     }
 
     Directly pass this dictionary to the **optimize_options** argument of the optimize method
-    `smash.optimize` (or `Model.optimize`).
+    `optimize` (or `Model.optimize`).
     It's equivalent to set **optimize_options** to None (which is the default value)
 
     >>> model_u = smash.optimize(model, mapping="uniform", optimize_options=opt_u)
@@ -239,7 +239,7 @@ def default_bayesian_optimize_options(
 
     Parameters
     ----------
-    model : `Model <smash.Model>`
+    model : `Model`
         Primary data structure of the hydrological model `smash`.
 
     mapping : `str`, default 'uniform'
@@ -275,7 +275,7 @@ def default_bayesian_optimize_options(
     optimize_options : `dict[str, Any]`
         Dictionary containing optimization options for fine-tuning the optimization process. The specific keys
         returned depend on the chosen **mapping** and **optimizer**. This dictionary can be directly pass to
-        the **optimize_options** argument of the optimize method `smash.bayesian_optimize` (or
+        the **optimize_options** argument of the optimize method `bayesian_optimize` (or
         `Model.bayesian_optimize`).
 
     Examples
@@ -303,7 +303,7 @@ def default_bayesian_optimize_options(
     }
 
     Directly pass this dictionary to the **optimize_options** argument of the optimize method
-    `smash.bayesian_optimize` (or `Model.bayesian_optimize`).
+    `bayesian_optimize` (or `Model.bayesian_optimize`).
     It's equivalent to set **optimize_options** to None (which is the default value)
 
     >>> model_u = smash.bayesian_optimize(model, mapping="uniform", optimize_options=opt_u)

--- a/smash/core/simulation/run/run.py
+++ b/smash/core/simulation/run/run.py
@@ -82,7 +82,7 @@ class ForwardRun:
         A list of length *n* containing the returned time steps.
 
     rr_states : `FortranDerivedTypeArray`
-        A list of length *n* of `RR_StatesDT <smash.fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
+        A list of length *n* of `RR_StatesDT <fcore._mwd_rr_states.RR_StatesDT>` for each **time_step**.
 
     q_domain : `numpy.ndarray`
         An array of shape *(nrow, ncol, n)* representing simulated discharges on the domain for each
@@ -97,7 +97,7 @@ class ForwardRun:
     Notes
     -----
     The object's available attributes depend on what is requested by the user in **return_options** during a
-    call to `smash.forward_run`.
+    call to `forward_run`.
 
     See Also
     --------

--- a/smash/factory/samples/samples.py
+++ b/smash/factory/samples/samples.py
@@ -29,7 +29,7 @@ class Samples:
     Notes
     -----
     This class may have additional attributes not listed here depending on the specific names provided
-    in the argument ``problem`` in the `smash.factory.generate_samples` method.
+    in the argument ``problem`` in the `smash.factory.generate_samples <factory.generate_samples>` method.
 
     Attributes
     ----------
@@ -73,7 +73,7 @@ class Samples:
 
         Returns
         -------
-        slice : `Samples <smash.Samples>`
+        slice : `Samples`
             The Samples object sliced according to **start** and **end** arguments.
 
         Examples
@@ -146,7 +146,7 @@ class Samples:
 
         Yields
         ------
-        slice : `Samples <smash.Samples>`
+        slice : `Samples`
             The Samples object sliced according to **by** arguments.
 
         See Also

--- a/smash/io/model_ddt.py
+++ b/smash/io/model_ddt.py
@@ -23,8 +23,8 @@ def save_model_ddt(model: Model, path: FilePath):
     """
     Save some derived data types of the Model object to HDF5.
 
-    This method is considerably lighter than `smash.io.save_model` method that saves the entire Model object.
-    However, it is not capable of reconstructing the Model object from the saved data file.
+    This method is considerably lighter than `smash.io.save_model <save_model>` method that saves the entire
+    Model object. However, it is not capable of reconstructing the Model object from the saved data file.
 
     By default, the following data are stored into the `HDF5 <https://www.hdfgroup.org/solutions/hdf5/>`__
     file:
@@ -90,7 +90,7 @@ def read_model_ddt(path: FilePath) -> dict[str, dict[str, Any]]:
     Read some derived data types of the Model object from HDF5.
 
     This method does not reconstruct the Model object because certain information has not been saved from the
-    `smash.io.save_model_ddt` method
+    `smash.io.save_model_ddt <save_model_ddt>` method
     in order to have light memory backup. This method returns a dictionary whose organisation is similar to
     the Model object.
 


### PR DESCRIPTION
Backport of #258

* MAINT: Sphinx v7.4 compatibility

- version disjunction in documentation custom directive (soon deprecated)
- Remove warning "summarized item should not include the current module"
- Add --fail-on-warning option when building the documentation

* MAINT: Add pickleshare as dependency