### PR TITLE
ENH/DOC: add automatic output code block generation, improve contributor guide

### DIFF
--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -1758,7 +1758,7 @@ The choice between these depends on the complexity and runtime of the tutorial.
     However, this approach requires additional computation time during documentation building.
 
 - code block:
-    The ``.. code-block:: python`` directive, on the other hand, is useful for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on an external package (for example, when estimate hyper-parameter sensitivity) is a concern.
+    The ``.. code-block:: python`` directive, on the other hand, is more suitable for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on external packages (for example, when estimating hyper-parameter sensitivity using `SALib <https://salib.readthedocs.io/>`__) is a concern.
     It allows you to include static code snippets without running them during documentation generation.
     Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and using the ``.. image::`` directive to include figures.
 

--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -1747,7 +1747,7 @@ User guide
 **********
 
 The user guide contains tutorials with code examples and explanations of various functionalities of `smash`.
-There are two approaches for writing a tutorial: using the ipython directive or using the code block directive. 
+There are two approaches for writing a tutorial: using the ``.. ipython:: python`` directive or using the ``.. code-block:: python`` directive. 
 The choice between these depends on the complexity and runtime of the tutorial.
 
 - ipython:
@@ -1758,7 +1758,7 @@ The choice between these depends on the complexity and runtime of the tutorial.
     However, this approach requires additional computation time during documentation building.
 
 - code block:
-    The ``.. code-block:: python`` directive, on the other hand, is useful for longer or more complex tutorials where execution time is a concern (for example, when calibrating models).
+    The ``.. code-block:: python`` directive, on the other hand, is useful for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on an external package (for example, when estimate hyper-parameter sensitivity) is a concern.
     It allows you to include static code snippets without running them during documentation generation.
     Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and using the ``.. image::`` directive to include figures.
 
@@ -1808,7 +1808,7 @@ The choice between these depends on the complexity and runtime of the tutorial.
 
     .. note::
 
-        Since the second approach is more manual, it is recommended to add the path of the file written using this approach to ``doc/source/user_guide/files_with_code_block.csv`` (if not already included). 
+        Since the ``.. code-block:: python`` directive approach is more manual, it is recommended to add the path of the file written using this approach to ``doc/source/user_guide/files_with_code_block.csv`` (if not already included). 
         This helps streamline the process of verifying and updating code snippets when the source code changes.
         You will be asked to do so when running the ``pyexec_rst.py`` script.
 

--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -1746,10 +1746,71 @@ Then, you need to call up this file in the desired toctree, for example in the f
 User guide
 **********
 
-The user guide contains all the `smash` tutorials. These tutorials are not hardcoded, the python commands written in the
-``.. ipython:: python`` directives are executed and automatically generate the tutorial output. This is quite handy, as it means you don't have to 
-update the documentation each time the source is modified, and adds an extra layer of testing since the documentation will not compile if 
-there is an error in executing a python command but which, on the other hand, requires a certain amount of computing time.
+The user guide contains tutorials with code examples and explanations of various functionalities of `smash`.
+There are two approaches for writing a tutorial: using the ipython directive or using the code block directive. 
+The choice between these depends on the complexity and runtime of the tutorial.
+
+- ipython:
+    The ``.. ipython:: python`` directive is more suitable for tutorials that execute quickly.
+    Since Python commands within this directive are run during documentation compilation, outputs are automatically generated.
+    This ensures that the documentation stays up to date without manual updates whenever the source code changes.
+    Additionally, it acts as an extra layer of validation, as the documentation compilation will fail if there are execution errors in any code directive.
+    However, this approach requires additional computation time during documentation building.
+
+- code block:
+    The ``.. code-block:: python`` directive, on the other hand, is useful for longer or more complex tutorials where execution time is a concern (for example, when calibrating models).
+    It allows you to include static code snippets without running them during documentation generation.
+    Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and using the ``.. image::`` directive to include figures.
+
+    .. code-block:: rst
+
+        .. code-block:: python
+        
+            >>> text = "smash developer"
+            >>> text
+        
+        .. parsed-literal::
+
+            smash developer
+
+    However, this way, the documentation may become outdated if the source code changes. To automatically create or update the output code, it is highly recommended to use ``doc/source/user_guide/pyexec_rst.py``.
+    For example, consider a file named ``doc/source/user_guide/in_depth/foo.rst``:
+
+    .. code-block:: rst
+    
+        .. code-block:: python
+
+            >>> text = "smash developer"
+            >>> text
+    
+        .. parsed-literal::
+
+            type any text here
+
+    To generate or update the output code:
+
+    .. code-block:: shell
+
+        python3 pyexec_rst.py in_depth/foo.rst
+
+    The output code will be generated in the ``doc/source/user_guide/in_depth/foo.rst`` file (if you choose to overwrite this file, otherwise a new file will be generated).
+
+    .. code-block:: rst
+    
+        .. code-block:: python
+
+            >>> text = "smash developer"
+            >>> text
+
+        .. parsed-literal::
+
+            smash developer
+
+    .. note::
+
+        Since the second approach is more manual, it is recommended to add the path of the file written using this approach to ``doc/source/user_guide/files_with_code_block.csv`` (if not already included). 
+        This helps streamline the process of verifying and updating code snippets when the source code changes.
+        You will be asked to do so when running the ``pyexec_rst.py`` script.
 
 API reference
 *************

