### PR TITLE
MAINT: Fix flux correction and Jaco calculation for hybrid gr4_ode_mlp structure

### DIFF
--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -253,7 +253,7 @@ HYDROLOGICAL_MODULE_INOUT_NEURONS = dict(
                 (4, 4),  # % gr4_mlp
                 (0, 0),  # % gr4_ri
                 (0, 0),  # % gr4_ode
-                (4, 5),  # % gr4_ode_mlp
+                (4, 4),  # % gr4_ode_mlp
                 (0, 0),  # % gr5
                 (4, 4),  # % gr5_mlp
                 (0, 0),  # % gr5_ri

--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -14847,9 +14847,10 @@ CONTAINS
       dh(1) = hp - hp0 - dt*fhp
       temp = ht**5
       temp0 = ht**3.5_sp
-      temp1 = 0.9_sp*pn*(hp*hp) - ct*temp + kexc*temp0
-      fht_d = inv_ct*(0.9_sp*(hp**2*pn_d+pn*2*hp*hp_d)-temp*ct_d-(ct*5*&
-&       ht**4-kexc*3.5_sp*ht**2.5)*ht_d+temp0*kexc_d) + temp1*inv_ct_d
+      temp1 = 0.9_sp*pn*(hp*hp) - 0.25_sp*ct*temp + kexc*temp0
+      fht_d = inv_ct*(0.9_sp*(hp**2*pn_d+pn*2*hp*hp_d)-0.25_sp*(temp*&
+&       ct_d+ct*5*ht**4*ht_d)+temp0*kexc_d+kexc*3.5_sp*ht**2.5*ht_d) + &
+&       temp1*inv_ct_d
       fht = temp1*inv_ct
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
@@ -14868,9 +14869,10 @@ CONTAINS
 ! 1 - dt*nabla_ht(fht)
       temp1 = ht**2.5_sp
       temp0 = ht**4
-      temp = 3.5_sp*kexc*temp1 - 5._sp*ct*temp0
+      temp = 3.5_sp*kexc*temp1 - 1.25_sp*ct*temp0
       jacob_d(2, 2) = -(dt*(inv_ct*(3.5_sp*(temp1*kexc_d+kexc*2.5_sp*ht&
-&       **1.5*ht_d)-5._sp*(temp0*ct_d+ct*4*ht**3*ht_d))+temp*inv_ct_d))
+&       **1.5*ht_d)-1.25_sp*(temp0*ct_d+ct*4*ht**3*ht_d))+temp*inv_ct_d)&
+&       )
       jacob(2, 2) = 1._sp - dt*(temp*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -14903,9 +14905,9 @@ CONTAINS
     l_d = temp1*kexc_d + kexc*3.5_sp*ht**2.5*ht_d
     l = kexc*temp1
     temp1 = ht**5
-    q_d = temp1*ct_d + ct*5*ht**4*ht_d + 0.1_sp*(hp**2*pn_d+pn*2*hp*hp_d&
-&     ) + l_d
-    q = ct*temp1 + 0.1_sp*(pn*(hp*hp)) + l
+    q_d = 0.25_sp*(temp1*ct_d+ct*5*ht**4*ht_d) + 0.1_sp*(hp**2*pn_d+pn*2&
+&     *hp*hp_d) + l_d
+    q = 0.25_sp*(ct*temp1) + 0.1_sp*(pn*(hp*hp)) + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_D
 
 !  Differentiation of gr_production_transfer_ode in reverse (adjoint) mode (with options fixinterface noISIZE context):
@@ -14956,7 +14958,7 @@ CONTAINS
       fhp = ((1._sp-hp**2)*pn-hp*(2._sp-hp)*en)*inv_cp
       CALL PUSHREAL4(dh(1))
       dh(1) = hp - hp0 - dt*fhp
-      fht = (0.9_sp*pn*hp**2-ct*ht**5+kexc*ht**3.5_sp)*inv_ct
+      fht = (0.9_sp*pn*hp**2-0.25_sp*ct*ht**5+kexc*ht**3.5_sp)*inv_ct
       CALL PUSHREAL4(dh(2))
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
@@ -14970,8 +14972,8 @@ CONTAINS
       jacob(2, 1) = -(dt*1.8_sp*pn*hp*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-5._sp*ct*ht**4)*&
-&       inv_ct
+      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-1.25_sp*ct*ht**4)&
+&       *inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15009,8 +15011,8 @@ CONTAINS
     END DO
     CALL PUSHINTEGER4(ad_count)
     l_b = q_b
-    ct_b = ct_b + ht**5*q_b
-    ht_b = ht_b + 5*ht**4*ct*q_b + 3.5_sp*ht**2.5*kexc*l_b
+    ct_b = ct_b + ht**5*0.25_sp*q_b
+    ht_b = ht_b + 5*ht**4*ct*0.25_sp*q_b + 3.5_sp*ht**2.5*kexc*l_b
     pn_b = pn_b + hp**2*0.1_sp*q_b
     hp_b = hp_b + 2*hp*pn*0.1_sp*q_b
     kexc_b = kexc_b + ht**3.5_sp*l_b
@@ -15044,7 +15046,7 @@ CONTAINS
       temp0 = ht**2.5_sp
       temp = ht**4
       temp_b0 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (3.5_sp*(kexc*temp0)-5._sp*(ct*temp))*dt*&
+      inv_ct_b = inv_ct_b - (3.5_sp*(kexc*temp0)-1.25_sp*(ct*temp))*dt*&
 &       jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
       CALL POPREAL4(jacob(2, 1))
@@ -15057,17 +15059,18 @@ CONTAINS
       temp1 = ht**3.5_sp
       temp_b = inv_ct*fht_b
       kexc_b = kexc_b + temp0*3.5_sp*temp_b0 + temp1*temp_b
-      ht_b = ht_b + (2.5_sp*ht**1.5*kexc*3.5_sp-4*ht**3*ct*5._sp)*&
-&       temp_b0 + dh_b(2) + (3.5_sp*ht**2.5*kexc-5*ht**4*ct)*temp_b
+      ht_b = ht_b + (2.5_sp*ht**1.5*kexc*3.5_sp-4*ht**3*ct*1.25_sp)*&
+&       temp_b0 + dh_b(2) + (3.5_sp*ht**2.5*kexc-5*ht**4*ct*0.25_sp)*&
+&       temp_b
       dh_b(2) = 0.0_4
       temp0 = ht**5
-      ct_b = ct_b - temp*5._sp*temp_b0 - temp0*temp_b
+      ct_b = ct_b - temp*1.25_sp*temp_b0 - temp0*0.25_sp*temp_b
       temp_b0 = -(dt*1.8_sp*jacob_b(2, 1))
       jacob_b(2, 1) = 0.0_4
       pn_b = pn_b + hp*inv_ct*temp_b0
       hp_b = hp_b + pn*inv_ct*temp_b0
-      inv_ct_b = inv_ct_b + pn*hp*temp_b0 + (0.9_sp*(pn*hp**2)-ct*temp0+&
-&       kexc*temp1)*fht_b
+      inv_ct_b = inv_ct_b + pn*hp*temp_b0 + (0.9_sp*(pn*hp**2)-0.25_sp*(&
+&       ct*temp0)+kexc*temp1)*fht_b
       temp_b0 = dt*2._sp*jacob_b(1, 1)
       jacob_b(1, 1) = 0.0_4
       temp_b1 = inv_cp*temp_b0
@@ -15118,7 +15121,7 @@ CONTAINS
     DO WHILE (.NOT.converged .AND. j .LT. maxiter)
       fhp = ((1._sp-hp**2)*pn-hp*(2._sp-hp)*en)*inv_cp
       dh(1) = hp - hp0 - dt*fhp
-      fht = (0.9_sp*pn*hp**2-ct*ht**5+kexc*ht**3.5_sp)*inv_ct
+      fht = (0.9_sp*pn*hp**2-0.25_sp*ct*ht**5+kexc*ht**3.5_sp)*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       jacob(1, 1) = 1._sp + dt*2._sp*(hp*(pn-en)+en)*inv_cp
@@ -15127,8 +15130,8 @@ CONTAINS
 ! -dt*nabla_hp(fht)
       jacob(2, 1) = -(dt*1.8_sp*pn*hp*inv_ct)
 ! 1 - dt*nabla_ht(fht)
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-5._sp*ct*ht**4)*&
-&       inv_ct
+      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-1.25_sp*ct*ht**4)&
+&       *inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -15142,7 +15145,7 @@ CONTAINS
       j = j + 1
     END DO
     l = kexc*ht**3.5_sp
-    q = ct*ht**5 + 0.1_sp*pn*hp**2 + l
+    q = 0.25_sp*ct*ht**5 + 0.1_sp*pn*hp**2 + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE
 
 !  Differentiation of gr_production_transfer_ode_mlp in forward (tangent) mode (with options fixinterface noISIZE context):
@@ -15214,12 +15217,13 @@ CONTAINS
 ! Range of correction for the three terms: (0, 2)
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp1 = 0.9_sp*(fq(1)+1._sp)*pn*(hp*hp) - (fq(4)+1._sp)*ct*temp0 +&
-&       temp*kexc*(fq(3)+1._sp)
+      temp1 = 0.9_sp*(fq(1)+1._sp)*pn*(hp*hp) - 0.25_sp*(fq(4)+1._sp)*ct&
+&       *temp0 + temp*kexc*(fq(3)+1._sp)
       fht_d = inv_ct*(0.9_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(&
-&       1)+1._sp)*pn*2*hp*hp_d)-temp0*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d)-((&
-&       fq(4)+1._sp)*ct*5*ht**4-kexc*(fq(3)+1._sp)*3.5_sp*ht**2.5)*ht_d+&
-&       temp*((fq(3)+1._sp)*kexc_d+kexc*fq_d(3))) + temp1*inv_ct_d
+&       1)+1._sp)*pn*2*hp*hp_d)-0.25_sp*(temp0*(ct*fq_d(4)+(fq(4)+1._sp)&
+&       *ct_d)+(fq(4)+1._sp)*ct*5*ht**4*ht_d)+kexc*(fq(3)+1._sp)*3.5_sp*&
+&       ht**2.5*ht_d+temp*((fq(3)+1._sp)*kexc_d+kexc*fq_d(3))) + temp1*&
+&       inv_ct_d
       fht = temp1*inv_ct
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
@@ -15246,28 +15250,28 @@ CONTAINS
       temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp2 = 0.9_sp*pn*hp*temp1 - jacobian_nn(4, 1)*ct*temp0 + &
+      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn(4, 1)*ct*temp0 + &
 &       jacobian_nn(3, 1)*kexc*temp
       jacob_d(2, 1) = -(dt*(inv_ct*(0.9_sp*(temp1*(hp*pn_d+pn*hp_d)+pn*&
 &       hp*(2._sp*fq_d(1)+hp*jacobian_nn_d(1, 1)+jacobian_nn(1, 1)*hp_d)&
-&       )-temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)-(&
-&       jacobian_nn(4, 1)*ct*5*ht**4-jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
-&       2.5)*ht_d+temp*(kexc*jacobian_nn_d(3, 1)+jacobian_nn(3, 1)*&
-&       kexc_d))+temp2*inv_ct_d))
+&       )-0.25_sp*(temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)&
+&       +jacobian_nn(4, 1)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_d(3, &
+&       1)+jacobian_nn(3, 1)*kexc_d)+jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
+&       2.5*ht_d)+temp2*inv_ct_d))
       jacob(2, 1) = -(dt*(temp2*inv_ct))
 ! 1 - dt*nabla_ht(fht)
       temp3 = ht**2.5
       temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
       temp1 = ht**4
-      temp0 = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
       temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn(1, 2)*pn*(hp*hp) - &
 &       temp0*ct*temp1
       jacob_d(2, 2) = -(dt*(inv_ct*(temp3*(kexc*(3.5_sp*fq_d(3)+ht*&
 &       jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*ht_d)+temp2*kexc_d)+temp2*&
 &       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_d(1, 2)+&
 &       jacobian_nn(1, 2)*pn_d)+jacobian_nn(1, 2)*pn*2*hp*hp_d)-ct*temp1&
-&       *(5._sp*fq_d(4)+ht*jacobian_nn_d(4, 2)+jacobian_nn(4, 2)*ht_d)-&
-&       temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
+&       *(1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_d(4, 2)+jacobian_nn(4&
+&       , 2)*ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
       jacob(2, 2) = 1._sp - dt*(temp4*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -15304,10 +15308,11 @@ CONTAINS
 ! Range of correction ct: (0, 2)
 ! Range of correction pn: (0, 2)
     temp2 = ht**5
-    q_d = temp2*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d) + (fq(4)+1._sp)*ct*5*ht&
-&     **4*ht_d + 0.1_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(1)+&
-&     1._sp)*pn*2*hp*hp_d) + l_d
-    q = (fq(4)+1._sp)*ct*temp2 + 0.1_sp*((fq(1)+1._sp)*pn*(hp*hp)) + l
+    q_d = 0.25_sp*(temp2*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d)+(fq(4)+1._sp)*&
+&     ct*5*ht**4*ht_d) + 0.1_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(&
+&     fq(1)+1._sp)*pn*2*hp*hp_d) + l_d
+    q = 0.25_sp*((fq(4)+1._sp)*ct*temp2) + 0.1_sp*((fq(1)+1._sp)*pn*(hp*&
+&     hp)) + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D
 
 !  Differentiation of gr_production_transfer_ode_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context):
