### PR TITLE
FIX: scaling layer for bounded outputs from activation layer

### DIFF
--- a/smash/factory/net/_standardize.py
+++ b/smash/factory/net/_standardize.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from smash._constant import ACTIVATION_FUNCTION, LAYER_NAME
 
 if TYPE_CHECKING:
+    from smash.factory.net.net import Net
     from smash.util._typing import AnyTuple
 
 
@@ -24,7 +25,7 @@ def _standardize_add_layer(layer: str) -> str:
     return layer
 
 
-def _standardize_add_options(layer: str, options: dict) -> dict:
+def _standardize_add_options(net: Net, layer: str, options: dict) -> dict:
     if isinstance(options, dict):
         if layer == "Activation":
             try:
@@ -51,6 +52,20 @@ def _standardize_add_options(layer: str, options: dict) -> dict:
             else:
                 raise TypeError("Key 'name' in options argument must be a str")
 
+        elif layer == "Scale":
+            # Add bound_in for scaling layer. This will be improved with
+            # the new structure of add() function from v1.1.0
+            if net.layers:
+                try:
+                    options["bound_in"] = net.layers[-1]._activation_func.bound
+                except Exception:
+                    raise ValueError(
+                        "Cannot apply scaling function to unbounded outputs from previous layer"
+                    ) from None
+
+            else:
+                raise ValueError("Scaling layer cannot be the first layer of the network")
+
         else:
             pass
 
@@ -60,9 +75,9 @@ def _standardize_add_options(layer: str, options: dict) -> dict:
     return options
 
 
-def _standardize_add_args(layer: str, options: dict) -> AnyTuple:
+def _standardize_add_args(net: Net, layer: str, options: dict) -> AnyTuple:
     layer = _standardize_add_layer(layer)
 
-    options = _standardize_add_options(layer, options)
+    options = _standardize_add_options(net, layer, options)
 
     return (layer, options)

--- a/smash/factory/net/net.py
+++ b/smash/factory/net/net.py
@@ -201,7 +201,7 @@ class Net(object):
         Trainable parameters: 884
         """
 
-        layer, options = _standardize_add_args(layer, options)
+        layer, options = _standardize_add_args(self, layer, options)
 
         lay = eval(layer)(**options)
 


### PR DESCRIPTION
Scaling layer is now able to take the outputs from other activation functions (not only sigmoid) such as softmax and tanh.