--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -1758,7 +1758,7 @@ The choice between these depends on the complexity and runtime of the tutorial.
     However, this approach requires additional computation time during documentation building.
 
 - code block:
-    The ``.. code-block:: python`` directive, on the other hand, is more suitable for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on external packages (for example, when estimating hyper-parameter sensitivity using `SALib <https://salib.readthedocs.io/>`__) is a concern.
+    The ``.. code-block:: python`` directive, on the other hand, is better suited for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on external packages (for example, when estimating hyper-parameter sensitivity using `SALib <https://salib.readthedocs.io/>`__) is a concern.
     It allows you to include static code snippets without running them during documentation generation.
     Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and using the ``.. image::`` directive to include figures.
 
@@ -1773,7 +1773,8 @@ The choice between these depends on the complexity and runtime of the tutorial.
 
             smash developer
 
-    However, this way, the documentation may become outdated if the source code changes. To automatically create or update the output code, it is highly recommended to use ``doc/source/user_guide/pyexec_rst.py``.
+    However, this way, the documentation may become outdated if the source code changes.
+    To automatically generate/update the output code and verify correctness in code blocks, it is highly recommended to use ``doc/source/user_guide/pyexec_rst.py``.
     For example, consider a file named ``doc/source/user_guide/in_depth/foo.rst``:
 
     .. code-block:: rst

--- a/doc/source/contributor_guide/development_process_details.rst
+++ b/doc/source/contributor_guide/development_process_details.rst
@@ -1755,12 +1755,34 @@ The choice between these depends on the complexity and runtime of the tutorial.
     Since Python commands within this directive are run during documentation compilation, outputs are automatically generated.
     This ensures that the documentation stays up to date without manual updates whenever the source code changes.
     Additionally, it acts as an extra layer of validation, as the documentation compilation will fail if there are execution errors in any code directive.
-    However, this approach requires additional computation time during documentation building.
+    However, this approach requires additional computation time during documentation building. Here is an example:
+
+    .. code-block:: rst
+
+        .. ipython:: python
+
+            text = "smash developer"
+            text
+
+    The output of the ipython directive is automatically generated when the documentation is compiled.
 
 - code block:
-    The ``.. code-block:: python`` directive, on the other hand, is better suited for longer or more complex tutorials where execution time (for example, when calibrating models) or dependency on external packages (for example, when estimating hyper-parameter sensitivity using `SALib <https://salib.readthedocs.io/>`__) is a concern.
+    The ``.. code-block:: python`` directive is better suited for longer or more complex tutorials where execution time (e.g., model calibration) or dependency on external packages (e.g., hyper-parameter sensitivity estimation using `SALib <https://salib.readthedocs.io/>`__) is a concern.
     It allows you to include static code snippets without running them during documentation generation.
-    Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and using the ``.. image::`` directive to include figures.
+    The code should start with ``>>>`` and use ``...`` for continuation lines or within loops/functions.
+
+    .. code-block:: rst
+
+        .. code-block:: python
+
+            >>> def linear_transform(x, a=23, b=5):  
+            ...     y = a * x + b  
+            ...     return y
+            ... 
+            >>> x = -1
+            >>> y = linear_transform(-1) 
+
+    Since the code is not executed, the outputs are not automatically generated. Alternative solutions include using the ``.. parsed-literal::`` directive to include the output code and the ``.. image::`` directive to include figures.
 
     .. code-block:: rst
 
