### PR TITLE
MAINT: directly remove generated files when compiling doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ tmp*
 
 # Documentation files
 doc/source/api_reference/**/smash
+doc/source/savefig
 doc/*-dataset
 doc/**/*~
 doc/**/*#

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,5 +27,5 @@ help:
 clean:
 	@rm -rf $(BUILDDIR)
 	@rm -rf $(SOURCEDIR)/savefig
-	@rm -rf *.hdf5 *yaml *-dataset $(SOURCEDIR)/user_guide/*.hdf5
+	@rm -rf *-dataset
 	@find $(SOURCEDIR)/api_reference/ -type d -name "smash" -exec rm -rf {} +

--- a/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
+++ b/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
@@ -6,11 +6,11 @@ Regionalization and Spatial Validation
 
 This tutorial explains how to perform regionalization and spatial validation methods with `smash` using physical descriptors.
 The parameters :math:`\boldsymbol{\theta}` can be written as a mapping :math:`\phi` of descriptors :math:`\boldsymbol{\mathcal{D}}`
-(slope, drainage density, soil water storage, etc) and :math:`\boldsymbol{\rho}` a control vector:
+(slope, drainage density, soil water storage, etc.) and :math:`\boldsymbol{\rho}`, a control vector:
 :math:`\boldsymbol{\theta}(x)=\phi\left(\boldsymbol{\mathcal{D}}(x),\boldsymbol{\rho}\right)`.
 See the :ref:`math_num_documentation.mapping` section for more details.
 Then the control vector of the mapping needs to be optimized: :math:`\boldsymbol{\hat{\rho}}=\underset{\mathrm{\boldsymbol{\rho}}}{\text{argmin}}\;J`,
-with :math:`J` the cost function.
+with :math:`J` being the cost function.
 
 We begin by opening a Python interface:
 
@@ -236,15 +236,17 @@ Now, we can customize several parameters such as the random state, learning rate
     refer to the in-depth tutorial on :ref:`Learnable Regionalization Mapping <user_guide.in_depth.advanced_learnable_regionalization>`.
 
 The returned `Optimize <smash.Optimize>` object ``opt_ann`` contains a `Net <smash.factory.Net>` object with the trained parameters.
-For example, we can access the bias of the last dense layer as follows:
+For example, we can access the bias of the last dense layer:
 
 .. code-block:: python
 
-    >>> opt_ann.net.layers[-3].bias
+    >>> opt_ann.net.get_bias()[-1]
 
 .. code-block:: output
 
     array([[-0.18723589, -0.16801801,  0.04658873, -0.15251763]])
+
+Or plot the cost function descent during the training:
 
 .. code-block:: python
 

--- a/doc/source/user_guide/quickstart/forward_run_classical_calibration.rst
+++ b/doc/source/user_guide/quickstart/forward_run_classical_calibration.rst
@@ -225,3 +225,12 @@ and read back using the `smash.io.save_model` and `smash.io.read_model` function
     .. code-block:: output
 
         dict_keys(['mesh', 'nn_parameters', 'physio_data', 'response', 'response_data', 'rr_final_states', 'rr_initial_states', 'rr_parameters', 'serr_mu_parameters', 'serr_sigma_parameters', 'setup'])
+
+.. use this directive to hide the code cell in the documentation while being captured by the script pyexec_rst.py
+.. only:: never
+
+    .. code-block:: python
+        
+        >>> import os
+        >>> os.remove("model.hdf5")
+        >>> os.remove("model_ddt.hdf5")

--- a/doc/source/user_guide/quickstart/hydrological_mesh_construction.rst
+++ b/doc/source/user_guide/quickstart/hydrological_mesh_construction.rst
@@ -219,3 +219,4 @@ This function stores the mesh in an `HDF5 <https://www.hdfgroup.org/solutions/hd
     :suppress:
 
     plt.close('all')
+    os.remove("mesh.hdf5")

--- a/doc/source/user_guide/quickstart/model_object_initialization.rst
+++ b/doc/source/user_guide/quickstart/model_object_initialization.rst
@@ -351,3 +351,4 @@ discharge is filled in with -99.
     :suppress:
 
     plt.close('all')
+    os.remove("setup.yaml")


### PR DESCRIPTION
- Remove generated files (hdf5, yaml,...) directly when running script or compiling the documentation
- Thus, no need to remove them with make doc-clean
- Add savefig in gitignore, so no need to make doc-clean to use git add .
- Minor typo fixes user guide