### PR TITLE
FIX: Update sink detection

### DIFF
--- a/doc/generate_dataset.py
+++ b/doc/generate_dataset.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         "--tar",
         default=False,
         action="store_true",
-        help="Skip tests to include",
+        help="output as tar format",
     )
 
     args = parser.parse_args()

--- a/doc/source/api_reference/sub-packages/factory.rst
+++ b/doc/source/api_reference/sub-packages/factory.rst
@@ -20,6 +20,7 @@ Mesh Generation
 .. autosummary::
       :toctree: smash/
 
+      detect_sink
       generate_mesh
 
 Neural Network Configuration

--- a/doc/source/user_guide/quickstart/cance_first_simulation.rst
+++ b/doc/source/user_guide/quickstart/cance_first_simulation.rst
@@ -61,7 +61,10 @@ the ``France_flwdir.tif`` contains the flow direction data on the whole France, 
     :align: center
     :width: 175
 
-Note: the flow directions must not contain well(s), i.e two consecutive cells flowing toward each other. Thus you must ensure that the flow directions are consistent from upstream to downstream.
+.. note::
+
+    The flow directions should not contain sink(s), i.e. consecutive cells flowing toward each other.
+    It is therefore important to ensure that flow directions are consistent from upstream to downstream.
 
 Gauge attributes
 ****************
@@ -400,8 +403,6 @@ An important step after generating the ``mesh`` is to check that the stations ha
 
 For this ``mesh``, we have a negative relative error on the simulated drainage area that varies from -0.3% for the most downstream gauge to -10% for the most upstream one
 (which can be explained by the fact that small upstream catchments are more sensitive to the relatively coarse ``mesh`` resolution).
-
-Note: the `smash.factory.generate_mesh` function first check the consitency of the flow directions (i.e the existence of well(s)). If some well(s) are detected, an error is printed and a dictionary with all necessary informations to identify the well(s) are returned. This check can be terned off by passing the flag `check_well=False` in the function `smash.factory.generate_mesh`.
 
 .. TODO FC link to automatic meshing
 

--- a/smash/factory/__init__.py
+++ b/smash/factory/__init__.py
@@ -1,9 +1,10 @@
 from smash.factory.dataset.dataset import load_dataset