@@ -1773,8 +1795,9 @@ The choice between these depends on the complexity and runtime of the tutorial.
 
             smash developer
 
-    However, this way, the documentation may become outdated if the source code changes.
+    However, this approach may result in outdated documentation if the source code changes.
     To automatically generate/update the output code and verify correctness in code blocks, it is highly recommended to use ``doc/source/user_guide/pyexec_rst.py``.
+    This script extracts Python code blocks from the ``rst`` file, executes them, and updates the output accordingly.
     For example, consider a file named ``doc/source/user_guide/in_depth/foo.rst``:
 
     .. code-block:: rst
@@ -1788,13 +1811,13 @@ The choice between these depends on the complexity and runtime of the tutorial.
 
             type any text here
 
-    To generate or update the output code:
+    To extract and execute the Python code from the ``rst`` file, and generate/update the output code:
 
     .. code-block:: shell
 
         python3 pyexec_rst.py in_depth/foo.rst
 
-    The output code will be generated in the ``doc/source/user_guide/in_depth/foo.rst`` file (if you choose to overwrite this file, otherwise a new file will be generated).
+    The output code will be generated in the ``doc/source/user_guide/in_depth/foo.rst`` file (if you choose to overwrite this file, otherwise a new file will be created).
 
     .. code-block:: rst
     

--- a/doc/source/user_guide/files_with_code_block.csv
+++ b/doc/source/user_guide/files_with_code_block.csv
@@ -1,0 +1,2 @@
+file_path
+post_processing_external_tools/sensitivity_analysis.rst

--- a/doc/source/user_guide/post_processing_external_tools/sensitivity_analysis.rst
+++ b/doc/source/user_guide/post_processing_external_tools/sensitivity_analysis.rst
@@ -7,7 +7,7 @@ Sensitivity Analysis
 ====================
 
 In this tutorial, we will show how to perform sensitivity analysis on a
-single catchment using `smash` and `SAlib <https://salib.readthedocs.io/>`__. We will use the :ref:`user_guide.data_and_format_description.cance` dataset as an example in this tutorial.
+single catchment using `smash` and `SALib <https://salib.readthedocs.io/>`__. We will use the :ref:`user_guide.data_and_format_description.cance` dataset as an example in this tutorial.
 
 First, open a Python interface:
 
@@ -28,15 +28,14 @@ We will first import the necessary libraries for this tutorial.
     >>> from SALib.analyze.sobol import analyze
     >>> from SALib.sample.sobol import sample
 
-
 .. note::
 
-    The library `SAlib <https://salib.readthedocs.io/>`__ is a requirement for this tutorial.
+    The library `SALib <https://salib.readthedocs.io/>`__ is a requirement for this tutorial.
     It is not installed by default but can be installed with pip as follows:
 
     .. code-block:: none
 
-        pip install SAlib
+        pip install SALib
 
 Define the catchment, load the model and data
 ---------------------------------------------
@@ -52,7 +51,6 @@ Create the model object. This also loads the data into the model object.
 .. code-block:: python
 
     >>> model = smash.Model(setup, mesh)
-
 
 .. parsed-literal::
 