@@ -15352,9 +15357,11 @@ CONTAINS
     REAL(sp) :: temp2
     REAL(sp) :: temp_b2
     REAL(sp) :: temp3
-    REAL*4 :: temp_b3
-    REAL*4 :: temp4
-    REAL(sp) :: temp_b4
+    REAL(sp) :: temp_b3
+    REAL(sp) :: temp4
+    REAL*4 :: temp_b4
+    REAL*4 :: temp5
+    REAL(sp) :: temp_b5
     INTEGER :: branch
     INTEGER :: ad_count
     INTEGER :: i
@@ -15376,8 +15383,8 @@ CONTAINS
       CALL PUSHREAL4(dh(1))
       dh(1) = hp - hp0 - dt*fhp
 ! Range of correction for the three terms: (0, 2)
-      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
-&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-0.25_sp*(1._sp+fq(4))*ct*ht**&
+&       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       CALL PUSHREAL4(dh(2))
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
@@ -15392,13 +15399,13 @@ CONTAINS
 ! -dt*nabla_hp(fht)
       CALL PUSHREAL4(jacob(2, 1))
       jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
-&       3.5_sp)*inv_ct)
+&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
+&       kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
       jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
-&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15436,18 +15443,18 @@ CONTAINS
     END DO
     CALL PUSHINTEGER4(ad_count)
     l_b = q_b
-    temp_b4 = ht**5*q_b
-    ht_b = ht_b + 5*ht**4*(fq(4)+1._sp)*ct*q_b + 3.5_sp*ht**2.5*(fq(3)+&
-&     1._sp)*kexc*l_b
-    temp_b2 = hp**2*0.1_sp*q_b
+    temp_b5 = ht**5*0.25_sp*q_b
+    ht_b = ht_b + 5*ht**4*(fq(4)+1._sp)*ct*0.25_sp*q_b + 3.5_sp*ht**2.5*&
+&     (fq(3)+1._sp)*kexc*l_b
+    temp_b3 = hp**2*0.1_sp*q_b
     hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.1_sp*q_b
-    fq_b(1) = fq_b(1) + pn*temp_b2
-    pn_b = pn_b + (fq(1)+1._sp)*temp_b2
-    fq_b(4) = fq_b(4) + ct*temp_b4
-    ct_b = ct_b + (fq(4)+1._sp)*temp_b4
-    temp_b4 = ht**3.5_sp*l_b
-    fq_b(3) = fq_b(3) + kexc*temp_b4
-    kexc_b = kexc_b + (fq(3)+1._sp)*temp_b4
+    fq_b(1) = fq_b(1) + pn*temp_b3
+    pn_b = pn_b + (fq(1)+1._sp)*temp_b3
+    fq_b(4) = fq_b(4) + ct*temp_b5
+    ct_b = ct_b + (fq(4)+1._sp)*temp_b5
+    temp_b5 = ht**3.5_sp*l_b
+    fq_b(3) = fq_b(3) + kexc*temp_b5
+    kexc_b = kexc_b + (fq(3)+1._sp)*temp_b5
     dt = 1._sp
     inv_cp = 1._sp/cp
     inv_ct = 1._sp/ct
@@ -15470,109 +15477,111 @@ CONTAINS
       IF (branch .EQ. 0) hp_b = 0.0_4
       CALL POPCONTROL1B(branch)
       IF (branch .EQ. 0) hp_b = 0.0_4
+      temp3 = ht**3.5_sp
+      temp = ht**5
       CALL POPREAL4(hp)
       delta_h_b(1) = delta_h_b(1) + hp_b
       CALL SOLVE_LINEAR_SYSTEM_2VARS_B(jacob, jacob_b, delta_h, &
 &                                delta_h_b, dh, dh_b)
       CALL POPREAL4(jacob(2, 2))
-      temp4 = ht**2.5
-      temp3 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
-      temp1 = ht**4
-      temp0 = ct*temp1
-      temp = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
-      temp_b3 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (temp3*kexc*temp4+0.9_sp*(jacobian_nn(1, 2)*&
-&       pn*hp**2)-temp*temp0)*dt*jacob_b(2, 2)
+      temp5 = ht**2.5
+      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp2 = ht**4
+      temp1 = ct*temp2
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
+      temp_b4 = -(inv_ct*dt*jacob_b(2, 2))
+      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn(1, 2)*&
+&       pn*hp**2)-temp0*temp1)*dt*jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
-      temp_b4 = kexc*temp4*temp_b3
-      kexc_b = kexc_b + temp3*temp4*temp_b3
-      temp_b2 = hp**2*0.9_sp*temp_b3
-      temp_b = -(temp0*temp_b3)
-      ct_b = ct_b - temp1*temp*temp_b3
-      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*temp_b
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b2
-      pn_b = pn_b + jacobian_nn(1, 2)*temp_b2
-      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b4
+      temp_b5 = kexc*temp5*temp_b4
+      kexc_b = kexc_b + temp4*temp5*temp_b4
+      temp_b3 = hp**2*0.9_sp*temp_b4
+      temp_b0 = -(temp1*temp_b4)
+      ct_b = ct_b - temp2*temp0*temp_b4
+      fq_b(4) = fq_b(4) + 1.25_sp*temp_b0
+      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*0.25_sp*temp_b0
+      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b3
+      pn_b = pn_b + jacobian_nn(1, 2)*temp_b3
+      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b5
       CALL POPREAL4(jacob(2, 1))
-      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
-      temp_b2 = -(inv_ct*dt*jacob_b(2, 1))
-      ht_b = ht_b + (2.5*ht**1.5*temp3*kexc-4*ht**3*ct*temp)*temp_b3 + &
-&       jacobian_nn(4, 2)*temp_b + jacobian_nn(3, 2)*temp_b4 + (3.5_sp*&
-&       ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)*ct)*&
-&       temp_b2
-      temp = ht**5
-      temp3 = ht**3.5_sp
-      inv_ct_b = inv_ct_b - (0.9_sp*(pn*hp*temp1)-jacobian_nn(4, 1)*ct*&
-&       temp+jacobian_nn(3, 1)*kexc*temp3)*dt*jacob_b(2, 1)
-      jacob_b(2, 1) = 0.0_4
-      temp_b0 = temp1*0.9_sp*temp_b2
-      temp_b1 = pn*hp*0.9_sp*temp_b2
-      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) - ct*temp*temp_b2
-      ct_b = ct_b - jacobian_nn(4, 1)*temp*temp_b2
-      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp3*temp_b2
-      kexc_b = kexc_b + jacobian_nn(3, 1)*temp3*temp_b2
-      fq_b(1) = fq_b(1) + 2._sp*temp_b1
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b1
+      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp_b3 = -(inv_ct*dt*jacob_b(2, 1))
+      ht_b = ht_b + (2.5*ht**1.5*temp4*kexc-4*ht**3*ct*temp0)*temp_b4 + &
+&       jacobian_nn(4, 2)*0.25_sp*temp_b0 + jacobian_nn(3, 2)*temp_b5 + &
+&       (3.5_sp*ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)&
+&       *ct*0.25_sp)*temp_b3
+      temp0 = ht**5
+      temp4 = ht**3.5_sp
+      temp_b1 = temp2*0.9_sp*temp_b3
+      temp_b2 = pn*hp*0.9_sp*temp_b3
+      temp_b = -(temp0*0.25_sp*temp_b3)
+      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp4*temp_b3
+      kexc_b = kexc_b + jacobian_nn(3, 1)*temp4*temp_b3
+      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) + ct*temp_b
+      fq_b(1) = fq_b(1) + 2._sp*temp_b2
+      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b2
       CALL POPREAL4(jacob(1, 2))
-      temp1 = -(hp*hp) + 1
-      temp0 = en*hp
-      temp = jacobian_nn(2, 2)*(-hp+2._sp)
-      temp_b2 = -(inv_cp*dt*jacob_b(1, 2))
-      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b3 + &
-&       jacobian_nn(1, 1)*temp_b1 + pn*temp_b0 + (jacobian_nn(2, 2)*&
-&       temp0-en*temp-2*hp*pn*jacobian_nn(1, 2))*temp_b2
-      pn_b = pn_b + hp*temp_b0 + jacobian_nn(1, 2)*temp1*temp_b2
-      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp1-temp*temp0)*dt*&
-&       jacob_b(1, 2)
-      jacob_b(1, 2) = 0.0_4
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp1*temp_b2
-      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp0*&
-&       temp_b2
-      en_b = en_b - hp*temp*temp_b2
+      temp1 = en*hp
+      temp_b3 = -(inv_cp*dt*jacob_b(1, 2))
+      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp1*&
+&       temp_b3
       CALL POPREAL4(jacob(1, 1))
-      temp1 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp0 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
-      temp_b2 = -(inv_cp*dt*jacob_b(1, 1))
-      inv_cp_b = inv_cp_b - (pn*temp1-en*temp0)*dt*jacob_b(1, 1)
-      jacob_b(1, 1) = 0.0_4
-      temp_b1 = pn*temp_b2
-      temp_b0 = -(en*temp_b2)
-      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b0
-      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
-&       fq(2)+1._sp)*2._sp)*temp_b0 - (2*hp*jacobian_nn(1, 1)+(fq(1)+&
-&       1._sp)*2._sp)*temp_b1
-      fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b0
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b1
-      fq_b(1) = fq_b(1) - hp*2._sp*temp_b1
       CALL POPREAL4(dh(2))
       ht0_b = ht0_b - dh_b(2)
       fht_b = -(dt*dh_b(2))
-      temp = ht**5
-      temp2 = ht**3.5_sp
+      inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-0.25_sp*((&
+&       fq(4)+1._sp)*ct*temp)+temp3*(kexc*(fq(3)+1._sp)))*fht_b - (&
+&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn(4, 1)*ct*temp0)+&
+&       jacobian_nn(3, 1)*kexc*temp4)*dt*jacob_b(2, 1)
+      jacob_b(2, 1) = 0.0_4
+      temp2 = -(hp*hp) + 1
+      pn_b = pn_b + hp*temp_b1 + jacobian_nn(1, 2)*temp2*temp_b3
+      temp0 = jacobian_nn(2, 2)*(-hp+2._sp)
+      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b4 + &
+&       jacobian_nn(1, 1)*temp_b2 + pn*temp_b1 + (jacobian_nn(2, 2)*&
+&       temp1-en*temp0-2*hp*pn*jacobian_nn(1, 2))*temp_b3
+      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp2-temp0*temp1)*dt*&
+&       jacob_b(1, 2)
+      jacob_b(1, 2) = 0.0_4
+      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp2*temp_b3
+      en_b = en_b - hp*temp0*temp_b3
+      temp2 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp1 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
+&       )+1._sp)
+      temp_b3 = -(inv_cp*dt*jacob_b(1, 1))
+      inv_cp_b = inv_cp_b - (pn*temp2-en*temp1)*dt*jacob_b(1, 1)
+      jacob_b(1, 1) = 0.0_4
+      temp_b2 = pn*temp_b3
+      en_b = en_b - temp1*temp_b3
+      temp_b1 = -(en*temp_b3)
+      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b1
+      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
+&       fq(2)+1._sp)*2._sp)*temp_b1
+      fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b1
+      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b2
       temp_b1 = inv_ct*fht_b
-      fq_b(4) = fq_b(4) + 5._sp*temp_b - ct*temp*temp_b1
-      fq_b(3) = fq_b(3) + 3.5_sp*temp_b4 + kexc*temp2*temp_b1
+      fq_b(3) = fq_b(3) + 3.5_sp*temp_b5 + kexc*temp3*temp_b1
+      hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1 - (2*hp*&
+&       jacobian_nn(1, 1)+(fq(1)+1._sp)*2._sp)*temp_b2
       ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(3)+1._sp)-5*ht**4&
-&       *(fq(4)+1._sp)*ct)*temp_b1
+&       *(fq(4)+1._sp)*ct*0.25_sp)*temp_b1
       dh_b(2) = 0.0_4
-      inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-(fq(4)+&
-&       1._sp)*ct*temp+temp2*(kexc*(fq(3)+1._sp)))*fht_b
       temp_b0 = hp**2*0.9_sp*temp_b1