-from smash.factory.mesh.mesh import generate_mesh
+from smash.factory.mesh.mesh import detect_sink, generate_mesh
 from smash.factory.net.net import Net
 from smash.factory.samples.samples import generate_samples
 
 __all__ = [
+    "detect_sink",
     "generate_mesh",
     "load_dataset",
     "generate_samples",

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -11,7 +11,6 @@ import rasterio
 from smash.factory.mesh._tools import _get_transform
 
 if TYPE_CHECKING:
-    from typing import Tuple
 
     from smash.util._typing import AlphaNumeric, AnyTuple, FilePath, ListLike, Numeric
 
@@ -47,7 +46,7 @@ def _standardize_detect_sink_flwdir_path(flwdir_path: FilePath) -> str:
     return _standardize_flwdir_path(flwdir_path)
 
 
-def _standardize_detect_sink_output_path(output_path: FilePath | None) -> str:
+def _standardize_detect_sink_output_path(output_path: FilePath | None) -> str | None:
     return _standardize_output_path(output_path)
 
 
@@ -58,7 +57,7 @@ def _standardize_detect_sink_args(flwdir_path: FilePath, output_path: FilePath |
 
     output_path = _standardize_detect_sink_output_path(output_path)
 
-    return (flwdir_dataset, output_path)
+    return flwdir_dataset, output_path
 
 
 def _standardize_generate_mesh_flwdir_path(flwdir_path: FilePath) -> str:
@@ -132,7 +131,7 @@ def _standardize_generate_mesh_x_y_area(
     x: Numeric | ListLike,
     y: Numeric | ListLike,
     area: Numeric | ListLike,
-) -> Tuple[np.ndarray]:
+) -> tuple[np.ndarray]:
     if not isinstance(x, (int, float, list, tuple, np.ndarray)):
         raise TypeError(
             "x argument must be of Numeric type (int, float) or ListLike type (List, Tuple, np.ndarray)"
@@ -197,7 +196,7 @@ def _standardize_generate_mesh_max_depth(max_depth: Numeric) -> int:
     return max_depth
 
 
-def _standardize_generate_mesh_epsg(epsg: AlphaNumeric | None) -> int:
+def _standardize_generate_mesh_epsg(epsg: AlphaNumeric | None) -> int | None:
     if epsg is None:
         pass
 
@@ -239,4 +238,4 @@ def _standardize_generate_mesh_args(
 
     epsg = _standardize_generate_mesh_epsg(epsg)
 
-    return (flwdir_dataset, bbox, x, y, area, code, max_depth, epsg)
+    return flwdir_dataset, bbox, x, y, area, code, max_depth, epsg

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -11,7 +11,6 @@ import rasterio
 from smash.factory.mesh._tools import _get_transform
 
 if TYPE_CHECKING:
-
     from smash.util._typing import AlphaNumeric, AnyTuple, FilePath, ListLike, Numeric
 
 

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from smash.util._typing import AlphaNumeric, AnyTuple, FilePath, ListLike, Numeric
 
 
-def _standardize_generate_mesh_flwdir_path(flwdir_path: FilePath) -> str:
+def _standardize_flwdir_path(flwdir_path: FilePath) -> str:
     if not isinstance(flwdir_path, (str, os.PathLike)):
         raise TypeError("flwdir_path argument must be of FilePath type (str, PathLike[str])")
 
@@ -26,6 +26,43 @@ def _standardize_generate_mesh_flwdir_path(flwdir_path: FilePath) -> str:
         raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), flwdir_path)
 
     return flwdir_path
+
+
+def _standardize_output_path(output_path: FilePath | None) -> str | None:
+    if output_path is None:
+        return
+
+    if not isinstance(output_path, (str, os.PathLike)):
+        raise TypeError("output_path argument must be of FilePath type (str, PathLike[str])")
+
+    output_path = str(output_path)
+
+    if not os.path.exists(os.path.dirname(output_path)):
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), os.path.dirname(output_path))
+
+    return output_path
+
+
+def _standardize_detect_sink_flwdir_path(flwdir_path: FilePath) -> str:
+    return _standardize_flwdir_path(flwdir_path)
+
+
+def _standardize_detect_sink_output_path(output_path: FilePath | None) -> str:
+    return _standardize_output_path(output_path)
+
+
+def _standardize_detect_sink_args(flwdir_path: FilePath, output_path: FilePath | None) -> AnyTuple:
+    flwdir_path = _standardize_detect_sink_flwdir_path(flwdir_path)
+
+    flwdir_dataset = rasterio.open(flwdir_path)
+
+    output_path = _standardize_detect_sink_output_path(output_path)
+
+    return (flwdir_dataset, output_path)
+
+
+def _standardize_generate_mesh_flwdir_path(flwdir_path: FilePath) -> str:
+    return _standardize_flwdir_path(flwdir_path)
 
 
 def _standardize_generate_mesh_bbox(flwdir_dataset: rasterio.DatasetReader, bbox: ListLike) -> np.ndarray:
@@ -182,7 +219,6 @@ def _standardize_generate_mesh_args(
     code: str | ListLike | None,
     max_depth: Numeric,
     epsg: AlphaNumeric | None,
-    check_well: bool,
 ) -> AnyTuple:
     flwdir_path = _standardize_generate_mesh_flwdir_path(flwdir_path)
 
