### PR TITLE
Fix crash in generate mesh if a well is present at a cell

### DIFF
--- a/smash/factory/mesh/mw_mesh.f90
+++ b/smash/factory/mesh/mw_mesh.f90
@@ -348,6 +348,8 @@ contains
 
             if (flwdir(row_imd, col_imd) .ne. i) cycle
 
+            if (abs(flwdir(row, col) - flwdir(row_imd, col_imd)) .eq. 4) cycle
+
             !% Check for nested catchment and set flag
             do j = 1, ng
 


### PR DESCRIPTION
Fix crash in generate mesh if a well is present at a cell : infinite recursive loop. Just test if it is a well and cycle.