-      pn_b = pn_b + temp1*temp_b2 + (fq(1)+1._sp)*temp_b0
-      hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1
-      ct_b = ct_b - (fq(4)+1._sp)*temp*temp_b1
-      kexc_b = kexc_b + (fq(3)+1._sp)*temp2*temp_b1
-      fq_b(1) = fq_b(1) + pn*temp_b0
+      pn_b = pn_b + temp2*temp_b3 + (fq(1)+1._sp)*temp_b0
+      fq_b(1) = fq_b(1) + pn*temp_b0 - hp*2._sp*temp_b2
+      temp_b2 = -(temp*0.25_sp*temp_b1)
+      ct_b = ct_b + jacobian_nn(4, 1)*temp_b + (fq(4)+1._sp)*temp_b2
+      kexc_b = kexc_b + (fq(3)+1._sp)*temp3*temp_b1
+      fq_b(4) = fq_b(4) + ct*temp_b2
       CALL POPREAL4(dh(1))
       hp0_b = hp0_b - dh_b(1)
       fhp_b = -(dt*dh_b(1))
       temp1 = (-hp+2._sp)*(fq(2)+1._sp)
       temp_b = inv_cp*fhp_b
-      en_b = en_b - temp0*temp_b2 - hp*temp1*temp_b
       inv_cp_b = inv_cp_b + ((1._sp-hp**2)*(pn*(fq(1)+1._sp))-hp*en*&
 &       temp1)*fhp_b
       temp_b0 = (1._sp-hp**2)*temp_b
+      en_b = en_b - hp*temp1*temp_b
       temp_b1 = -(hp*en*temp_b)
       hp_b = hp_b + dh_b(1) - (2*hp*pn*(fq(1)+1._sp)+en*temp1)*temp_b - &
 &       (fq(2)+1._sp)*temp_b1
@@ -15623,8 +15632,8 @@ CONTAINS
 &       )))*inv_cp
       dh(1) = hp - hp0 - dt*fhp
 ! Range of correction for the three terms: (0, 2)
-      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
-&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-0.25_sp*(1._sp+fq(4))*ct*ht**&
+&       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
@@ -15635,12 +15644,12 @@ CONTAINS
 &       2, 2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
       jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
-&       3.5_sp)*inv_ct)
+&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
+&       kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
-&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -15657,7 +15666,8 @@ CONTAINS
     l = (1._sp+fq(3))*kexc*ht**3.5_sp
 ! Range of correction ct: (0, 2)
 ! Range of correction pn: (0, 2)
-    q = (1._sp+fq(4))*ct*ht**5 + 0.1_sp*(1._sp+fq(1))*pn*hp**2 + l
+    q = 0.25_sp*(1._sp+fq(4))*ct*ht**5 + 0.1_sp*(1._sp+fq(1))*pn*hp**2 +&
+&     l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP
 
 !  Differentiation of gr4_time_step in forward (tangent) mode (with options fixinterface noISIZE context):

--- a/smash/fcore/forward/forward_openmp_db.f90
+++ b/smash/fcore/forward/forward_openmp_db.f90
@@ -15203,8 +15203,8 @@ CONTAINS
 &   ct_d, kexc, kexc_d, hp, hp_d, ht, ht_d, q, q_d, l)
     IMPLICIT NONE
 ! fixed NN output size
-    REAL(sp), DIMENSION(5), INTENT(IN) :: fq
-    REAL(sp), DIMENSION(5), INTENT(IN) :: fq_d
+    REAL(sp), DIMENSION(4), INTENT(IN) :: fq
+    REAL(sp), DIMENSION(4), INTENT(IN) :: fq_d
     INTRINSIC SIZE
 ! fixed NN input size
     REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
@@ -15231,10 +15231,8 @@ CONTAINS
     REAL(sp) :: temp0
     REAL(sp) :: temp1
     REAL(sp) :: temp2
-    REAL(sp) :: temp3
+    REAL*4 :: temp3
     REAL*4 :: temp4
-    REAL*4 :: temp5
-    REAL*4 :: temp6
     inv_cp_d = -(cp_d/cp**2)
     inv_cp = 1._sp/cp
     inv_ct_d = -(ct_d/ct**2)
@@ -15262,70 +15260,64 @@ CONTAINS
       fhp = temp0*inv_cp
       dh_d(1) = hp_d - hp0_d - dt*fhp_d
       dh(1) = hp - hp0 - dt*fhp
-! Range of correction c0.9: (1, 0), for the remaining terms: (0, 2)
-      temp0 = pn*(hp*hp)
-      temp = ht**5
-      temp1 = ht**3.5_sp
-      temp2 = 0.9_sp*(-(fq(3)*fq(3))+1._sp)*temp0 - (fq(5)+1._sp)*ct*&
-&       temp + temp1*kexc*(fq(4)+1._sp)
-      fht_d = inv_ct*(0.9_sp*((1._sp-fq(3)**2)*(hp**2*pn_d+pn*2*hp*hp_d)&
-&       -temp0*2*fq(3)*fq_d(3))-temp*(ct*fq_d(5)+(fq(5)+1._sp)*ct_d)-((&
-&       fq(5)+1._sp)*ct*5*ht**4-kexc*(fq(4)+1._sp)*3.5_sp*ht**2.5)*ht_d+&
-&       temp1*((fq(4)+1._sp)*kexc_d+kexc*fq_d(4))) + temp2*inv_ct_d
-      fht = temp2*inv_ct
+! Range of correction for the three terms: (0, 2)
+      temp0 = ht**5
+      temp = ht**3.5_sp
+      temp1 = 0.9_sp*(fq(1)+1._sp)*pn*(hp*hp) - (fq(4)+1._sp)*ct*temp0 +&
+&       temp*kexc*(fq(3)+1._sp)
+      fht_d = inv_ct*(0.9_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(&
+&       1)+1._sp)*pn*2*hp*hp_d)-temp0*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d)-((&
+&       fq(4)+1._sp)*ct*5*ht**4-kexc*(fq(3)+1._sp)*3.5_sp*ht**2.5)*ht_d+&
+&       temp*((fq(3)+1._sp)*kexc_d+kexc*fq_d(3))) + temp1*inv_ct_d
+      fht = temp1*inv_ct
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
-      temp2 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp1 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
+      temp1 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp0 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
 &       )+1._sp)
-      temp0 = pn*temp2 - en*temp1
-      jacob_d(1, 1) = -(dt*(inv_cp*(temp2*pn_d+pn*((1-hp**2)*&
+      temp = pn*temp1 - en*temp0
+      jacob_d(1, 1) = -(dt*(inv_cp*(temp1*pn_d+pn*((1-hp**2)*&
 &       jacobian_nn_d(1, 1)-jacobian_nn(1, 1)*2*hp*hp_d-2._sp*((fq(1)+&
-&       1._sp)*hp_d+hp*fq_d(1)))-temp1*en_d-en*(hp*(2._sp-hp)*&
+&       1._sp)*hp_d+hp*fq_d(1)))-temp0*en_d-en*(hp*(2._sp-hp)*&
 &       jacobian_nn_d(2, 1)+jacobian_nn(2, 1)*(2._sp-2*hp)*hp_d+2._sp*((&
-&       1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp0*inv_cp_d))
-      jacob(1, 1) = 1._sp - dt*(temp0*inv_cp)
+&       1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp*inv_cp_d))
+      jacob(1, 1) = 1._sp - dt*(temp*inv_cp)
 ! -dt*nabla_ht(fhp)
-      temp2 = jacobian_nn(2, 2)*(-hp+2._sp)
-      temp1 = pn*jacobian_nn(1, 2)*(-(hp*hp)+1) - temp2*en*hp
+      temp1 = jacobian_nn(2, 2)*(-hp+2._sp)
+      temp0 = pn*jacobian_nn(1, 2)*(-(hp*hp)+1) - temp1*en*hp
       jacob_d(1, 2) = -(dt*(inv_cp*((1-hp**2)*(jacobian_nn(1, 2)*pn_d+pn&
 &       *jacobian_nn_d(1, 2))-pn*jacobian_nn(1, 2)*2*hp*hp_d-en*hp*((&
-&       2._sp-hp)*jacobian_nn_d(2, 2)-jacobian_nn(2, 2)*hp_d)-temp2*(hp*&
-&       en_d+en*hp_d))+temp1*inv_cp_d))
-      jacob(1, 2) = -(dt*(temp1*inv_cp))
+&       2._sp-hp)*jacobian_nn_d(2, 2)-jacobian_nn(2, 2)*hp_d)-temp1*(hp*&
+&       en_d+en*hp_d))+temp0*inv_cp_d))
+      jacob(1, 2) = -(dt*(temp0*inv_cp))
 ! -dt*nabla_hp(fht)
-      temp2 = jacobian_nn(3, 1)*fq(3)
-      temp1 = hp*(-(fq(3)*fq(3))+1._sp) - temp2*(hp*hp)
+      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp3 = 1.8_sp*pn*temp1 - jacobian_nn(5, 1)*ct*temp0 + jacobian_nn&
-&       (4, 1)*kexc*temp
-      jacob_d(2, 1) = -(dt*(inv_ct*(1.8_sp*(temp1*pn_d+pn*((1._sp-temp2*&
-&       2*hp-fq(3)**2)*hp_d-hp*2*fq(3)*fq_d(3)-hp**2*(fq(3)*&
-&       jacobian_nn_d(3, 1)+jacobian_nn(3, 1)*fq_d(3))))-temp0*(ct*&
-&       jacobian_nn_d(5, 1)+jacobian_nn(5, 1)*ct_d)-(jacobian_nn(5, 1)*&
-&       ct*5*ht**4-jacobian_nn(4, 1)*kexc*3.5_sp*ht**2.5)*ht_d+temp*(&
-&       kexc*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*kexc_d))+temp3*&
-&       inv_ct_d))
-      jacob(2, 1) = -(dt*(temp3*inv_ct))
+      temp2 = 0.9_sp*pn*hp*temp1 - jacobian_nn(4, 1)*ct*temp0 + &
+&       jacobian_nn(3, 1)*kexc*temp
+      jacob_d(2, 1) = -(dt*(inv_ct*(0.9_sp*(temp1*(hp*pn_d+pn*hp_d)+pn*&
+&       hp*(2._sp*fq_d(1)+hp*jacobian_nn_d(1, 1)+jacobian_nn(1, 1)*hp_d)&
+&       )-temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)-(&
+&       jacobian_nn(4, 1)*ct*5*ht**4-jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
+&       2.5)*ht_d+temp*(kexc*jacobian_nn_d(3, 1)+jacobian_nn(3, 1)*&
+&       kexc_d))+temp2*inv_ct_d))
+      jacob(2, 1) = -(dt*(temp2*inv_ct))
 ! 1 - dt*nabla_ht(fht)
-      temp4 = ht**2.5
-      temp5 = ht**3.5
-      temp3 = jacobian_nn(3, 2)*(hp*hp)
-      temp2 = ht**4
-      temp1 = ht**5
-      temp6 = 3.5_sp*(fq(4)+1._sp)*kexc*temp4 + jacobian_nn(4, 2)*temp5 &
-&       - 1.8_sp*fq(3)*pn*temp3 - 5._sp*(fq(5)+1._sp)*ct*temp2 - &
-&       jacobian_nn(5, 2)*temp1
-      jacob_d(2, 2) = -(dt*(inv_ct*(3.5_sp*(temp4*(kexc*fq_d(4)+(fq(4)+&
-&       1._sp)*kexc_d)+(fq(4)+1._sp)*kexc*2.5*ht**1.5*ht_d)+temp5*&
-&       jacobian_nn_d(4, 2)+(jacobian_nn(4, 2)*3.5*ht**2.5-jacobian_nn(5&
-&       , 2)*5*ht**4)*ht_d-1.8_sp*(temp3*(pn*fq_d(3)+fq(3)*pn_d)+fq(3)*&
-&       pn*(hp**2*jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*2*hp*hp_d))-&
-&       5._sp*(temp2*(ct*fq_d(5)+(fq(5)+1._sp)*ct_d)+(fq(5)+1._sp)*ct*4*&
-&       ht**3*ht_d)-temp1*jacobian_nn_d(5, 2))+temp6*inv_ct_d))
-      jacob(2, 2) = 1._sp - dt*(temp6*inv_ct)
+      temp3 = ht**2.5
+      temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp1 = ht**4
+      temp0 = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
+      temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn(1, 2)*pn*(hp*hp) - &
+&       temp0*ct*temp1
+      jacob_d(2, 2) = -(dt*(inv_ct*(temp3*(kexc*(3.5_sp*fq_d(3)+ht*&
+&       jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*ht_d)+temp2*kexc_d)+temp2*&
+&       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_d(1, 2)+&
+&       jacobian_nn(1, 2)*pn_d)+jacobian_nn(1, 2)*pn*2*hp*hp_d)-ct*temp1&
+&       *(5._sp*fq_d(4)+ht*jacobian_nn_d(4, 2)+jacobian_nn(4, 2)*ht_d)-&
+&       temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
+      jacob(2, 2) = 1._sp - dt*(temp4*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
       hp_d = hp_d + delta_h_d(1)
@@ -15354,20 +15346,17 @@ CONTAINS
       j = j + 1
     END DO
 ! Range of correction kexc: (0, 2)
-    temp3 = ht**3.5_sp
-    l_d = temp3*(kexc*fq_d(4)+(fq(4)+1._sp)*kexc_d) + (fq(4)+1._sp)*kexc&
+    temp2 = ht**3.5_sp
+    l_d = temp2*(kexc*fq_d(3)+(fq(3)+1._sp)*kexc_d) + (fq(3)+1._sp)*kexc&
 &     *3.5_sp*ht**2.5*ht_d
-    l = (fq(4)+1._sp)*kexc*temp3
+    l = (fq(3)+1._sp)*kexc*temp2
 ! Range of correction ct: (0, 2)
-! Range of correction c0.1: (1, 10)
 ! Range of correction pn: (0, 2)
-    temp3 = ht**5
-    temp2 = (fq(1)+1._sp)*pn*(hp*hp)
-    temp1 = 0.9_sp*(fq(3)*fq(3)) + 0.1_sp
-    q_d = temp3*(ct*fq_d(5)+(fq(5)+1._sp)*ct_d) + (fq(5)+1._sp)*ct*5*ht&
-&     **4*ht_d + temp2*0.9_sp*2*fq(3)*fq_d(3) + temp1*(hp**2*(pn*fq_d(1)&
-&     +(fq(1)+1._sp)*pn_d)+(fq(1)+1._sp)*pn*2*hp*hp_d) + l_d
-    q = (fq(5)+1._sp)*ct*temp3 + temp1*temp2 + l
+    temp2 = ht**5
+    q_d = temp2*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d) + (fq(4)+1._sp)*ct*5*ht&
+&     **4*ht_d + 0.1_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(1)+&
+&     1._sp)*pn*2*hp*hp_d) + l_d
+    q = (fq(4)+1._sp)*ct*temp2 + 0.1_sp*((fq(1)+1._sp)*pn*(hp*hp)) + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D
 
 !  Differentiation of gr_production_transfer_ode_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context OpenMP)