--- a/doc/source/user_guide/pyexec_rst.py
+++ b/doc/source/user_guide/pyexec_rst.py
@@ -1,0 +1,199 @@
+import re
+from io import StringIO
+import sys
+import pathlib
+import pandas as pd
+
+
+def clean_code_block(code_block: str) -> str:
+    """
+    Clean Python code blocks by removing REPL prompts and handling multiline statements.
+
+    Args:
+        code_block (str): Raw code block containing >>> and ... prompts
+
+    Returns:
+        str: Cleaned code with prompts removed and proper formatting
+    """
+    lines = code_block.split("\n")
+    cleaned_lines = []
+    current_statement = []
+    in_function = False
+
+    for line in lines:
+        line = line.strip()
+        if not line or line in (">>>", "..."):
+            continue
+
+        # Handle function definitions
+        if line.startswith(">>> def "):
+            if current_statement:
+                cleaned_lines.append("".join(current_statement))
+                current_statement = []
+            in_function = True
+            current_statement.append(line[4:])
+            continue
+
+        # Handle function body or continuation lines
+        if line.startswith("... "):
+            current_statement.append("\n" + line[4:] if in_function else line[4:])
+        elif line.startswith(">>> "):
+            if current_statement:
+                cleaned_lines.append("".join(current_statement))
+            current_statement = [line[4:]]
+            in_function = False
+
+    # Add any remaining statement
+    if current_statement:
+        cleaned_lines.append("".join(current_statement))
+
+    return "\n".join(cleaned_lines)
+
+
+def extract_code_blocks(rst_content: str) -> list:
+    """
+    Extract Python code blocks from RST content using regex pattern matching.
+
+    Args:
+        rst_content (str): RST document content
+
+    Returns:
+        list: List of tuples containing (cleaned_code, has_parsed_literal, parsed_literal_position)
+    """
+    blocks = []
+    pattern = r"""
+        \.\.?\s*code-block::\s*python\s*\n
+        (?:\s*\n)?
+        (\s+>>>.*?(?:\n\s+(?:>>>|\.\.\.).*?)*)
+        (?=\n(?:\s*\n|\s+\n)|$)
+        (?:\n+(?:[ \t]*\n)*\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\w|$))?
+    """
+
+    for match in re.finditer(pattern, rst_content, re.VERBOSE | re.DOTALL):
+        code_block = match.group(1)
+        has_parsed_literal = match.group(2) is not None
+        parsed_literal_pos = match.end(1) if has_parsed_literal else None
+
+        cleaned_code = clean_code_block(code_block)
+        if cleaned_code:
+            blocks.append((cleaned_code, has_parsed_literal, parsed_literal_pos))
+
+    return blocks
+
+
+class CodeExecutor:
+    def __init__(self):
+        self.globals = {}
+
+    def execute_block(self, code: str) -> str:
+        with StringIO() as redirected_output:
+            old_stdout = sys.stdout
+            sys.stdout = redirected_output
+
+            try:
+                if "def " in code:
+                    # Execute the entire block at once for function definitions
+                    try:
+                        exec(code, self.globals)
+                    except Exception as e:
+                        print(f"Error: {str(e)}")
+                else:
+                    # Handle line by line for other code
+                    for line in code.strip().split("\n"):
+                        try:
+                            result = eval(compile(line, "<string>", "eval"), self.globals)
+                            if result is not None:
+                                print(result)
+                        except SyntaxError:
+                            exec(line, self.globals)
+                        except Exception as e:
+                            print(f"Error: {str(e)}")
+
+                output = redirected_output.getvalue().strip()
+                return "\n".join(
+                    [" " * 4 + line if i > 0 else line for i, line in enumerate(output.split("\n"))]
+                    if output
+                    else []
+                )
+            finally:
+                sys.stdout = old_stdout
+
+
+def process_rst_file(file_path: str, overwrite: bool) -> list:
+    """
+    Process an RST file by executing code blocks and updating parsed-literal sections.
+
+    Args:
+        file_path (str): Path to the RST file
+
+    Returns:
+        list: List of tuples containing (code, output) for each block
+    """
+    with open(file_path, "r") as file:
+        content = file.read()
+
+    blocks = extract_code_blocks(content)
+    executor = CodeExecutor()
+
+    # Execute all blocks to build state
+    block_outputs = [executor.execute_block(code) for code, _, _ in blocks]
+
+    # Update parsed-literal sections
+    modified_content = list(content)
+    outputs = []
+
+    for (code, has_parsed_literal, parsed_literal_pos), output in zip(
+        reversed(blocks), reversed(block_outputs)
+    ):
+        outputs.insert(0, (code, output))
+
+        if has_parsed_literal:
+            pattern = r"\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\w|$)"
+            match = re.search(pattern, content[parsed_literal_pos:], re.DOTALL)
+
+            if match:
+                start = parsed_literal_pos + match.start(1)
+                end = parsed_literal_pos + match.end(1)
+                modified_content[start:end] = list(output)
+
+    if not overwrite:
+        file_path = file_path.replace(".rst", "_updated.rst")
+
+    # Save updated content
+    with open(file_path, "w") as file:
+        file.write("".join(modified_content))
+
+    return outputs
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise IndexError("No file path provided to generate rst file")
+
+    file_path = pathlib.Path(sys.argv[1])
+
+    file_path = file_path.with_suffix(".rst")
+
+    if file_path.exists():
+        df = pd.read_csv("files_with_code_block.csv")
+        if str(file_path) not in df["file_path"].to_list():
+            path_input = input("Add file path to files_with_code_block.csv ([y]/n) ? ")
+
+            if path_input.lower() in ["", "y", "yes"]:
+                df = pd.concat([df, pd.DataFrame([{"file_path": str(file_path)}])], ignore_index=True)
+                df.to_csv("files_with_code_block.csv", index=False)
+
+        exists_input = input("Overwrite existing file ([y]/n) ? ")
+
+        if exists_input.lower() in ["", "y", "yes"]:
+            overwrite = True
+        else:
+            overwrite = False
+
+        results = process_rst_file(str(file_path), overwrite)
+
+        for i, (code, output) in enumerate(results, 1):
+            print(f"\nBlock {i} - Output:\n   ", output)
+
+    else:
+        raise FileNotFoundError(f"File not found at path: {file_path}")

