### PR TITLE
MAINT: Sparse optimize on only one structure

### DIFF
--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -83,7 +83,8 @@ def test_optimize():
 
 
 def test_sparse_optimize():
-    res = generic_optimize(pytest.sparse_model_structure)
+    # % Only test sparse storage optimization on one model structure
+    res = generic_optimize(pytest.sparse_model_structure[0:1])
 
     for key, value in res.items():
         # % Check qsim in sparse storage run


### PR DESCRIPTION
Only test the optimization on sparse data for one structure instead of all. One structure should be sufficient to test this feature.

This should significantly reduce test calculation time