### PR TITLE
MAINT: upgrade Python version to 3.13

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -27,7 +27,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
-            python-version: "3.12"
+            python-version: "3.13"
 
         - name: Install dependencies
           run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12'
+            python-version: '3.13'
 
         - name: Install dependencies
           run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
           matrix:
-            python-version: ['3.9', '3.10', '3.11', '3.12']
+            python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         steps:
         - uses: actions/checkout@v4
           with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -33,7 +33,7 @@ jobs:
         - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 
-        python-version: ['cp39', 'cp310', 'cp311', 'cp312']
+        python-version: ['cp39', 'cp310', 'cp311', 'cp312', 'cp313']
 
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Derived from Pandas
-FROM python:3.12
+FROM python:3.13
 WORKDIR /home/smash
 
 RUN apt-get update && apt-get -y upgrade

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -9,7 +9,7 @@ Installation
 ------------
 
 `smash` can be installed with pip on **Linux**, **macOS**, **Windows** or from source and supports Python
-versions **3.9** to **3.12**.
+versions **3.9** to **3.13**.
 
 .. note::
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: smash-dev
 channels:
     - conda-forge
 dependencies:
-    - python=3.12
+    - python=3.13
     - pip
 
     # required dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ tag_prefix = "v"
 parentdir_prefix = "smash-"
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-* cp38-* cp313-* pp* *_i686 *_ppc64le *_s390x"
+skip = "cp36-* cp37-* cp38-* pp* *_i686 *_ppc64le *_s390x"
 test-command = 'python -c "import smash; print(smash.__version__)"'
 build-verbosity = 3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3 :: Only',
     'Topic :: Scientific/Engineering',
     'Operating System :: Unix',


### PR DESCRIPTION
Upgrade Python version 3.13 for:
- PyPi project
- Dev envs on Conda, Docker
- Workflows
- Getting started description