@@ -15381,8 +15370,8 @@ CONTAINS
 &   ct_b, kexc, kexc_b, hp, hp_b, ht, ht_b, q, q_b, l)
     IMPLICIT NONE
 ! fixed NN output size
-    REAL(sp), DIMENSION(5), INTENT(IN) :: fq
-    REAL(sp), DIMENSION(5) :: fq_b
+    REAL(sp), DIMENSION(4), INTENT(IN) :: fq
+    REAL(sp), DIMENSION(4) :: fq_b
     INTRINSIC SIZE
 ! fixed NN input size
     REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
@@ -15416,9 +15405,6 @@ CONTAINS
     REAL*4 :: temp_b3
     REAL*4 :: temp4
     REAL(sp) :: temp_b4
-    REAL*4 :: temp5
-    REAL(sp) :: temp6
-    REAL(sp) :: temp_b5
     INTEGER :: branch
     INTEGER :: ad_count
     INTEGER :: i
@@ -15439,9 +15425,9 @@ CONTAINS
 &       )))*inv_cp
       CALL PUSHREAL4(dh(1))
       dh(1) = hp - hp0 - dt*fhp
-! Range of correction c0.9: (1, 0), for the remaining terms: (0, 2)
-      fht = (0.9_sp*(1._sp-fq(3)**2)*pn*hp**2-(1._sp+fq(5))*ct*ht**5+&
-&       kexc*ht**3.5_sp*(1._sp+fq(4)))*inv_ct
+! Range of correction for the three terms: (0, 2)
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
+&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       CALL PUSHREAL4(dh(2))
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
@@ -15455,14 +15441,14 @@ CONTAINS
 &       2, 2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
       CALL PUSHREAL4(jacob(2, 1))
-      jacob(2, 1) = -(dt*(1.8_sp*pn*(hp*(1._sp-fq(3)**2)-jacobian_nn(3, &
-&       1)*fq(3)*hp**2)-jacobian_nn(5, 1)*ct*ht**5+jacobian_nn(4, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
+&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
+&       3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*(1._sp+fq(4))*kexc*ht**2.5+&
-&       jacobian_nn(4, 2)*ht**3.5-1.8_sp*fq(3)*jacobian_nn(3, 2)*pn*hp**&
-&       2-5._sp*(1._sp+fq(5))*ct*ht**4-jacobian_nn(5, 2)*ht**5)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
+&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15500,20 +15486,18 @@ CONTAINS
     END DO
     CALL PUSHINTEGER4(ad_count)
     l_b = q_b
-    temp_b5 = ht**5*q_b
-    ht_b = ht_b + 5*ht**4*(fq(5)+1._sp)*ct*q_b + 3.5_sp*ht**2.5*(fq(4)+&
+    temp_b4 = ht**5*q_b
+    ht_b = ht_b + 5*ht**4*(fq(4)+1._sp)*ct*q_b + 3.5_sp*ht**2.5*(fq(3)+&
 &     1._sp)*kexc*l_b
-    fq_b(3) = fq_b(3) + 2*fq(3)*0.9_sp*(fq(1)+1._sp)*pn*hp**2*q_b
-    temp_b4 = (0.9_sp*fq(3)**2+0.1_sp)*q_b
-    temp_b2 = hp**2*temp_b4
-    hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*temp_b4
+    temp_b2 = hp**2*0.1_sp*q_b
+    hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.1_sp*q_b
     fq_b(1) = fq_b(1) + pn*temp_b2
     pn_b = pn_b + (fq(1)+1._sp)*temp_b2
-    fq_b(5) = fq_b(5) + ct*temp_b5
-    ct_b = ct_b + (fq(5)+1._sp)*temp_b5
-    temp_b5 = ht**3.5_sp*l_b
-    fq_b(4) = fq_b(4) + kexc*temp_b5
-    kexc_b = kexc_b + (fq(4)+1._sp)*temp_b5
+    fq_b(4) = fq_b(4) + ct*temp_b4
+    ct_b = ct_b + (fq(4)+1._sp)*temp_b4
+    temp_b4 = ht**3.5_sp*l_b
+    fq_b(3) = fq_b(3) + kexc*temp_b4
+    kexc_b = kexc_b + (fq(3)+1._sp)*temp_b4
     dt = 1._sp
     inv_cp = 1._sp/cp
     inv_ct = 1._sp/ct
@@ -15542,59 +15526,55 @@ CONTAINS
 &                                delta_h_b, dh, dh_b)
       CALL POPREAL4(jacob(2, 2))
       temp4 = ht**2.5
-      temp5 = ht**3.5
-      temp2 = jacobian_nn(3, 2)*(hp*hp)
-      temp0 = ht**4
-      temp6 = ht**5
+      temp3 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp1 = ht**4
+      temp0 = ct*temp1
+      temp = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
       temp_b3 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (3.5_sp*((fq(4)+1._sp)*kexc*temp4)+&
-&       jacobian_nn(4, 2)*temp5-1.8_sp*(fq(3)*pn*temp2)-5._sp*((fq(5)+&
-&       1._sp)*ct*temp0)-jacobian_nn(5, 2)*temp6)*dt*jacob_b(2, 2)
+      inv_ct_b = inv_ct_b - (temp3*kexc*temp4+0.9_sp*(jacobian_nn(1, 2)*&
+&       pn*hp**2)-temp*temp0)*dt*jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
-      temp_b4 = temp4*3.5_sp*temp_b3
-      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + temp5*temp_b3
-      temp_b1 = -(temp2*1.8_sp*temp_b3)
-      temp_b2 = -(fq(3)*pn*1.8_sp*temp_b3)
-      temp_b = -(temp0*5._sp*temp_b3)
-      jacobian_nn_b(5, 2) = jacobian_nn_b(5, 2) - temp6*temp_b3
-      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + hp**2*temp_b2
-      hp_b = hp_b + 2*hp*jacobian_nn(3, 2)*temp_b2
-      fq_b(3) = fq_b(3) + pn*temp_b1
+      temp_b4 = kexc*temp4*temp_b3
+      kexc_b = kexc_b + temp3*temp4*temp_b3
+      temp_b2 = hp**2*0.9_sp*temp_b3
+      temp_b = -(temp0*temp_b3)
+      ct_b = ct_b - temp1*temp*temp_b3
+      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*temp_b
+      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b2
+      pn_b = pn_b + jacobian_nn(1, 2)*temp_b2
+      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b4
       CALL POPREAL4(jacob(2, 1))
-      temp1 = jacobian_nn(3, 1)*fq(3)
-      temp0 = hp*(-(fq(3)*fq(3))+1._sp) - temp1*(hp*hp)
+      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp_b2 = -(inv_ct*dt*jacob_b(2, 1))
+      ht_b = ht_b + (2.5*ht**1.5*temp3*kexc-4*ht**3*ct*temp)*temp_b3 + &
+&       jacobian_nn(4, 2)*temp_b + jacobian_nn(3, 2)*temp_b4 + (3.5_sp*&
+&       ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)*ct)*&
+&       temp_b2
       temp = ht**5
       temp3 = ht**3.5_sp
-      temp_b2 = -(inv_ct*dt*jacob_b(2, 1))
-      ht_b = ht_b + (2.5*ht**1.5*(fq(4)+1._sp)*kexc*3.5_sp+3.5*ht**2.5*&
-&       jacobian_nn(4, 2)-4*ht**3*(fq(5)+1._sp)*ct*5._sp-5*ht**4*&
-&       jacobian_nn(5, 2))*temp_b3 + (3.5_sp*ht**2.5*jacobian_nn(4, 1)*&
-&       kexc-5*ht**4*jacobian_nn(5, 1)*ct)*temp_b2
-      ct_b = ct_b + (fq(5)+1._sp)*temp_b - jacobian_nn(5, 1)*temp*&
-&       temp_b2
-      pn_b = pn_b + fq(3)*temp_b1 + temp0*1.8_sp*temp_b2
-      kexc_b = kexc_b + (fq(4)+1._sp)*temp_b4 + jacobian_nn(4, 1)*temp3*&
-&       temp_b2
-      inv_ct_b = inv_ct_b - (1.8_sp*(pn*temp0)-jacobian_nn(5, 1)*ct*temp&
-&       +jacobian_nn(4, 1)*kexc*temp3)*dt*jacob_b(2, 1)
+      inv_ct_b = inv_ct_b - (0.9_sp*(pn*hp*temp1)-jacobian_nn(4, 1)*ct*&
+&       temp+jacobian_nn(3, 1)*kexc*temp3)*dt*jacob_b(2, 1)
       jacob_b(2, 1) = 0.0_4
-      temp_b0 = pn*1.8_sp*temp_b2
-      jacobian_nn_b(5, 1) = jacobian_nn_b(5, 1) - ct*temp*temp_b2
-      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) + kexc*temp3*temp_b2
-      temp_b1 = -(hp**2*temp_b0)
-      fq_b(3) = fq_b(3) + jacobian_nn(3, 1)*temp_b1 - 2*fq(3)*hp*temp_b0
-      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + fq(3)*temp_b1
+      temp_b0 = temp1*0.9_sp*temp_b2
+      temp_b1 = pn*hp*0.9_sp*temp_b2
+      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) - ct*temp*temp_b2
+      ct_b = ct_b - jacobian_nn(4, 1)*temp*temp_b2
+      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp3*temp_b2
+      kexc_b = kexc_b + jacobian_nn(3, 1)*temp3*temp_b2
+      fq_b(1) = fq_b(1) + 2._sp*temp_b1
+      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b1
       CALL POPREAL4(jacob(1, 2))
+      temp1 = -(hp*hp) + 1
       temp0 = en*hp
       temp = jacobian_nn(2, 2)*(-hp+2._sp)
       temp_b2 = -(inv_cp*dt*jacob_b(1, 2))
-      hp_b = hp_b + (1._sp-2*hp*temp1-fq(3)**2)*temp_b0 + (jacobian_nn(2&
-&       , 2)*temp0-en*temp-2*hp*pn*jacobian_nn(1, 2))*temp_b2
-      temp1 = -(hp*hp) + 1
+      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b3 + &
+&       jacobian_nn(1, 1)*temp_b1 + pn*temp_b0 + (jacobian_nn(2, 2)*&
+&       temp0-en*temp-2*hp*pn*jacobian_nn(1, 2))*temp_b2
+      pn_b = pn_b + hp*temp_b0 + jacobian_nn(1, 2)*temp1*temp_b2
       inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp1-temp*temp0)*dt*&
 &       jacob_b(1, 2)
       jacob_b(1, 2) = 0.0_4
-      pn_b = pn_b + jacobian_nn(1, 2)*temp1*temp_b2
       jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp1*temp_b2
       jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp0*&
 &       temp_b2
@@ -15621,32 +15601,32 @@ CONTAINS
       temp = ht**5
       temp2 = ht**3.5_sp
       temp_b1 = inv_ct*fht_b