--- a/doc/source/user_guide/pyexec_rst.py
+++ b/doc/source/user_guide/pyexec_rst.py
@@ -1,7 +1,8 @@
-import re
-from io import StringIO
-import sys
 import pathlib
+import re
+import sys
+from io import StringIO
+
 import pandas as pd
 
 
@@ -17,35 +18,13 @@ def clean_code_block(code_block: str) -> str:
     """
     lines = code_block.split("\n")
     cleaned_lines = []
-    current_statement = []
-    in_function = False
 
     for line in lines:
         line = line.strip()
         if not line or line in (">>>", "..."):
             continue
 
-        # Handle function definitions
-        if line.startswith(">>> def "):
-            if current_statement:
-                cleaned_lines.append("".join(current_statement))
-                current_statement = []
-            in_function = True
-            current_statement.append(line[4:])
-            continue
-
-        # Handle function body or continuation lines
-        if line.startswith("... "):
-            current_statement.append("\n" + line[4:] if in_function else line[4:])
-        elif line.startswith(">>> "):
-            if current_statement:
-                cleaned_lines.append("".join(current_statement))
-            current_statement = [line[4:]]
-            in_function = False
-
-    # Add any remaining statement
-    if current_statement:
-        cleaned_lines.append("".join(current_statement))
+        cleaned_lines.append("".join([line[4:]]))
 
     return "\n".join(cleaned_lines)
 
@@ -60,15 +39,15 @@ def extract_code_blocks(rst_content: str) -> list:
     Returns:
         list: List of tuples containing (cleaned_code, has_parsed_literal, parsed_literal_position)
     """
-    blocks = []
     pattern = r"""
-        \.\.?\s*code-block::\s*python\s*\n
-        (?:\s*\n)?
-        (\s+>>>.*?(?:\n\s+(?:>>>|\.\.\.).*?)*)
-        (?=\n(?:\s*\n|\s+\n)|$)
-        (?:\n+(?:[ \t]*\n)*\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\w|$))?
+    \.\.?\s*code-block::\s*python\s*\n
+    (?:\s*\n)?
+    (\s+>>>.*?(?:\n\s+(?:>>>|\.\.\.).*?)*)
+    (?=\n(?:\s*\n|\.\.?\s*parsed-literal::|\s*\n|\.\.?\s*code-block::|\.\.?\s*note::)|$)
+    (?:\n+(?:[ \t]*\n)*\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\n|$))?
     """
 
+    blocks = []
     for match in re.finditer(pattern, rst_content, re.VERBOSE | re.DOTALL):
         code_block = match.group(1)
         has_parsed_literal = match.group(2) is not None
@@ -91,23 +70,24 @@ class CodeExecutor:
             sys.stdout = redirected_output
 
             try:
-                if "def " in code:
-                    # Execute the entire block at once for function definitions
+                last_line = code.split("\n")[-1]  # to print if it is a variable
+
+                if last_line[0] == " ":
+                    # Execute the entire block
+                    exec(code, self.globals)  # noqa: S102
+
+                else:  # separate the last line from the entire block
+                    # Execute the entire block except the last line
+                    exec(code[: -len(last_line)], self.globals)  # noqa: S102
+                    # Try to print the last line output or execute it
                     try:
