### PR TITLE
MAINT: remove also dataset directories when using make doc-clean

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,5 +27,5 @@ help:
 clean:
 	@rm -rf $(BUILDDIR)
 	@rm -rf $(SOURCEDIR)/savefig
-	@rm -rf *.hdf5 *yaml
+	@rm -rf *.hdf5 *yaml *-dataset
 	@find $(SOURCEDIR)/api_reference/ -type d -name "smash" -exec rm -rf {} +


### PR DESCRIPTION
To ensure the datasets are up-to-date with the online version, it's recommended to remove local files before generating the documentation.