-      fq_b(5) = fq_b(5) + ct*temp_b - ct*temp*temp_b1
-      fq_b(4) = fq_b(4) + kexc*temp_b4 + kexc*temp2*temp_b1
-      ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(4)+1._sp)-5*ht**4&
-&       *(fq(5)+1._sp)*ct)*temp_b1
+      fq_b(4) = fq_b(4) + 5._sp*temp_b - ct*temp*temp_b1
+      fq_b(3) = fq_b(3) + 3.5_sp*temp_b4 + kexc*temp2*temp_b1
+      ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(3)+1._sp)-5*ht**4&
+&       *(fq(4)+1._sp)*ct)*temp_b1
       dh_b(2) = 0.0_4
-      temp_b0 = (1._sp-fq(3)**2)*0.9_sp*temp_b1
-      pn_b = pn_b + temp1*temp_b2 + hp**2*temp_b0
-      ct_b = ct_b - (fq(5)+1._sp)*temp*temp_b1
-      kexc_b = kexc_b + (fq(4)+1._sp)*temp2*temp_b1
+      inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-(fq(4)+&
+&       1._sp)*ct*temp+temp2*(kexc*(fq(3)+1._sp)))*fht_b
+      temp_b0 = hp**2*0.9_sp*temp_b1
+      pn_b = pn_b + temp1*temp_b2 + (fq(1)+1._sp)*temp_b0
+      hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1
+      ct_b = ct_b - (fq(4)+1._sp)*temp*temp_b1
+      kexc_b = kexc_b + (fq(3)+1._sp)*temp2*temp_b1
+      fq_b(1) = fq_b(1) + pn*temp_b0
       CALL POPREAL4(dh(1))
       hp0_b = hp0_b - dh_b(1)
       fhp_b = -(dt*dh_b(1))
       temp1 = (-hp+2._sp)*(fq(2)+1._sp)
       temp_b = inv_cp*fhp_b
       en_b = en_b - temp0*temp_b2 - hp*temp1*temp_b
-      temp0 = pn*(hp*hp)
-      inv_ct_b = inv_ct_b + (0.9_sp*((1._sp-fq(3)**2)*temp0)-(fq(5)+&
-&       1._sp)*ct*temp+temp2*(kexc*(fq(4)+1._sp)))*fht_b
-      fq_b(3) = fq_b(3) - 2*fq(3)*temp0*0.9_sp*temp_b1
       inv_cp_b = inv_cp_b + ((1._sp-hp**2)*(pn*(fq(1)+1._sp))-hp*en*&
 &       temp1)*fhp_b
-      temp_b1 = -(hp*en*temp_b)
-      hp_b = hp_b + 2*hp*pn*temp_b0 + dh_b(1) - (2*hp*pn*(fq(1)+1._sp)+&
-&       en*temp1)*temp_b - (fq(2)+1._sp)*temp_b1
-      dh_b(1) = 0.0_4
       temp_b0 = (1._sp-hp**2)*temp_b
+      temp_b1 = -(hp*en*temp_b)
+      hp_b = hp_b + dh_b(1) - (2*hp*pn*(fq(1)+1._sp)+en*temp1)*temp_b - &
+&       (fq(2)+1._sp)*temp_b1
+      dh_b(1) = 0.0_4
       fq_b(2) = fq_b(2) + (2._sp-hp)*temp_b1
       pn_b = pn_b + (fq(1)+1._sp)*temp_b0
       fq_b(1) = fq_b(1) + pn*temp_b0
@@ -15662,7 +15642,7 @@ CONTAINS
 &   imperviousness, cp, ct, kexc, hp, ht, q, l)
     IMPLICIT NONE
 ! fixed NN output size
-    REAL(sp), DIMENSION(5), INTENT(IN) :: fq
+    REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     INTRINSIC SIZE
 ! fixed NN input size
     REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
@@ -15692,9 +15672,9 @@ CONTAINS
       fhp = ((1._sp-hp**2)*pn*(1._sp+fq(1))-hp*(2._sp-hp)*en*(1._sp+fq(2&
 &       )))*inv_cp
       dh(1) = hp - hp0 - dt*fhp
-! Range of correction c0.9: (1, 0), for the remaining terms: (0, 2)
-      fht = (0.9_sp*(1._sp-fq(3)**2)*pn*hp**2-(1._sp+fq(5))*ct*ht**5+&
-&       kexc*ht**3.5_sp*(1._sp+fq(4)))*inv_ct
+! Range of correction for the three terms: (0, 2)
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
+&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
@@ -15704,13 +15684,13 @@ CONTAINS
       jacob(1, 2) = -(dt*(pn*jacobian_nn(1, 2)*(1-hp**2)-en*jacobian_nn(&
 &       2, 2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
-      jacob(2, 1) = -(dt*(1.8_sp*pn*(hp*(1._sp-fq(3)**2)-jacobian_nn(3, &
-&       1)*fq(3)*hp**2)-jacobian_nn(5, 1)*ct*ht**5+jacobian_nn(4, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
+&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
+&       3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*(1._sp+fq(4))*kexc*ht**2.5+&
-&       jacobian_nn(4, 2)*ht**3.5-1.8_sp*fq(3)*jacobian_nn(3, 2)*pn*hp**&
-&       2-5._sp*(1._sp+fq(5))*ct*ht**4-jacobian_nn(5, 2)*ht**5)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
+&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -15724,12 +15704,10 @@ CONTAINS
       j = j + 1
     END DO
 ! Range of correction kexc: (0, 2)
-    l = (1._sp+fq(4))*kexc*ht**3.5_sp
+    l = (1._sp+fq(3))*kexc*ht**3.5_sp
 ! Range of correction ct: (0, 2)
-! Range of correction c0.1: (1, 10)
 ! Range of correction pn: (0, 2)
-    q = (1._sp+fq(5))*ct*ht**5 + (0.1_sp+0.9_sp*fq(3)**2)*(1._sp+fq(1))*&
-&     pn*hp**2 + l
+    q = (1._sp+fq(4))*ct*ht**5 + 0.1_sp*(1._sp+fq(1))*pn*hp**2 + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP
 
 !  Differentiation of gr4_time_step in forward (tangent) mode (with options fixinterface noISIZE context OpenMP):

--- a/smash/fcore/forward/forward_openmp_db.f90
+++ b/smash/fcore/forward/forward_openmp_db.f90
@@ -14895,9 +14895,10 @@ CONTAINS
       dh(1) = hp - hp0 - dt*fhp
       temp = ht**5
       temp0 = ht**3.5_sp
-      temp1 = 0.9_sp*pn*(hp*hp) - ct*temp + kexc*temp0
-      fht_d = inv_ct*(0.9_sp*(hp**2*pn_d+pn*2*hp*hp_d)-temp*ct_d-(ct*5*&
-&       ht**4-kexc*3.5_sp*ht**2.5)*ht_d+temp0*kexc_d) + temp1*inv_ct_d
+      temp1 = 0.9_sp*pn*(hp*hp) - 0.25_sp*ct*temp + kexc*temp0
+      fht_d = inv_ct*(0.9_sp*(hp**2*pn_d+pn*2*hp*hp_d)-0.25_sp*(temp*&
+&       ct_d+ct*5*ht**4*ht_d)+temp0*kexc_d+kexc*3.5_sp*ht**2.5*ht_d) + &
+&       temp1*inv_ct_d
       fht = temp1*inv_ct
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
@@ -14916,9 +14917,10 @@ CONTAINS
 ! 1 - dt*nabla_ht(fht)
       temp1 = ht**2.5_sp
       temp0 = ht**4
-      temp = 3.5_sp*kexc*temp1 - 5._sp*ct*temp0
+      temp = 3.5_sp*kexc*temp1 - 1.25_sp*ct*temp0
       jacob_d(2, 2) = -(dt*(inv_ct*(3.5_sp*(temp1*kexc_d+kexc*2.5_sp*ht&
-&       **1.5*ht_d)-5._sp*(temp0*ct_d+ct*4*ht**3*ht_d))+temp*inv_ct_d))
+&       **1.5*ht_d)-1.25_sp*(temp0*ct_d+ct*4*ht**3*ht_d))+temp*inv_ct_d)&
+&       )
       jacob(2, 2) = 1._sp - dt*(temp*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -14951,9 +14953,9 @@ CONTAINS
     l_d = temp1*kexc_d + kexc*3.5_sp*ht**2.5*ht_d
     l = kexc*temp1
     temp1 = ht**5
-    q_d = temp1*ct_d + ct*5*ht**4*ht_d + 0.1_sp*(hp**2*pn_d+pn*2*hp*hp_d&
-&     ) + l_d
-    q = ct*temp1 + 0.1_sp*(pn*(hp*hp)) + l
+    q_d = 0.25_sp*(temp1*ct_d+ct*5*ht**4*ht_d) + 0.1_sp*(hp**2*pn_d+pn*2&
+&     *hp*hp_d) + l_d
+    q = 0.25_sp*(ct*temp1) + 0.1_sp*(pn*(hp*hp)) + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_D
 
 !  Differentiation of gr_production_transfer_ode in reverse (adjoint) mode (with options fixinterface noISIZE context OpenMP):
@@ -15004,7 +15006,7 @@ CONTAINS
       fhp = ((1._sp-hp**2)*pn-hp*(2._sp-hp)*en)*inv_cp
       CALL PUSHREAL4(dh(1))
       dh(1) = hp - hp0 - dt*fhp
-      fht = (0.9_sp*pn*hp**2-ct*ht**5+kexc*ht**3.5_sp)*inv_ct
+      fht = (0.9_sp*pn*hp**2-0.25_sp*ct*ht**5+kexc*ht**3.5_sp)*inv_ct
       CALL PUSHREAL4(dh(2))
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
@@ -15018,8 +15020,8 @@ CONTAINS
       jacob(2, 1) = -(dt*1.8_sp*pn*hp*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-5._sp*ct*ht**4)*&
-&       inv_ct
+      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-1.25_sp*ct*ht**4)&
+&       *inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15057,8 +15059,8 @@ CONTAINS
     END DO
     CALL PUSHINTEGER4(ad_count)
     l_b = q_b
-    ct_b = ct_b + ht**5*q_b
-    ht_b = ht_b + 5*ht**4*ct*q_b + 3.5_sp*ht**2.5*kexc*l_b
+    ct_b = ct_b + ht**5*0.25_sp*q_b
+    ht_b = ht_b + 5*ht**4*ct*0.25_sp*q_b + 3.5_sp*ht**2.5*kexc*l_b
     pn_b = pn_b + hp**2*0.1_sp*q_b
     hp_b = hp_b + 2*hp*pn*0.1_sp*q_b
     kexc_b = kexc_b + ht**3.5_sp*l_b
@@ -15092,7 +15094,7 @@ CONTAINS
       temp0 = ht**2.5_sp
       temp = ht**4
       temp_b0 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (3.5_sp*(kexc*temp0)-5._sp*(ct*temp))*dt*&
+      inv_ct_b = inv_ct_b - (3.5_sp*(kexc*temp0)-1.25_sp*(ct*temp))*dt*&
 &       jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
       CALL POPREAL4(jacob(2, 1))
@@ -15105,17 +15107,18 @@ CONTAINS
       temp1 = ht**3.5_sp
       temp_b = inv_ct*fht_b
       kexc_b = kexc_b + temp0*3.5_sp*temp_b0 + temp1*temp_b
-      ht_b = ht_b + (2.5_sp*ht**1.5*kexc*3.5_sp-4*ht**3*ct*5._sp)*&
-&       temp_b0 + dh_b(2) + (3.5_sp*ht**2.5*kexc-5*ht**4*ct)*temp_b
+      ht_b = ht_b + (2.5_sp*ht**1.5*kexc*3.5_sp-4*ht**3*ct*1.25_sp)*&
+&       temp_b0 + dh_b(2) + (3.5_sp*ht**2.5*kexc-5*ht**4*ct*0.25_sp)*&
+&       temp_b
       dh_b(2) = 0.0_4
       temp0 = ht**5
-      ct_b = ct_b - temp*5._sp*temp_b0 - temp0*temp_b
+      ct_b = ct_b - temp*1.25_sp*temp_b0 - temp0*0.25_sp*temp_b
       temp_b0 = -(dt*1.8_sp*jacob_b(2, 1))
       jacob_b(2, 1) = 0.0_4
       pn_b = pn_b + hp*inv_ct*temp_b0
       hp_b = hp_b + pn*inv_ct*temp_b0
-      inv_ct_b = inv_ct_b + pn*hp*temp_b0 + (0.9_sp*(pn*hp**2)-ct*temp0+&
-&       kexc*temp1)*fht_b
+      inv_ct_b = inv_ct_b + pn*hp*temp_b0 + (0.9_sp*(pn*hp**2)-0.25_sp*(&
+&       ct*temp0)+kexc*temp1)*fht_b
       temp_b0 = dt*2._sp*jacob_b(1, 1)
       jacob_b(1, 1) = 0.0_4
       temp_b1 = inv_cp*temp_b0
@@ -15166,7 +15169,7 @@ CONTAINS
     DO WHILE (.NOT.converged .AND. j .LT. maxiter)
       fhp = ((1._sp-hp**2)*pn-hp*(2._sp-hp)*en)*inv_cp
       dh(1) = hp - hp0 - dt*fhp
-      fht = (0.9_sp*pn*hp**2-ct*ht**5+kexc*ht**3.5_sp)*inv_ct
+      fht = (0.9_sp*pn*hp**2-0.25_sp*ct*ht**5+kexc*ht**3.5_sp)*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       jacob(1, 1) = 1._sp + dt*2._sp*(hp*(pn-en)+en)*inv_cp
@@ -15175,8 +15178,8 @@ CONTAINS
 ! -dt*nabla_hp(fht)
       jacob(2, 1) = -(dt*1.8_sp*pn*hp*inv_ct)
 ! 1 - dt*nabla_ht(fht)
-      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-5._sp*ct*ht**4)*&
-&       inv_ct
+      jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*ht**2.5_sp-1.25_sp*ct*ht**4)&
+&       *inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -15190,7 +15193,7 @@ CONTAINS
       j = j + 1
     END DO
     l = kexc*ht**3.5_sp