-                        exec(code, self.globals)
-                    except Exception as e:
-                        print(f"Error: {str(e)}")
-                else:
-                    # Handle line by line for other code
-                    for line in code.strip().split("\n"):
-                        try:
-                            result = eval(compile(line, "<string>", "eval"), self.globals)
-                            if result is not None:
-                                print(result)
-                        except SyntaxError:
-                            exec(line, self.globals)
-                        except Exception as e:
-                            print(f"Error: {str(e)}")
+                        result = eval(compile(last_line, "<string>", "eval"), self.globals)
+                        if result is not None:
+                            print(result)
+                    except SyntaxError:
+                        exec(last_line, self.globals)  # noqa: S102
+                    except Exception as exception:
+                        raise exception
 
                 output = redirected_output.getvalue().strip()
                 return "\n".join(
@@ -125,6 +105,7 @@ def process_rst_file(file_path: str, overwrite: bool) -> list:
 
     Args:
         file_path (str): Path to the RST file
+        overwrite (bool): Overwrite the existing file or create a new file with updated content
 
     Returns:
         list: List of tuples containing (code, output) for each block
@@ -148,7 +129,7 @@ def process_rst_file(file_path: str, overwrite: bool) -> list:
         outputs.insert(0, (code, output))
 
         if has_parsed_literal:
-            pattern = r"\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\w|$)"
+            pattern = r"\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\n|$)"
             match = re.search(pattern, content[parsed_literal_pos:], re.DOTALL)
 
             if match:
@@ -193,7 +174,7 @@ if __name__ == "__main__":
         results = process_rst_file(str(file_path), overwrite)
 
         for i, (code, output) in enumerate(results, 1):
-            print(f"\nBlock {i} - Output:\n   ", output)
+            print(f"Block {i} - Output:\n   ", output)
 
     else:
         raise FileNotFoundError(f"File not found at path: {file_path}")

--- a/doc/source/user_guide/pyexec_rst.py
+++ b/doc/source/user_guide/pyexec_rst.py
@@ -40,11 +40,11 @@ def extract_code_blocks(rst_content: str) -> list:
         list: List of tuples containing (cleaned_code, has_parsed_literal, parsed_literal_position)
     """
     pattern = r"""
-    \.\.?\s*code-block::\s*python\s*\n
-    (?:\s*\n)?
-    (\s+>>>.*?(?:\n\s+(?:>>>|\.\.\.).*?)*)
-    (?=\n(?:\s*\n|\.\.?\s*parsed-literal::|\s*\n|\.\.?\s*code-block::|\.\.?\s*note::)|$)
-    (?:\n+(?:[ \t]*\n)*\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\n|$))?
+        \.\.?\s*code-block::\s*python\s*\n
+        (?:\s*\n)?
+        (\s+>>>.*?(?:\n\s+(?:>>>|\.\.\.).*?)*)
+        (?=\n(?:\s*\n|\s+\n)|$)
+        (?:\n+(?:[ \t]*\n)*\.\.?\s*parsed-literal::\s*\n\s*(.*?)(?=\n\s*\n|$))?
     """
 
     blocks = []
@@ -81,9 +81,9 @@ class CodeExecutor:
                     exec(code[: -len(last_line)], self.globals)  # noqa: S102
                     # Try to print the last line output or execute it
                     try:
-                        result = eval(compile(last_line, "<string>", "eval"), self.globals)
-                        if result is not None:
-                            print(result)
+                        code_last_line = eval(compile(last_line, "<string>", "eval"), self.globals)
+                        if code_last_line is not None:
+                            print(repr(code_last_line))
                     except SyntaxError:
                         exec(last_line, self.globals)  # noqa: S102
                     except Exception as exception:
@@ -171,10 +171,10 @@ if __name__ == "__main__":
         else:
             overwrite = False
 
-        results = process_rst_file(str(file_path), overwrite)
+        outputs = process_rst_file(str(file_path), overwrite)
 
-        for i, (code, output) in enumerate(results, 1):
-            print(f"Block {i} - Output:\n   ", output)
+        for i, (code, output_i) in enumerate(outputs, 1):
+            print(f"Block {i} - Output:\n   ", output_i)
 
     else:
         raise FileNotFoundError(f"File not found at path: {file_path}")


### PR DESCRIPTION
This PR simplifies and improves the process of generating/verifying code when developers choose to write a tutorial using the hardcoded code block style:
- Add a new Python script that extracts and executes code blocks from an .rst file, then generates or updates the output code in the same file. This ensures that the code in hardcoded blocks runs correctly and that outputs are properly generated.
- Improve the contributor guide by detailing the two possible approaches for writing a user guide.