### PR TITLE
ENH: set parameters condition outside active cell

### DIFF
--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -352,8 +352,6 @@ DEFAULT_BOUNDS_RR_INITIAL_STATES = dict(
     )
 )
 
-TOL_BOUNDS = 1e-9
-
 ### OPTIMIZABLE PARAMETERS ###
 ##############################
 

--- a/smash/core/model/_standardize.py
+++ b/smash/core/model/_standardize.py
@@ -526,16 +526,22 @@ def _standardize_rr_parameters_value(
     if not isinstance(value, (int, float, np.ndarray)):
         raise TypeError("value argument must be of Numeric type (int, float) or np.ndarray")
 
-    arr = np.array(value, ndmin=1)
-    low, upp = FEASIBLE_RR_PARAMETERS[key]
-    low_arr = np.min(arr)
-    upp_arr = np.max(arr)
+    arr = np.array(value, ndmin=1, dtype=np.float32)
 
-    if isinstance(value, np.ndarray) and value.shape != model.mesh.flwdir.shape and value.size != 1:
+    if arr.size == 1:
+        mask = np.ones(arr.shape, dtype=bool)
+    elif arr.shape == model.mesh.flwdir.shape:
+        # Do not check if a value is inside the feasible domain outside of active cells
+        mask = model.mesh.active_cell == 1
+    else:
         raise ValueError(
             f"Invalid shape for model rr_parameter '{key}'. Could not broadcast input array from shape "
-            f"{value.shape} into shape {model.mesh.flwdir.shape}"
+            f"{arr.shape} into shape {model.mesh.flwdir.shape}"
         )
+
+    low, upp = FEASIBLE_RR_PARAMETERS[key]
+    low_arr = np.min(arr, where=mask, initial=np.inf)
+    upp_arr = np.max(arr, where=mask, initial=-np.inf)
 
     if (low_arr + F_PRECISION) <= low or (upp_arr - F_PRECISION) >= upp:
         raise ValueError(
@@ -552,16 +558,22 @@ def _standardize_rr_states_value(
     if not isinstance(value, (int, float, np.ndarray)):
         raise TypeError("value argument must be of Numeric type (int, float) or np.ndarray")
 
-    arr = np.array(value, ndmin=1)
-    low, upp = FEASIBLE_RR_INITIAL_STATES[key]
-    low_arr = np.min(arr)
-    upp_arr = np.max(arr)
+    arr = np.array(value, ndmin=1, dtype=np.float32)
 
-    if isinstance(value, np.ndarray) and value.shape != model.mesh.flwdir.shape and value.size != 1:
+    if arr.size == 1:
+        mask = np.ones(arr.shape, dtype=bool)
+    elif arr.shape == model.mesh.flwdir.shape:
+        # Do not check if a value is inside the feasible domain outside of active cells
+        mask = model.mesh.active_cell == 1
+    else:
         raise ValueError(
             f"Invalid shape for model {state_kind} '{key}'. Could not broadcast input array from shape "
-            f"{value.shape} into shape {model.mesh.flwdir.shape}"
+            f"{arr.shape} into shape {model.mesh.flwdir.shape}"
         )
+
+    low, upp = FEASIBLE_RR_INITIAL_STATES[key]
+    low_arr = np.min(arr, where=mask, initial=np.inf)
+    upp_arr = np.max(arr, where=mask, initial=-np.inf)
 
     if (low_arr + F_PRECISION) <= low or (upp_arr - F_PRECISION) >= upp:
         raise ValueError(
@@ -578,18 +590,19 @@ def _standardize_serr_mu_parameters_value(
     if not isinstance(value, (int, float, np.ndarray)):
         raise TypeError("value argument must be of Numeric type (int, float) or np.ndarray")
 
-    arr = np.array(value, ndmin=1)
+    arr = np.array(value, ndmin=1, dtype=np.float32)
+
+    if arr.shape != (model.mesh.ng,) and arr.size != 1:
+        raise ValueError(
+            f"Invalid shape for model serr_mu_parameter '{key}'. Could not broadcast input array from shape "
+            f"{arr.shape} into shape {(model.mesh.ng,)}"
+        )
+
     low, upp = FEASIBLE_SERR_MU_PARAMETERS[key]
     low_arr = np.min(arr)
     upp_arr = np.max(arr)
 
-    if isinstance(value, np.ndarray) and value.shape != (model.mesh.ng,) and value.size != 1:
-        raise ValueError(
-            f"Invalid shape for model serr_mu_parameter '{key}'. Could not broadcast input array from shape "
-            f"{value.shape} into shape {(model.mesh.ng,)}"
-        )
-
-    if low_arr <= low or upp_arr >= upp:
+    if (low_arr + F_PRECISION) <= low or (upp_arr - F_PRECISION) >= upp:
         raise ValueError(
             f"Invalid value for model serr_mu_parameter '{key}'. serr_mu_parameter domain "
             f"[{low_arr}, {upp_arr}] is not included in the feasible domain ]{low}, {upp}["
@@ -604,18 +617,19 @@ def _standardize_serr_sigma_parameters_value(
     if not isinstance(value, (int, float, np.ndarray)):
         raise TypeError("value argument must be of Numeric type (int, float) or np.ndarray")
 
-    arr = np.array(value, ndmin=1)
+    arr = np.array(value, ndmin=1, dtype=np.float32)
+
+    if arr.shape != (model.mesh.ng,) and arr.size != 1:
+        raise ValueError(
+            f"Invalid shape for model serr_sigma_parameter '{key}'. Could not broadcast input array from "
+            f"shape {arr.shape} into shape {(model.mesh.ng,)}"
+        )
+
     low, upp = FEASIBLE_SERR_SIGMA_PARAMETERS[key]
     low_arr = np.min(arr)
     upp_arr = np.max(arr)
 
-    if isinstance(value, np.ndarray) and value.shape != (model.mesh.ng,) and value.size != 1:
-        raise ValueError(
-            f"Invalid shape for model serr_sigma_parameter '{key}'. Could not broadcast input array from "
-            f"shape {value.shape} into shape {(model.mesh.ng,)}"
-        )
-
-    if low_arr <= low or upp_arr >= upp:
+    if (low_arr + F_PRECISION) <= low or (upp_arr - F_PRECISION) >= upp:
         raise ValueError(
             f"Invalid value for model serr_sigma_parameter '{key}'. serr_sigma_parameter domain "
             f"[{low_arr}, {upp_arr}] is not included in the feasible domain ]{low}, {upp}["

--- a/smash/core/simulation/_doc.py
+++ b/smash/core/simulation/_doc.py
@@ -1646,8 +1646,7 @@ uniform optimization
 
 _forward_run_doc_appender = DocAppender(_forward_run_doc, indents=0)
 _smash_forward_run_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
-    "`smash`.",
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model `smash`.",
     model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_fwd = smash.forward_run()",
     model_example_response="model_fwd",
@@ -1663,8 +1662,7 @@ _model_forward_run_doc_substitution = DocSubstitution(
 
 _optimize_doc_appender = DocAppender(_optimize_doc, indents=0)
 _smash_optimize_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
-    "`smash`.",
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model `smash`.",
     default_optimize_options_func="default_optimize_options",
     parameters_serr_mu_parameters="",
     parameters_serr_sigma_parameters="",
@@ -1690,8 +1688,7 @@ _model_optimize_doc_substitution = DocSubstitution(
 
 _multiset_estimate_doc_appender = DocAppender(_multiset_estimate_doc, indents=0)
 _smash_multiset_estimate_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
-    "`smash`.",
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model `smash`.",
     model_return="model : `Model`\n\t It returns an updated copy of the initial Model object.",
     model_example_func="model_estim = smash.multiset_estimate(model, multiset=mfr)",
     model_example_response="model_estim",
@@ -1707,8 +1704,7 @@ _model_multiset_estimate_doc_substitution = DocSubstitution(
 
 _bayesian_optimize_doc_appender = DocAppender(_bayesian_optimize_doc, indents=0)
 _smash_bayesian_optimize_doc_substitution = DocSubstitution(
-    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model "
-    "`smash`.",
+    model_parameter="model : `Model`\n\tPrimary data structure of the hydrological model `smash`.",
     default_optimize_options_func="default_bayesian_optimize_options",
     parameters_serr_mu_parameters="- `Model.serr_mu_parameters`",
     parameters_serr_sigma_parameters="- `Model.serr_sigma_parameters`",


### PR DESCRIPTION
Backport of #287 

* ENH: Mask active cell when checking if parameter is inside feasible domain

- Allow to pass any value to a non active cell and it does not return an error.
- Ruff and fprettify formatting applied
- Remove unused constant TOL_BOUNDS since F_PRECISION is now used

* FIX: Add F_PRECISION to serr parameters

Missing F_PRECISION for structural error parameters

* FIX PR: Clean model standardize