-    q = ct*ht**5 + 0.1_sp*pn*hp**2 + l
+    q = 0.25_sp*ct*ht**5 + 0.1_sp*pn*hp**2 + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE
 
 !  Differentiation of gr_production_transfer_ode_mlp in forward (tangent) mode (with options fixinterface noISIZE context OpenMP)
@@ -15263,12 +15266,13 @@ CONTAINS
 ! Range of correction for the three terms: (0, 2)
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp1 = 0.9_sp*(fq(1)+1._sp)*pn*(hp*hp) - (fq(4)+1._sp)*ct*temp0 +&
-&       temp*kexc*(fq(3)+1._sp)
+      temp1 = 0.9_sp*(fq(1)+1._sp)*pn*(hp*hp) - 0.25_sp*(fq(4)+1._sp)*ct&
+&       *temp0 + temp*kexc*(fq(3)+1._sp)
       fht_d = inv_ct*(0.9_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(&
-&       1)+1._sp)*pn*2*hp*hp_d)-temp0*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d)-((&
-&       fq(4)+1._sp)*ct*5*ht**4-kexc*(fq(3)+1._sp)*3.5_sp*ht**2.5)*ht_d+&
-&       temp*((fq(3)+1._sp)*kexc_d+kexc*fq_d(3))) + temp1*inv_ct_d
+&       1)+1._sp)*pn*2*hp*hp_d)-0.25_sp*(temp0*(ct*fq_d(4)+(fq(4)+1._sp)&
+&       *ct_d)+(fq(4)+1._sp)*ct*5*ht**4*ht_d)+kexc*(fq(3)+1._sp)*3.5_sp*&
+&       ht**2.5*ht_d+temp*((fq(3)+1._sp)*kexc_d+kexc*fq_d(3))) + temp1*&
+&       inv_ct_d
       fht = temp1*inv_ct
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
@@ -15295,28 +15299,28 @@ CONTAINS
       temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp2 = 0.9_sp*pn*hp*temp1 - jacobian_nn(4, 1)*ct*temp0 + &
+      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn(4, 1)*ct*temp0 + &
 &       jacobian_nn(3, 1)*kexc*temp
       jacob_d(2, 1) = -(dt*(inv_ct*(0.9_sp*(temp1*(hp*pn_d+pn*hp_d)+pn*&
 &       hp*(2._sp*fq_d(1)+hp*jacobian_nn_d(1, 1)+jacobian_nn(1, 1)*hp_d)&
-&       )-temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)-(&
-&       jacobian_nn(4, 1)*ct*5*ht**4-jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
-&       2.5)*ht_d+temp*(kexc*jacobian_nn_d(3, 1)+jacobian_nn(3, 1)*&
-&       kexc_d))+temp2*inv_ct_d))
+&       )-0.25_sp*(temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)&
+&       +jacobian_nn(4, 1)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_d(3, &
+&       1)+jacobian_nn(3, 1)*kexc_d)+jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
+&       2.5*ht_d)+temp2*inv_ct_d))
       jacob(2, 1) = -(dt*(temp2*inv_ct))
 ! 1 - dt*nabla_ht(fht)
       temp3 = ht**2.5
       temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
       temp1 = ht**4
-      temp0 = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
       temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn(1, 2)*pn*(hp*hp) - &
 &       temp0*ct*temp1
       jacob_d(2, 2) = -(dt*(inv_ct*(temp3*(kexc*(3.5_sp*fq_d(3)+ht*&
 &       jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*ht_d)+temp2*kexc_d)+temp2*&
 &       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_d(1, 2)+&
 &       jacobian_nn(1, 2)*pn_d)+jacobian_nn(1, 2)*pn*2*hp*hp_d)-ct*temp1&
-&       *(5._sp*fq_d(4)+ht*jacobian_nn_d(4, 2)+jacobian_nn(4, 2)*ht_d)-&
-&       temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
+&       *(1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_d(4, 2)+jacobian_nn(4&
+&       , 2)*ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
       jacob(2, 2) = 1._sp - dt*(temp4*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -15353,10 +15357,11 @@ CONTAINS
 ! Range of correction ct: (0, 2)
 ! Range of correction pn: (0, 2)
     temp2 = ht**5
-    q_d = temp2*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d) + (fq(4)+1._sp)*ct*5*ht&
-&     **4*ht_d + 0.1_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(fq(1)+&
-&     1._sp)*pn*2*hp*hp_d) + l_d
-    q = (fq(4)+1._sp)*ct*temp2 + 0.1_sp*((fq(1)+1._sp)*pn*(hp*hp)) + l
+    q_d = 0.25_sp*(temp2*(ct*fq_d(4)+(fq(4)+1._sp)*ct_d)+(fq(4)+1._sp)*&
+&     ct*5*ht**4*ht_d) + 0.1_sp*(hp**2*(pn*fq_d(1)+(fq(1)+1._sp)*pn_d)+(&
+&     fq(1)+1._sp)*pn*2*hp*hp_d) + l_d
+    q = 0.25_sp*((fq(4)+1._sp)*ct*temp2) + 0.1_sp*((fq(1)+1._sp)*pn*(hp*&
+&     hp)) + l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D
 
 !  Differentiation of gr_production_transfer_ode_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context OpenMP)
@@ -15402,9 +15407,11 @@ CONTAINS
     REAL(sp) :: temp2
     REAL(sp) :: temp_b2
     REAL(sp) :: temp3
-    REAL*4 :: temp_b3
-    REAL*4 :: temp4
-    REAL(sp) :: temp_b4
+    REAL(sp) :: temp_b3
+    REAL(sp) :: temp4
+    REAL*4 :: temp_b4
+    REAL*4 :: temp5
+    REAL(sp) :: temp_b5
     INTEGER :: branch
     INTEGER :: ad_count
     INTEGER :: i
@@ -15426,8 +15433,8 @@ CONTAINS
       CALL PUSHREAL4(dh(1))
       dh(1) = hp - hp0 - dt*fhp
 ! Range of correction for the three terms: (0, 2)
-      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
-&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-0.25_sp*(1._sp+fq(4))*ct*ht**&
+&       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       CALL PUSHREAL4(dh(2))
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
@@ -15442,13 +15449,13 @@ CONTAINS
 ! -dt*nabla_hp(fht)
       CALL PUSHREAL4(jacob(2, 1))
       jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
-&       3.5_sp)*inv_ct)
+&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
+&       kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
       jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
-&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15486,18 +15493,18 @@ CONTAINS
     END DO
     CALL PUSHINTEGER4(ad_count)
     l_b = q_b
-    temp_b4 = ht**5*q_b
-    ht_b = ht_b + 5*ht**4*(fq(4)+1._sp)*ct*q_b + 3.5_sp*ht**2.5*(fq(3)+&
-&     1._sp)*kexc*l_b
-    temp_b2 = hp**2*0.1_sp*q_b
+    temp_b5 = ht**5*0.25_sp*q_b
+    ht_b = ht_b + 5*ht**4*(fq(4)+1._sp)*ct*0.25_sp*q_b + 3.5_sp*ht**2.5*&
+&     (fq(3)+1._sp)*kexc*l_b
+    temp_b3 = hp**2*0.1_sp*q_b
     hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.1_sp*q_b
-    fq_b(1) = fq_b(1) + pn*temp_b2
-    pn_b = pn_b + (fq(1)+1._sp)*temp_b2
-    fq_b(4) = fq_b(4) + ct*temp_b4
-    ct_b = ct_b + (fq(4)+1._sp)*temp_b4
-    temp_b4 = ht**3.5_sp*l_b
-    fq_b(3) = fq_b(3) + kexc*temp_b4
-    kexc_b = kexc_b + (fq(3)+1._sp)*temp_b4
+    fq_b(1) = fq_b(1) + pn*temp_b3
+    pn_b = pn_b + (fq(1)+1._sp)*temp_b3
+    fq_b(4) = fq_b(4) + ct*temp_b5
+    ct_b = ct_b + (fq(4)+1._sp)*temp_b5
+    temp_b5 = ht**3.5_sp*l_b
+    fq_b(3) = fq_b(3) + kexc*temp_b5
+    kexc_b = kexc_b + (fq(3)+1._sp)*temp_b5
     dt = 1._sp
     inv_cp = 1._sp/cp
     inv_ct = 1._sp/ct
@@ -15520,109 +15527,111 @@ CONTAINS
       IF (branch .EQ. 0) hp_b = 0.0_4
       CALL POPCONTROL1B(branch)
       IF (branch .EQ. 0) hp_b = 0.0_4
+      temp3 = ht**3.5_sp
+      temp = ht**5
       CALL POPREAL4(hp)
       delta_h_b(1) = delta_h_b(1) + hp_b
       CALL SOLVE_LINEAR_SYSTEM_2VARS_B(jacob, jacob_b, delta_h, &
 &                                delta_h_b, dh, dh_b)
       CALL POPREAL4(jacob(2, 2))
-      temp4 = ht**2.5
-      temp3 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
-      temp1 = ht**4
-      temp0 = ct*temp1
-      temp = 5._sp*(fq(4)+1._sp) + jacobian_nn(4, 2)*ht
-      temp_b3 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (temp3*kexc*temp4+0.9_sp*(jacobian_nn(1, 2)*&
-&       pn*hp**2)-temp*temp0)*dt*jacob_b(2, 2)
+      temp5 = ht**2.5
+      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp2 = ht**4
+      temp1 = ct*temp2
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
+      temp_b4 = -(inv_ct*dt*jacob_b(2, 2))
+      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn(1, 2)*&
+&       pn*hp**2)-temp0*temp1)*dt*jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
-      temp_b4 = kexc*temp4*temp_b3
-      kexc_b = kexc_b + temp3*temp4*temp_b3
-      temp_b2 = hp**2*0.9_sp*temp_b3
-      temp_b = -(temp0*temp_b3)
-      ct_b = ct_b - temp1*temp*temp_b3
-      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*temp_b
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b2
-      pn_b = pn_b + jacobian_nn(1, 2)*temp_b2
-      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b4
+      temp_b5 = kexc*temp5*temp_b4
+      kexc_b = kexc_b + temp4*temp5*temp_b4
+      temp_b3 = hp**2*0.9_sp*temp_b4
+      temp_b0 = -(temp1*temp_b4)
+      ct_b = ct_b - temp2*temp0*temp_b4
+      fq_b(4) = fq_b(4) + 1.25_sp*temp_b0
+      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*0.25_sp*temp_b0
+      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b3
+      pn_b = pn_b + jacobian_nn(1, 2)*temp_b3
+      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b5
       CALL POPREAL4(jacob(2, 1))
