### PR TITLE
MAINT: Switch to macOS-13 env

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -30,7 +30,7 @@ jobs:
         # Use windows-2019 otherwise there is undefined reference to _setjmpex. This is linked to f90wrap
         # and f90wrap_abort with FortranDerivedTypeArray
         - [windows-2019, win, AMD64]
-        - [macos-12, macosx, x86_64]
+        - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 
         python-version: ['cp39', 'cp310', 'cp311', 'cp312']


### PR DESCRIPTION
Switch to `macOS-13` env as `macOS-12` will be obsolete on 3 December 2024
See https://github.com/actions/runner-images/issues/10721