### PR TITLE
MAINT: Remove sphinx-autosummary-accessors from smash dependencies

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,6 @@ dependencies:
     - pickleshare
     - sphinxcontrib-bibtex
     - sphinx-design
-    - sphinx-autosummary-accessors
     - matplotlib
 
     # test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ doc = [
     "pickleshare",
     "sphinxcontrib-bibtex",
     "sphinx-design",
-    "sphinx-autosummary-accessors",
     "matplotlib>=3.8.4"
 ]
 dev = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,6 @@ ipython
 pickleshare
 sphinxcontrib-bibtex
 sphinx-design
-sphinx-autosummary-accessors
 matplotlib
 
 # test


### PR DESCRIPTION
Remove sphinx-autosummary-accessors from smash dependencies since smash no longer uses this sphinx extension.