-      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
-      temp_b2 = -(inv_ct*dt*jacob_b(2, 1))
-      ht_b = ht_b + (2.5*ht**1.5*temp3*kexc-4*ht**3*ct*temp)*temp_b3 + &
-&       jacobian_nn(4, 2)*temp_b + jacobian_nn(3, 2)*temp_b4 + (3.5_sp*&
-&       ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)*ct)*&
-&       temp_b2
-      temp = ht**5
-      temp3 = ht**3.5_sp
-      inv_ct_b = inv_ct_b - (0.9_sp*(pn*hp*temp1)-jacobian_nn(4, 1)*ct*&
-&       temp+jacobian_nn(3, 1)*kexc*temp3)*dt*jacob_b(2, 1)
-      jacob_b(2, 1) = 0.0_4
-      temp_b0 = temp1*0.9_sp*temp_b2
-      temp_b1 = pn*hp*0.9_sp*temp_b2
-      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) - ct*temp*temp_b2
-      ct_b = ct_b - jacobian_nn(4, 1)*temp*temp_b2
-      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp3*temp_b2
-      kexc_b = kexc_b + jacobian_nn(3, 1)*temp3*temp_b2
-      fq_b(1) = fq_b(1) + 2._sp*temp_b1
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b1
+      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp_b3 = -(inv_ct*dt*jacob_b(2, 1))
+      ht_b = ht_b + (2.5*ht**1.5*temp4*kexc-4*ht**3*ct*temp0)*temp_b4 + &
+&       jacobian_nn(4, 2)*0.25_sp*temp_b0 + jacobian_nn(3, 2)*temp_b5 + &
+&       (3.5_sp*ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)&
+&       *ct*0.25_sp)*temp_b3
+      temp0 = ht**5
+      temp4 = ht**3.5_sp
+      temp_b1 = temp2*0.9_sp*temp_b3
+      temp_b2 = pn*hp*0.9_sp*temp_b3
+      temp_b = -(temp0*0.25_sp*temp_b3)
+      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp4*temp_b3
+      kexc_b = kexc_b + jacobian_nn(3, 1)*temp4*temp_b3
+      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) + ct*temp_b
+      fq_b(1) = fq_b(1) + 2._sp*temp_b2
+      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b2
       CALL POPREAL4(jacob(1, 2))
-      temp1 = -(hp*hp) + 1
-      temp0 = en*hp
-      temp = jacobian_nn(2, 2)*(-hp+2._sp)
-      temp_b2 = -(inv_cp*dt*jacob_b(1, 2))
-      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b3 + &
-&       jacobian_nn(1, 1)*temp_b1 + pn*temp_b0 + (jacobian_nn(2, 2)*&
-&       temp0-en*temp-2*hp*pn*jacobian_nn(1, 2))*temp_b2
-      pn_b = pn_b + hp*temp_b0 + jacobian_nn(1, 2)*temp1*temp_b2
-      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp1-temp*temp0)*dt*&
-&       jacob_b(1, 2)
-      jacob_b(1, 2) = 0.0_4
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp1*temp_b2
-      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp0*&
-&       temp_b2
-      en_b = en_b - hp*temp*temp_b2
+      temp1 = en*hp
+      temp_b3 = -(inv_cp*dt*jacob_b(1, 2))
+      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp1*&
+&       temp_b3
       CALL POPREAL4(jacob(1, 1))
-      temp1 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp0 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
-      temp_b2 = -(inv_cp*dt*jacob_b(1, 1))
-      inv_cp_b = inv_cp_b - (pn*temp1-en*temp0)*dt*jacob_b(1, 1)
-      jacob_b(1, 1) = 0.0_4
-      temp_b1 = pn*temp_b2
-      temp_b0 = -(en*temp_b2)
-      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b0
-      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
-&       fq(2)+1._sp)*2._sp)*temp_b0 - (2*hp*jacobian_nn(1, 1)+(fq(1)+&
-&       1._sp)*2._sp)*temp_b1
-      fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b0
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b1
-      fq_b(1) = fq_b(1) - hp*2._sp*temp_b1
       CALL POPREAL4(dh(2))
       ht0_b = ht0_b - dh_b(2)
       fht_b = -(dt*dh_b(2))
-      temp = ht**5
-      temp2 = ht**3.5_sp
+      inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-0.25_sp*((&
+&       fq(4)+1._sp)*ct*temp)+temp3*(kexc*(fq(3)+1._sp)))*fht_b - (&
+&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn(4, 1)*ct*temp0)+&
+&       jacobian_nn(3, 1)*kexc*temp4)*dt*jacob_b(2, 1)
+      jacob_b(2, 1) = 0.0_4
+      temp2 = -(hp*hp) + 1
+      pn_b = pn_b + hp*temp_b1 + jacobian_nn(1, 2)*temp2*temp_b3
+      temp0 = jacobian_nn(2, 2)*(-hp+2._sp)
+      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b4 + &
+&       jacobian_nn(1, 1)*temp_b2 + pn*temp_b1 + (jacobian_nn(2, 2)*&
+&       temp1-en*temp0-2*hp*pn*jacobian_nn(1, 2))*temp_b3
+      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp2-temp0*temp1)*dt*&
+&       jacob_b(1, 2)
+      jacob_b(1, 2) = 0.0_4
+      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp2*temp_b3
+      en_b = en_b - hp*temp0*temp_b3
+      temp2 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp1 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
+&       )+1._sp)
+      temp_b3 = -(inv_cp*dt*jacob_b(1, 1))
+      inv_cp_b = inv_cp_b - (pn*temp2-en*temp1)*dt*jacob_b(1, 1)
+      jacob_b(1, 1) = 0.0_4
+      temp_b2 = pn*temp_b3
+      en_b = en_b - temp1*temp_b3
+      temp_b1 = -(en*temp_b3)
+      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b1
+      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
+&       fq(2)+1._sp)*2._sp)*temp_b1
+      fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b1
+      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b2
       temp_b1 = inv_ct*fht_b
-      fq_b(4) = fq_b(4) + 5._sp*temp_b - ct*temp*temp_b1
-      fq_b(3) = fq_b(3) + 3.5_sp*temp_b4 + kexc*temp2*temp_b1
+      fq_b(3) = fq_b(3) + 3.5_sp*temp_b5 + kexc*temp3*temp_b1
+      hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1 - (2*hp*&
+&       jacobian_nn(1, 1)+(fq(1)+1._sp)*2._sp)*temp_b2
       ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(3)+1._sp)-5*ht**4&
-&       *(fq(4)+1._sp)*ct)*temp_b1
+&       *(fq(4)+1._sp)*ct*0.25_sp)*temp_b1
       dh_b(2) = 0.0_4
-      inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-(fq(4)+&
-&       1._sp)*ct*temp+temp2*(kexc*(fq(3)+1._sp)))*fht_b
       temp_b0 = hp**2*0.9_sp*temp_b1
-      pn_b = pn_b + temp1*temp_b2 + (fq(1)+1._sp)*temp_b0
-      hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1
-      ct_b = ct_b - (fq(4)+1._sp)*temp*temp_b1
-      kexc_b = kexc_b + (fq(3)+1._sp)*temp2*temp_b1
-      fq_b(1) = fq_b(1) + pn*temp_b0
+      pn_b = pn_b + temp2*temp_b3 + (fq(1)+1._sp)*temp_b0
+      fq_b(1) = fq_b(1) + pn*temp_b0 - hp*2._sp*temp_b2
+      temp_b2 = -(temp*0.25_sp*temp_b1)
+      ct_b = ct_b + jacobian_nn(4, 1)*temp_b + (fq(4)+1._sp)*temp_b2
+      kexc_b = kexc_b + (fq(3)+1._sp)*temp3*temp_b1
+      fq_b(4) = fq_b(4) + ct*temp_b2
       CALL POPREAL4(dh(1))
       hp0_b = hp0_b - dh_b(1)
       fhp_b = -(dt*dh_b(1))
       temp1 = (-hp+2._sp)*(fq(2)+1._sp)
       temp_b = inv_cp*fhp_b
-      en_b = en_b - temp0*temp_b2 - hp*temp1*temp_b
       inv_cp_b = inv_cp_b + ((1._sp-hp**2)*(pn*(fq(1)+1._sp))-hp*en*&
 &       temp1)*fhp_b
       temp_b0 = (1._sp-hp**2)*temp_b
+      en_b = en_b - hp*temp1*temp_b
       temp_b1 = -(hp*en*temp_b)
       hp_b = hp_b + dh_b(1) - (2*hp*pn*(fq(1)+1._sp)+en*temp1)*temp_b - &
 &       (fq(2)+1._sp)*temp_b1
@@ -15673,8 +15682,8 @@ CONTAINS
 &       )))*inv_cp
       dh(1) = hp - hp0 - dt*fhp
 ! Range of correction for the three terms: (0, 2)
-      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-(1._sp+fq(4))*ct*ht**5+kexc*&
-&       ht**3.5_sp*(1._sp+fq(3)))*inv_ct
+      fht = (0.9_sp*(1._sp+fq(1))*pn*hp**2-0.25_sp*(1._sp+fq(4))*ct*ht**&
+&       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
@@ -15685,12 +15694,12 @@ CONTAINS
 &       2, 2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
       jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*kexc*ht**&
-&       3.5_sp)*inv_ct)
+&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
+&       kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(5._sp*(1._sp&
-&       +fq(4))+jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -15707,7 +15716,8 @@ CONTAINS
     l = (1._sp+fq(3))*kexc*ht**3.5_sp
 ! Range of correction ct: (0, 2)
 ! Range of correction pn: (0, 2)
-    q = (1._sp+fq(4))*ct*ht**5 + 0.1_sp*(1._sp+fq(1))*pn*hp**2 + l
+    q = 0.25_sp*(1._sp+fq(4))*ct*ht**5 + 0.1_sp*(1._sp+fq(1))*pn*hp**2 +&
+&     l
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP
 
 !  Differentiation of gr4_time_step in forward (tangent) mode (with options fixinterface noISIZE context OpenMP):

--- a/smash/fcore/operator/md_gr_operator.f90
+++ b/smash/fcore/operator/md_gr_operator.f90
@@ -259,13 +259,13 @@ contains
             fhp = ((1._sp - hp**2)*pn - hp*(2._sp - hp)*en)*inv_cp
             dh(1) = hp - hp0 - dt*fhp
 
-            fht = (0.9_sp*pn*hp**2 - ct*ht**5 + kexc*ht**3.5_sp)*inv_ct
+            fht = (0.9_sp*pn*hp**2 - 0.25_sp*ct*ht**5 + kexc*ht**3.5_sp)*inv_ct
             dh(2) = ht - ht0 - dt*fht
 
             jacob(1, 1) = 1._sp + dt*2._sp*(hp*(pn - en) + en)*inv_cp  ! 1 - dt*nabla_hp(fhp)
             jacob(1, 2) = 0._sp  ! -dt*nabla_ht(fhp)
             jacob(2, 1) = -dt*1.8_sp*pn*hp*inv_ct  ! -dt*nabla_hp(fht)
-            jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*(ht**2.5_sp) - 5._sp*ct*ht**4)*inv_ct  ! 1 - dt*nabla_ht(fht)
+            jacob(2, 2) = 1._sp - dt*(3.5_sp*kexc*(ht**2.5_sp) - 1.25_sp*ct*ht**4)*inv_ct  ! 1 - dt*nabla_ht(fht)
 
             call solve_linear_system_2vars(jacob, delta_h, dh)
 
@@ -284,7 +284,7 @@ contains
 
         l = kexc*ht**3.5_sp
 
-        q = ct*ht**5 + 0.1_sp*pn*hp**2 + l
+        q = 0.25_sp*ct*ht**5 + 0.1_sp*pn*hp**2 + l
 
     end subroutine gr_production_transfer_ode
 
@@ -327,7 +327,7 @@ contains
             dh(1) = hp - hp0 - dt*fhp
 
             ! Range of correction for the three terms: (0, 2)
-            fht = (0.9_sp*(1._sp + fq(1))*pn*hp**2 - (1._sp + fq(4))*ct*ht**5 &
+            fht = (0.9_sp*(1._sp + fq(1))*pn*hp**2 - 0.25_sp*(1._sp + fq(4))*ct*ht**5 &
             & + (kexc*ht**3.5_sp)*(1._sp + fq(3)))*inv_ct
             dh(2) = ht - ht0 - dt*fht
 
@@ -341,12 +341,12 @@ contains
 
             ! -dt*nabla_hp(fht)
             jacob(2, 1) = -dt*(0.9_sp*pn*hp*(2._sp*(1._sp + fq(1)) + jacobian_nn(1, 1)*hp) &
-            & - jacobian_nn(4, 1)*ct*ht**5 + jacobian_nn(3, 1)*kexc*ht**3.5_sp)*inv_ct
+            & - 0.25_sp*jacobian_nn(4, 1)*ct*ht**5 + jacobian_nn(3, 1)*kexc*ht**3.5_sp)*inv_ct
 
             ! 1 - dt*nabla_ht(fht)
             jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp + fq(3)) + jacobian_nn(3, 2)*ht)*kexc*ht**2.5 &
             & + 0.9_sp*jacobian_nn(1, 2)*pn*hp**2 &