@@ -203,4 +239,4 @@ def _standardize_generate_mesh_args(
 
     epsg = _standardize_generate_mesh_epsg(epsg)
 
-    return (flwdir_dataset, bbox, x, y, area, code, max_depth, epsg, check_well)
+    return (flwdir_dataset, bbox, x, y, area, code, max_depth, epsg)

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -32,6 +32,9 @@ def detect_sink(flwdir_path: FilePath, output_path: FilePath | None = None) -> n
     """
     Detect the sink cells in a flow direction file.
 
+    Sinks in flow direction lead to numerical issues in the routing scheme and should be removed before
+    generating the mesh.
+
     Parameters
     ----------
     flwdir_path : `str`
@@ -52,6 +55,10 @@ def detect_sink(flwdir_path: FilePath, output_path: FilePath | None = None) -> n
 
         - ``0``: non-sink cell
         - ``1``: sink cell
+
+    See Also
+    --------
+    smash.factory.generate_mesh : Automatic mesh generation.
 
     Examples
     --------
@@ -76,13 +83,13 @@ def detect_sink(flwdir_path: FilePath, output_path: FilePath | None = None) -> n
            [0, 0, 0, ..., 0, 0, 0]], dtype=int32)
 
     ``sink`` is a mask of sink cells. The value ``1`` represents a sink cell and ``0`` a non-sink cell. The
-    given flow direction file in the example does not contain any sink cells. ``sink`` is therefore a matrix
+    given flow direction file in the example does not contain any sink cell. ``sink`` is therefore a matrix
     of zeros.
 
     >>> np.all(sink == 0)
     np.True_
 
-    In this example, we are going to add a false sinks (2 cells) to show how they can be identified.
+    In this example, we are going to add a false sink (2 cells) to show how they can be identified.
 
     >>> sink[10, 10:12] = 1
     >>> np.all(sink == 0), np.count_nonzero(sink == 1)
@@ -303,6 +310,7 @@ def generate_mesh(
     See Also
     --------
     smash.Model : Primary data structure of the hydrological model `smash`.
+    smash.factory.detect_sink : Detect the sink cells in a flow direction file.
 
     Examples
     --------

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -4,9 +4,13 @@ import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
+import rasterio
 
 from smash.factory.mesh._libmesh import mw_mesh
-from smash.factory.mesh._standardize import _standardize_generate_mesh_args
+from smash.factory.mesh._standardize import (
+    _standardize_detect_sink_args,
+    _standardize_generate_mesh_args,
+)
 from smash.factory.mesh._tools import (
     _get_array,
     _get_catchment_slice_window,
@@ -19,11 +23,114 @@ from smash.factory.mesh._tools import (
 if TYPE_CHECKING:
     from typing import Any
 
-    import rasterio
-
     from smash.util._typing import AlphaNumeric, FilePath, ListLike, Numeric
 
-__all__ = ["generate_mesh"]
+__all__ = ["detect_sink", "generate_mesh"]
+
+
+def detect_sink(flwdir_path: FilePath, output_path: FilePath | None = None) -> np.ndarray:
+    """
+    Detect the sink cells in a flow direction file.
+
+    Parameters
+    ----------
+    flwdir_path : `str`
+        Path to the flow directions file. The flow direction convention is the following:
+
+        .. image:: ../../../_static/flwdir_convention.png
+            :width: 100
+            :align: center
+
+    output_path : `str` or None, default None
+        Path to the output file. If given, a raster file, in ``tif`` format, is written representing the sink
+        cells.
+
+    Returns
+    -------
+    sink : `numpy.ndarray`
+        An array of shape *(nrow, ncol)*  containing a mask of sink cells.
+
+        - ``0``: non-sink cell
+        - ``1``: sink cell
+
+    Examples
+    --------
+    >>> from smash.factory import load_dataset, detect_sink
+
+    Retrieve a path to a flow direction file. A pre-processed file is available in the `smash` package (the
+    path is updated for each user).
+
+    >>> flwdir = load_dataset("flwdir")
+    flwdir
+
+    Detect the sink cells in the flow direction file.
+
+    >>> sink = detect_sink(flwdir)
+    >>> sink
+    array([[0, 0, 0, ..., 0, 0, 0],
+           [0, 0, 0, ..., 0, 0, 0],
+           [0, 0, 0, ..., 0, 0, 0],
+           ...,
+           [0, 0, 0, ..., 0, 0, 0],
+           [0, 0, 0, ..., 0, 0, 0],
+           [0, 0, 0, ..., 0, 0, 0]], dtype=int32)
+
+    ``sink`` is a mask of sink cells. The value ``1`` represents a sink cell and ``0`` a non-sink cell. The
+    given flow direction file in the example does not contain any sink cells. ``sink`` is therefore a matrix
+    of zeros.
+
+    >>> np.all(sink == 0)
+    np.True_
+
+    In this example, we are going to add a false sinks (2 cells) to show how they can be identified.
+
+    >>> sink[10, 10:12] = 1
+    >>> np.all(sink == 0), np.count_nonzero(sink == 1)
+    (np.False_, 2)
+
+    We can retrieve the indices of the sink cells.
+
+    >>> idx = np.argwhere(sink == 1)
+    array([[10, 10],
+           [10, 11]])
+
+    The flow direction file can be modified to remove sink cells.
+
+    >>> with rasterio.open(flwdir) as ds_in:
+    ...     flwdir_data = ds_in.read(1)
+    ...     flwdir_data[sink == 1] = 0
+    ...     with rasterio.open("flwdir_wo_sink.tif", "w", **ds_in.profile) as ds_out:
+    ...         ds_out.write(flwdir_data, 1)
+
+    .. note::
+        Setting ``0`` to sink cells in the flow direction file is a way to remove them. However, it might not
+        be the best way to handle sink cells.
+
+    Finally, we can write the sink cells to a raster file by providing the output path.
+
+    >>> detect_sink(flwdir, "./flwdir_sink.tif")
+
+    The sink cells are written to the file ``flwdir_sink.tif`` and can be post-processed with a GIS software.
+    """
+
+    args = _standardize_detect_sink_args(flwdir_path, output_path)
+
+    return _detect_sink(*args)
+
+
+def _detect_sink(flwdir_dataset: rasterio.DatasetReader, output_path: str | None) -> np.ndarray:
+    flwdir = _get_array(flwdir_dataset)
+
+    sink = mw_mesh.detect_sink(flwdir)
+
+    if output_path is not None:
+        profile = flwdir_dataset.profile
+        profile.update(dtype=np.uint8, count=1, nodata=np.iinfo(np.uint8).max)
+
+        with rasterio.open(output_path, "w", **profile) as dst:
+            dst.write(sink, 1)
+
+    return sink
 
 
 def generate_mesh(
@@ -35,7 +142,6 @@ def generate_mesh(
     code: str | ListLike[str] | None = None,
     max_depth: Numeric = 1,
     epsg: AlphaNumeric | None = None,
-    check_well: bool = True,
 ) -> dict[str, Any]:
     # % TODO FC: Add advanced user guide
     """
@@ -98,12 +204,6 @@ def generate_mesh(
         defined in the flow directions file. It is not necessary to provide the value of
         the ``EPSG``. On the other hand, if the projection is not well defined in the flow directions file
         (i.e. in ``ASCII`` file). The **epsg** argument must be filled in.
-
-    check_well: `bool`, default True
-        Whether to check the consistency of the flow directions. If any wells are detected, the function
-        will raise a warning and return a dictionary with all necessary information to identify the well(s).
-        If False, this check is disabled. Note that the presence of wells could lead to unexpected behaviors,
-        such as crashes or inconsistent hydrological results.
 
     Returns
     -------
@@ -252,7 +352,7 @@ def generate_mesh(
     (1000.0, 906044, 0)
     """
 
-    args = _standardize_generate_mesh_args(flwdir_path, bbox, x, y, area, code, max_depth, epsg, check_well)
+    args = _standardize_generate_mesh_args(flwdir_path, bbox, x, y, area, code, max_depth, epsg)
 
     return _generate_mesh(*args)
 
@@ -286,6 +386,7 @@ def _generate_mesh_from_xy(
     row_dln = np.zeros(shape=x.shape, dtype=np.int32)
     col_dln = np.zeros(shape=x.shape, dtype=np.int32)
     area_dln = np.zeros(shape=x.shape, dtype=np.float32)
+    sink_dln = np.zeros(shape=x.shape, dtype=np.bool)
     mask_dln = np.zeros(shape=flwdir.shape, dtype=np.int32)
 
     for ind in range(x.size):
@@ -306,7 +407,7 @@ def _generate_mesh_from_xy(
         dy_win = dy[slice_win]
         flwdir_win = flwdir[slice_win]
 
-        mask_dln_win, row_dln_win, col_dln_win = mw_mesh.catchment_dln(
+        mask_dln_win, row_dln_win, col_dln_win, sink_dln[ind] = mw_mesh.catchment_dln(
             flwdir_win, dx_win, dy_win, row_win, col_win, area[ind], max_depth
         )
 
@@ -316,6 +417,16 @@ def _generate_mesh_from_xy(
         area_dln[ind] = np.sum(mask_dln_win * dx_win * dy_win)
 
         mask_dln[slice_win] = np.where(mask_dln_win == 1, 1, mask_dln[slice_win])
+
+    if np.any(sink_dln):
+        warnings.warn(
+            f"One or more sinks were detected when trying to delineate the catchment(s): "
+            f"'{code[sink_dln == 1]}'. The catchment(s) might not be correctly delineated avoiding the sink "
+            f"cells. See also the 'smash.factory.detect_sink' function "
+            f"(https://smash.recover.inrae.fr/api_reference/sub-packages/smash/"
+            f"smash.factory.detect_sink.html) to identify and correct sinks beforehand",
+            stacklevel=2,
+        )
 
     flwdir = np.ma.masked_array(flwdir, mask=(1 - mask_dln))
     flwdir, slice_win = _trim_mask_2d(flwdir, slice_win=True)
@@ -385,6 +496,18 @@ def _generate_mesh_from_bbox(flwdir_dataset: rasterio.DatasetReader, bbox: np.nd
     # % Can close dataset
     flwdir_dataset.close()
 
+    sink = mw_mesh.detect_sink(flwdir)
+    # Check if sinks are detected on active cells and remove them
+    if np.any(sink[flwdir > 0]):
+        flwdir[sink == 1] = 0
+        warnings.warn(
+            "One or more sinks were detected in the given bounding box. The sink cells will be considered as "
+            "non-active cells. See also the 'smash.factory.detect_sink' function "
+            "(https://smash.recover.inrae.fr/api_reference/sub-packages/smash/"
+            "smash.factory.detect_sink.html) to identify and correct sinks beforehand",
+            stacklevel=2,
+        )
+
     flwdir = np.ma.masked_array(flwdir, mask=(flwdir < 1))
 
     # % Accepting arrays for dx and dy in case of unstructured meshing
@@ -430,28 +553,6 @@ def _generate_mesh_from_bbox(flwdir_dataset: rasterio.DatasetReader, bbox: np.nd
     return mesh
 
 
-def _check_well_in_flwdir(
-    flwdir_dataset: rasterio.DatasetReader,
-):
-    (xmin, _, xres, _, ymax, yres) = _get_transform(flwdir_dataset)
-    flwdir = _get_array(flwdir_dataset)
-
-    well = mw_mesh.check_well_in_flwdir(flwdir)
-
-    well_coord_x = xmin + np.where(well > 0)[0] * xres
-    well_coord_y = ymax - np.where(well > 0)[1] * yres
-
-    well_location = {
-        "meta": flwdir_dataset.meta,
-        "flwdir": flwdir,
-        "well": well,
-        "well_coord_x": well_coord_x,
-        "well_coord_y": well_coord_y,
-    }
-
-    return well_location
-
-
 def _generate_mesh(
     flwdir_dataset: rasterio.DatasetReader,
     bbox: np.ndarray | None,
@@ -461,24 +562,7 @@ def _generate_mesh(
     code: np.ndarray | None,
     max_depth: int,
     epsg: int | None,
-    check_well: bool,
 ) -> dict:
-    if check_well:
-        print("</> Checking the consistency of the flow directions")
-        well = _check_well_in_flwdir(flwdir_dataset)
-
-        if np.sum(well["well"]) != 0:
-            warnings.warn(
-                "Well(s) detected in the flow directions may lead to unexpected hydrological behaviors",
-                stacklevel=2,
-            )
-
-            flwdir_dataset.close()
-
-            return well
-
-    print("</> Generating mesh")
-
     if bbox is not None:
         return _generate_mesh_from_bbox(flwdir_dataset, bbox, epsg)
     else:

--- a/smash/factory/mesh/mw_mesh.f90
+++ b/smash/factory/mesh/mw_mesh.f90
@@ -34,7 +34,7 @@ contains
 
     end subroutine latlon_dxdy
 
-    recursive subroutine mask_upstream_cells(nrow, ncol, flwdir, row, col, mask)
+    recursive subroutine mask_upstream_cells(nrow, ncol, flwdir, row, col, mask, sink)
 
         implicit none
 
@@ -42,10 +42,10 @@ contains
         integer, dimension(nrow, ncol), intent(in) :: flwdir
         integer, intent(in) :: row, col
         integer, dimension(nrow, ncol), intent(inout) :: mask
+        logical, intent(inout) :: sink
 
         integer, dimension(8) :: drow = (/1, 1, 0, -1, -1, -1, 0, 1/)
         integer, dimension(8) :: dcol = (/0, -1, -1, -1, 0, 1, 1, 1/)
-        integer, dimension(8) :: opposite_dir = (/5, 6, 7, 8, 1, 2, 3, 4/)
         integer :: i, row_imd, col_imd
 
         mask(row, col) = 1
@@ -54,17 +54,27 @@ contains
 
             row_imd = row + drow(i)
             col_imd = col + dcol(i)
-
+            
+            ! % Bounds
             if (row_imd .lt. 1 .or. row_imd .gt. nrow .or. col_imd .lt. 1 .or. col_imd .gt. ncol) cycle
 
-            if (flwdir(row_imd, col_imd) .eq. i) call mask_upstream_cells(nrow, ncol, flwdir, row_imd, col_imd, mask)
+            ! % Non upstream cell
+            if (flwdir(row_imd, col_imd) .ne. i) cycle
+
+            ! % Upstream sink cell, must return
+            if (mask(row_imd, col_imd) .eq. 1) then
+                sink = .true.
+                return
+            end if
+            
+            call mask_upstream_cells(nrow, ncol, flwdir, row_imd, col_imd, mask, sink)
 
         end do
 
     end subroutine mask_upstream_cells
 
     subroutine catchment_dln(nrow, ncol, flwdir, dx, dy, row, col, area, &
-    & max_depth, mask_dln, row_dln, col_dln)
+    & max_depth, mask_dln, row_dln, col_dln, sink_dln)
 
         implicit none
 
@@ -76,10 +86,12 @@ contains
         integer, intent(in) :: max_depth
         integer, dimension(nrow, ncol), intent(out) :: mask_dln
         integer, intent(out) :: col_dln, row_dln
+        logical, intent(out) :: sink_dln
 
         integer, dimension(nrow, ncol) :: mask_dln_imd
         integer :: i, j, row_imd, col_imd
         real(4) :: min_tol, tol
+        logical :: sink_dln_imd
 
         !% Transform from Python to FORTRAN index
         row = row + 1
@@ -94,11 +106,17 @@ contains
                 row_imd = row + j
                 col_imd = col + i
                 mask_dln_imd = 0
+                sink_dln_imd = .false.
 
                 if (row_imd .lt. 1 .or. row_imd .gt. nrow .or. col_imd .lt. 1 .or. col_imd .gt. ncol) cycle
 
                 call mask_upstream_cells(nrow, ncol, flwdir, row_imd, &
-                & col_imd, mask_dln_imd)
+                & col_imd, mask_dln_imd, sink_dln_imd)
+
+                if (sink_dln_imd) then
+                    sink_dln = .true.
+                    cycle
+                end if
 
                 tol = abs(area - sum(mask_dln_imd*dx*dy))/area
 
@@ -336,7 +354,6 @@ contains
 
         integer, dimension(8) :: drow = (/1, 1, 0, -1, -1, -1, 0, 1/)
         integer, dimension(8) :: dcol = (/0, -1, -1, -1, 0, 1, 1, 1/)
-        integer, dimension(8) :: opposite_dir = (/5, 6, 7, 8, 1, 2, 3, 4/)
         integer :: i, j, row_imd, col_imd
 
         do i = 1, 8
@@ -470,34 +487,36 @@ contains
 
     end subroutine flow_partition_variable
 
-    subroutine check_well_in_flwdir(nrow, ncol, flwdir, well)
+    !% This function only check "pair" of cells. A sink can be more than 2 cells ...
+    subroutine detect_sink(nrow, ncol, flwdir, sink)
 
         implicit none
 
         integer, intent(in) :: nrow, ncol
         integer, dimension(nrow, ncol), intent(in) :: flwdir
-        integer, dimension(nrow, ncol), intent(out) :: well
+        integer, dimension(nrow, ncol), intent(out) :: sink
 
-        integer :: i, j, k, row_imd, col_imd
+        integer :: row, col, i, row_imd, col_imd
         integer, dimension(3) :: drow = (/0, 1, 1/)
         integer, dimension(3) :: dcol = (/1, 1, 0/)
         integer, dimension(3) :: dir = (/3, 4, 5/)
         integer, dimension(3) :: opposite_dir = (/7, 8, 1/)
 
-        well = 0
+        sink = 0
 
-        do i = 1, nrow - 1
+        do col = 1, ncol - 1
 
-            do j = 1, ncol - 1
+            do row = 1, nrow - 1
 
-                do k = 1, 3
+                do i = 1, 3
 
-                    row_imd = i + drow(k)
-                    col_imd = j + dcol(k)
+                    row_imd = row + drow(i)
+                    col_imd = col + dcol(i)
 
-                    if (flwdir(row_imd, col_imd) .eq. opposite_dir(k) .and. flwdir(i, j) .eq. dir(k)) then
+                    if (flwdir(row_imd, col_imd) .eq. opposite_dir(i) .and. flwdir(row, col) .eq. dir(i)) then
 
-                        well(i, j) = 1
+                        sink(row, col) = 1
+                        sink(row_imd, col_imd) = 1
 
                     end if
 
@@ -507,6 +526,6 @@ contains
 
         end do
 
-    end subroutine check_well_in_flwdir
+    end subroutine detect_sink
 
 end module mw_mesh

--- a/smash/factory/mesh/mw_mesh.f90
+++ b/smash/factory/mesh/mw_mesh.f90
@@ -54,7 +54,7 @@ contains
 
             row_imd = row + drow(i)
             col_imd = col + dcol(i)
-            
+
             ! % Bounds
             if (row_imd .lt. 1 .or. row_imd .gt. nrow .or. col_imd .lt. 1 .or. col_imd .gt. ncol) cycle
 
@@ -66,7 +66,7 @@ contains
                 sink = .true.
                 return
             end if
-            
+
             call mask_upstream_cells(nrow, ncol, flwdir, row_imd, col_imd, mask, sink)
 
         end do

--- a/smash/fcore/routine/mw_mask.f90
+++ b/smash/fcore/routine/mw_mask.f90
@@ -24,7 +24,6 @@ contains
         integer :: i, row_imd, col_imd
         integer, dimension(8) :: drow = (/1, 1, 0, -1, -1, -1, 0, 1/)
         integer, dimension(8) :: dcol = (/0, -1, -1, -1, 0, 1, 1, 1/)
-        integer, dimension(8) :: opposite_dir = (/5, 6, 7, 8, 1, 2, 3, 4/)
 
         mask(row, col) = .true.
 

--- a/smash/tests/factory/test_mesh.py
+++ b/smash/tests/factory/test_mesh.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pytest
 
@@ -87,3 +89,15 @@ def test_bbox_padding():
 
     assert mesh_roff["xmin"] != mesh["xmin"], "overlap_read_data.uoff_xmin_neq"
     assert mesh_roff["ymax"] != mesh["ymax"], "overlap_read_data.uoff_ymax_neq"
+
+
+def test_detect_sink():
+    flwdir = smash.factory.load_dataset("flwdir")
+
+    sink = smash.factory.detect_sink(flwdir, "./tmp_flwdir_sink.tif")
+
+    # % Check detect_sink - There should be no sinks in the flow direction file
+    assert np.all(sink == 0), "detect_sink.all_zero"
+
+    # % Check detect_sink - A file with sinks should have been created
+    assert os.path.exists("./tmp_flwdir_sink.tif"), "detect_sink.file_exists"


### PR DESCRIPTION
- Add a new fonction `smash.factory.detect_sink` that check for sinks in the flow direction file. It returns an array masking the sinks cells. It can also write a raster file
- Handle warning either for bbox meshing or xy meshing
- Remove sink cells when bbox meshing
- Avoid sink cells when xy meshing
- Fix help for `--tar` argument in `generate_dataset.py`