### PR TITLE
Fix missing return lcurve pnd

### DIFF
--- a/doc/source/math_num_documentation/forward_structure.rst
+++ b/doc/source/math_num_documentation/forward_structure.rst
@@ -666,7 +666,7 @@ Hydrological processes can be described at pixel scale in `smash` with one of th
 
         \begin{eqnarray}
             &p_{rr}(x, t)& &=& &0.6 \times 0.9(p_r(x, t) + p_{erc}(x, t)) + l_{exc}(x, t)\\
-            &p_{rl}(x, t)& &=& &0.4 \times 0.9(p_r(x, t) + p_{erc}(x, t)) + l_{exc}(x, t)\\
+            &p_{rl}(x, t)& &=& &0.4 \times 0.9(p_r(x, t) + p_{erc}(x, t)) \\
             &p_{rd}(x, t)& &=& &0.1(p_r(x, t) + p_{erc}(x, t))
         \end{eqnarray}
 

--- a/smash/core/simulation/optimize/optimize.py
+++ b/smash/core/simulation/optimize/optimize.py
@@ -336,7 +336,6 @@ def _optimize_lcurve_wjreg(
         returns,
     )
     jobs_max = returns.jobs
-
     # % Avoid to make a complete copy of model
     wparameters = model._parameters.copy()
     _apply_optimizer(model, wparameters, options, returns, optimize_options, return_options, callback=None)
@@ -380,6 +379,7 @@ def _optimize_lcurve_wjreg(
     distance, wjreg = _get_lcurve_wjreg_best(cost_arr, jobs_arr, jreg_arr, wjreg_arr)
 
     lcurve = {
+        "wjreg_approx": wjreg_fast,
         "wjreg_opt": wjreg,
         "distance": distance,
         "cost": cost_arr,

--- a/smash/fcore/operator/md_gr_operator.f90
+++ b/smash/fcore/operator/md_gr_operator.f90
@@ -1577,7 +1577,7 @@ contains
                 end if
 
                 prr = 0.6_sp*0.9_sp*(pr + perc) + l
-                prl = 0.4_sp*0.9_sp*(pr + perc) + l
+                prl = 0.4_sp*0.9_sp*(pr + perc)
                 prd = 0.1_sp*(pr + perc)
 
                 call gr_transfer(5._sp, ac_prcp(k), prr, ac_ct(k), ac_ht(k), qr)


### PR DESCRIPTION
Fix missing return lcurve pnd: add wjreg_approx in the returned dict to be able to compare both method : fast and complete lcurve
Please add this to the next 1.1 release
Thanks