-            & - (5._sp*(1._sp + fq(4)) + jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+            & - (1.25_sp*(1._sp + fq(4)) + 0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
 
             call solve_linear_system_2vars(jacob, delta_h, dh)
 
@@ -365,7 +365,7 @@ contains
 
         l = (1._sp + fq(3))*kexc*ht**3.5_sp  ! Range of correction kexc: (0, 2)
 
-        q = (1._sp + fq(4))*ct*ht**5 &  ! Range of correction ct: (0, 2)
+        q = 0.25_sp*(1._sp + fq(4))*ct*ht**5 &  ! Range of correction ct: (0, 2)
         & + 0.1_sp*(1._sp + fq(1))*pn*hp**2 + l  ! Range of correction pn: (0, 2)
 
     end subroutine gr_production_transfer_ode_mlp

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,18 +1,8 @@
-commit 647c1d8a838d59350799080cba131a6d4da72c78
-Author: Ngo Nghi Truyen Huynh <129378719+nghi-truyen@users.noreply.github.com>
-Date:   Wed Jan 29 10:46:46 2025 +0100
+commit d5f5608a508550a9f0f125b479a1d72305f27c56
+Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
+Date:   Tue Feb 4 10:38:14 2025 +0100
 
-    DOC: fix model initialization for examples in user guide tutorials (#370)
-    
-    * DOC: fix model initialization for examples in user guide tutorials
-    
-    * Apply suggestions from code review
-    
-    Co-authored-by: asjeb <151923475+asjeb@users.noreply.github.com>
-    
-    ---------
-    
-    Co-authored-by: asjeb <151923475+asjeb@users.noreply.github.com>
+    Fix workflow, test_constant
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -135,40 +125,40 @@ forward_run.zero-gr4_mlp-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr4_mlp-lr.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr4_mlp-lr.rr_states.ht                       |NON MODIFIED
 forward_run.zero-gr4_mlp-lr.sim_q                              |NON MODIFIED
-forward_run.zero-gr4_ode-kw.cost                               |NON MODIFIED
-forward_run.zero-gr4_ode-kw.jobs                               |NON MODIFIED
-forward_run.zero-gr4_ode-kw.q_domain                           |NON MODIFIED
+forward_run.zero-gr4_ode-kw.cost                               |MODIFIED
+forward_run.zero-gr4_ode-kw.jobs                               |MODIFIED
+forward_run.zero-gr4_ode-kw.q_domain                           |MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_ode-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_ode-kw.sim_q                              |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.cost                             |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.jobs                             |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.q_domain                         |NON MODIFIED
+forward_run.zero-gr4_ode-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-gr4_ode-kw.sim_q                              |MODIFIED
+forward_run.zero-gr4_ode-lag0.cost                             |MODIFIED
+forward_run.zero-gr4_ode-lag0.jobs                             |MODIFIED
+forward_run.zero-gr4_ode-lag0.q_domain                         |MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hi                     |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-gr4_ode-lr.cost                               |NON MODIFIED
-forward_run.zero-gr4_ode-lr.jobs                               |NON MODIFIED
-forward_run.zero-gr4_ode-lr.q_domain                           |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-gr4_ode-lag0.sim_q                            |MODIFIED
+forward_run.zero-gr4_ode-lr.cost                               |MODIFIED
+forward_run.zero-gr4_ode-lr.jobs                               |MODIFIED
+forward_run.zero-gr4_ode-lr.q_domain                           |MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_ode-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_ode-lr.sim_q                              |NON MODIFIED
+forward_run.zero-gr4_ode-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-gr4_ode-lr.sim_q                              |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.cost                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.jobs                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.q_domain                       |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.rr_states.hi                   |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.rr_states.hp                   |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.rr_states.hp                   |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.rr_states.ht                   |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.sim_q                          |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.cost                         |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.jobs                         |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.q_domain                     |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.rr_states.hi                 |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.rr_states.hp                 |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.rr_states.hp                 |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.rr_states.ht                 |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.sim_q                        |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.cost                           |MODIFIED
@@ -176,7 +166,7 @@ forward_run.zero-gr4_ode_mlp-lr.jobs                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.q_domain                       |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.hi                   |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.hlr                  |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.rr_states.hp                   |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.rr_states.hp                   |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.ht                   |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.sim_q                          |MODIFIED
 forward_run.zero-gr4_ri-kw.cost                                |NON MODIFIED
@@ -553,33 +543,33 @@ internal_fluxes.zero-gr4_mlp-lr.qup                            |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.en                             |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.lexc                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.pn                             |NON MODIFIED
-internal_fluxes.zero-gr4_ode-kw.qim1j                          |NON MODIFIED
-internal_fluxes.zero-gr4_ode-kw.qt                             |NON MODIFIED
+internal_fluxes.zero-gr4_ode-kw.qim1j                          |MODIFIED
+internal_fluxes.zero-gr4_ode-kw.qt                             |MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.en                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.lexc                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.pn                           |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lag0.qt                           |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lag0.qup                          |NON MODIFIED
+internal_fluxes.zero-gr4_ode-lag0.qt                           |MODIFIED
+internal_fluxes.zero-gr4_ode-lag0.qup                          |MODIFIED
 internal_fluxes.zero-gr4_ode-lr.en                             |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lr.lexc                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lr.pn                             |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lr.qt                             |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lr.qup                            |NON MODIFIED
+internal_fluxes.zero-gr4_ode-lr.qt                             |MODIFIED
+internal_fluxes.zero-gr4_ode-lr.qup                            |MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.en                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.lexc                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.pn                         |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-kw.qim1j                      |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-kw.qt                         |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-kw.qim1j                      |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-kw.qt                         |MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.en                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.lexc                     |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.pn                       |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lag0.qt                       |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lag0.qup                      |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lag0.qt                       |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lag0.qup                      |MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.en                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.lexc                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.pn                         |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lr.qt                         |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lr.qup                        |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lr.qt                         |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lr.qup                        |MODIFIED
 internal_fluxes.zero-gr4_ri-kw.en                              |NON MODIFIED
 internal_fluxes.zero-gr4_ri-kw.es                              |NON MODIFIED
 internal_fluxes.zero-gr4_ri-kw.lexc                            |NON MODIFIED
@@ -1232,36 +1222,36 @@ optimize.zero-gr4_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
 optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
 optimize.zero-gr4_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_mlp-lr.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_ode-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr4_ode-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-gr4_ode-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-gr4_ode-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-gr4_ode-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |NON MODIFIED
-optimize.zero-gr4_ode-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-gr4_ode-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-gr4_ode-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_ode-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr4_ode-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr4_ode-kw.ann.control_vector                    |MODIFIED
+optimize.zero-gr4_ode-kw.ann.sim_q                             |MODIFIED
+optimize.zero-gr4_ode-kw.distributed.control_vector            |MODIFIED
+optimize.zero-gr4_ode-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-gr4_ode-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr4_ode-kw.uniform.control_vector                |MODIFIED
+optimize.zero-gr4_ode-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-gr4_ode-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-gr4_ode-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-gr4_ode-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-gr4_ode-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |MODIFIED
+optimize.zero-gr4_ode-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-gr4_ode-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-gr4_ode-lr.ann.control_vector                    |MODIFIED
+optimize.zero-gr4_ode-lr.ann.sim_q                             |MODIFIED
+optimize.zero-gr4_ode-lr.distributed.control_vector            |MODIFIED
+optimize.zero-gr4_ode-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-gr4_ode-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr4_ode-lr.uniform.control_vector                |MODIFIED
+optimize.zero-gr4_ode-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.sim_q                         |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |MODIFIED

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,8 +1,18 @@
-commit 959fc8fdd05d109f11104f13bb7a3f0948748e11
+commit 647c1d8a838d59350799080cba131a6d4da72c78
 Author: Ngo Nghi Truyen Huynh <129378719+nghi-truyen@users.noreply.github.com>
-Date:   Mon Dec 16 21:12:03 2024 +0100
+Date:   Wed Jan 29 10:46:46 2025 +0100
 
-    MAINT: Upgrade Python version to 3.12 for docker and workflow (#362)
+    DOC: fix model initialization for examples in user guide tutorials (#370)
+    
+    * DOC: fix model initialization for examples in user guide tutorials
+    
+    * Apply suggestions from code review
+    
+    Co-authored-by: asjeb <151923475+asjeb@users.noreply.github.com>
+    
+    ---------
+    
+    Co-authored-by: asjeb <151923475+asjeb@users.noreply.github.com>
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -147,28 +157,28 @@ forward_run.zero-gr4_ode-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.ht                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.sim_q                              |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.cost                           |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.jobs                           |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.q_domain                       |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.cost                           |MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.jobs                           |MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.q_domain                       |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.rr_states.hi                   |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.rr_states.hp                   |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.rr_states.ht                   |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-kw.sim_q                          |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.cost                         |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.jobs                         |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.q_domain                     |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.rr_states.ht                   |MODIFIED
+forward_run.zero-gr4_ode_mlp-kw.sim_q                          |MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.cost                         |MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.jobs                         |MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.q_domain                     |MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.rr_states.hi                 |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-lag0.rr_states.hp                 |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.rr_states.ht                 |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lag0.sim_q                        |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.cost                           |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.jobs                           |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.q_domain                       |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.rr_states.ht                 |MODIFIED
+forward_run.zero-gr4_ode_mlp-lag0.sim_q                        |MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.cost                           |MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.jobs                           |MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.q_domain                       |MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.hi                   |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.hlr                  |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-lr.rr_states.hp                   |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.rr_states.ht                   |NON MODIFIED
-forward_run.zero-gr4_ode_mlp-lr.sim_q                          |NON MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.rr_states.ht                   |MODIFIED
+forward_run.zero-gr4_ode_mlp-lr.sim_q                          |MODIFIED
 forward_run.zero-gr4_ri-kw.cost                                |NON MODIFIED
 forward_run.zero-gr4_ri-kw.jobs                                |NON MODIFIED
 forward_run.zero-gr4_ri-kw.q_domain                            |NON MODIFIED
@@ -460,8 +470,8 @@ forward_run.zero-vic3l-lr.rr_states.husl                       |NON MODIFIED
 forward_run.zero-vic3l-lr.sim_q                                |NON MODIFIED
 generate_samples.normal                                        |NON MODIFIED
 generate_samples.uniform                                       |NON MODIFIED
-hydrograph_segmentation.by_obs                                 |MODIFIED
-hydrograph_segmentation.by_sim                                 |MODIFIED
+hydrograph_segmentation.by_obs                                 |NON MODIFIED
+hydrograph_segmentation.by_sim                                 |NON MODIFIED
 internal_fluxes.zero-gr4-kw.en                                 |NON MODIFIED
 internal_fluxes.zero-gr4-kw.es                                 |NON MODIFIED
 internal_fluxes.zero-gr4-kw.lexc                               |NON MODIFIED
@@ -1252,36 +1262,36 @@ optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |NON MODIFIED
 optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |NON MODIFIED
 optimize.zero-gr4_ode-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_ode-lr.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.ann.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.distributed.sim_q                 |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-linear.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-linear.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-polynomial.control_vector   |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-polynomial.sim_q            |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.uniform.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.uniform.sim_q                     |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.ann.control_vector              |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.ann.sim_q                       |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.distributed.control_vector      |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.distributed.sim_q               |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-linear.control_vector     |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-linear.sim_q              |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.control_vector |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.sim_q          |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.uniform.control_vector          |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.uniform.sim_q                   |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.ann.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.ann.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.distributed.control_vector        |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.distributed.sim_q                 |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-linear.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-linear.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-polynomial.control_vector   |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-polynomial.sim_q            |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.uniform.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.uniform.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.ann.sim_q                         |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.distributed.sim_q                 |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.multi-linear.control_vector       |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.multi-linear.sim_q                |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.multi-polynomial.control_vector   |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.multi-polynomial.sim_q            |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.uniform.control_vector            |MODIFIED
+optimize.zero-gr4_ode_mlp-kw.uniform.sim_q                     |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.ann.control_vector              |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.ann.sim_q                       |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.distributed.control_vector      |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.distributed.sim_q               |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.multi-linear.control_vector     |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.multi-linear.sim_q              |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.control_vector |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.sim_q          |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.uniform.control_vector          |MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.uniform.sim_q                   |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.ann.control_vector                |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.ann.sim_q                         |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.distributed.control_vector        |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.distributed.sim_q                 |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.multi-linear.control_vector       |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.multi-linear.sim_q                |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.multi-polynomial.control_vector   |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.multi-polynomial.sim_q            |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.uniform.control_vector            |MODIFIED
+optimize.zero-gr4_ode_mlp-lr.uniform.sim_q                     |MODIFIED
 optimize.zero-gr4_ri-kw.ann.control_vector                     |NON MODIFIED
 optimize.zero-gr4_ri-kw.ann.sim_q                              |NON MODIFIED
 optimize.zero-gr4_ri-kw.distributed.control_vector             |NON MODIFIED

--- a/smash/tests/test_constant.py
+++ b/smash/tests/test_constant.py
@@ -255,7 +255,7 @@ def test_parameterization_neural_network_structure():
                     (4, 4),  # % gr4_mlp
                     (0, 0),  # % gr4_ri
                     (0, 0),  # % gr4_ode
-                    (4, 5),  # % gr4_ode_mlp
+                    (4, 4),  # % gr4_ode_mlp
                     (0, 0),  # % gr5
                     (4, 4),  # % gr5_mlp
                     (0, 0),  # % gr5_ri


### PR DESCRIPTION
- Remove correction on the coefficient 0.9 and 0.1
- Add correction for Pn in the equation of dh_t/dt
- Fix the calculation of Q_t in ODE and neural ODE structure
- Re-compute the Jaco matrix for new formulation