### PR TITLE
MAINT/ENH: add SiLU activation function

### DIFF
--- a/smash/factory/net/_layers.py
+++ b/smash/factory/net/_layers.py
@@ -393,6 +393,15 @@ class SoftPlus:
         return 1 / (1 + np.exp(-x))
 
 
+class SiLU:
+    def __call__(self, x):
+        return x / (1 + np.exp(-x))
+
+    def gradient(self, x):
+        s = 1 / (1 + np.exp(-x))
+        return s + x * s * (1 - s)
+
+
 ### SCALING FUNCTION ###
 
 

--- a/smash/factory/net/net.py
+++ b/smash/factory/net/net.py
@@ -203,6 +203,7 @@ class Net(object):
             - ``'leakyrelu'`` : Leaky Rectified Linear Unit
             - ``'tanh'`` : Hyperbolic Tangent
             - ``'softplus'`` : Softplus
+            - ``'silu'`` : Sigmoid Linear Unit
 
         kernel_initializer : str, default 'glorot_uniform'
             Kernel initialization method. Should be one of ``'uniform'``, ``'glorot_uniform'``,
@@ -283,6 +284,7 @@ class Net(object):
             - ``'leakyrelu'`` : Leaky Rectified Linear Unit
             - ``'tanh'`` : Hyperbolic Tangent
             - ``'softplus'`` : Softplus
+            - ``'silu'`` : Sigmoid Linear Unit
 
         kernel_initializer : str, default 'glorot_uniform'
             Kernel initialization method. Should be one of ``'uniform'``, ``'glorot_uniform'``,

--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -17151,13 +17151,13 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_d
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1_d
+&   output_jacobian_1_d
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2_d
+&   output_jacobian_2_d
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_d, pn_d, en_d
     INTEGER :: row, col, k, time_step_returns
@@ -17190,9 +17190,9 @@ CONTAINS
         END IF
       END DO
     END DO
+    output_jacobian_1_d = 0.0_4
+    output_jacobian_2_d = 0.0_4
     output_layer_d = 0.0_4
-    jacobian_nn_1_d = 0.0_4
-    jacobian_nn_2_d = 0.0_4
 ! Forward MLP without OPENMP
     DO col=1,mesh%ncol
       DO row=1,mesh%nrow
@@ -17209,17 +17209,17 @@ CONTAINS
 &                                     weight_3_d, bias_3, bias_3_d, &
 &                                     input_layer, input_layer_d, &
 &                                     output_layer(:, k), output_layer_d&
-&                                     (:, k), jacobian_nn_1(:, k), &
-&                                     jacobian_nn_1_d(:, k), &
-&                                     jacobian_nn_2(:, k), &
-&                                     jacobian_nn_2_d(:, k))
+&                                     (:, k), output_jacobian_1(:, k), &
+&                                     output_jacobian_1_d(:, k), &
+&                                     output_jacobian_2(:, k), &
+&                                     output_jacobian_2_d(:, k))
           ELSE
             output_layer_d(:, k) = 0.0_4
             output_layer(:, k) = 0._sp
-            jacobian_nn_1_d(:, k) = 0.0_4
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2_d(:, k) = 0.0_4
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1_d(:, k) = 0.0_4
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2_d(:, k) = 0.0_4
+            output_jacobian_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17234,11 +17234,11 @@ CONTAINS
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_D(output_layer(:, k), &
 &                                         output_layer_d(:, k), &
-&                                         jacobian_nn_1(:, k), &
-&                                         jacobian_nn_1_d(:, k), &
-&                                         jacobian_nn_2(:, k), &
-&                                         jacobian_nn_2_d(:, k), pn(k), &
-&                                         pn_d(k), en(k), en_d(k), &
+&                                         output_jacobian_1(:, k), &
+&                                         output_jacobian_1_d(:, k), &
+&                                         output_jacobian_2(:, k), &
+&                                         output_jacobian_2_d(:, k), pn(&
+&                                         k), pn_d(k), en(k), en_d(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_d(k), ac_ct(k), ac_ct_d(&
 &                                         k), ac_kexc(k), ac_kexc_d(k), &
@@ -17310,13 +17310,13 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_b
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1_b
+&   output_jacobian_1_b
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2_b
+&   output_jacobian_2_b
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_b, pn_b, en_b
     INTEGER :: row, col, k, time_step_returns
@@ -17362,13 +17362,13 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
-&                                   , k))
+&                                   output_jacobian_1(:, k), &
+&                                   output_jacobian_2(:, k))
             CALL PUSHCONTROL2B(2)
           ELSE
             output_layer(:, k) = 0._sp
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2(:, k) = 0._sp
             CALL PUSHCONTROL2B(1)
           END IF
         END IF
@@ -17389,20 +17389,20 @@ CONTAINS
           CALL PUSHREAL4(ac_hp(k))
           CALL PUSHREAL4(pn(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn_1(:, k), &
-&                                       jacobian_nn_2(:, k), pn(k), en(k&
-&                                       ), imperviousness, ac_cp(k), &
-&                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
-&                                       ac_ht(k), ac_qt(k), l)
+&                                       output_jacobian_1(:, k), &
+&                                       output_jacobian_2(:, k), pn(k), &
+&                                       en(k), imperviousness, ac_cp(k)&
+&                                       , ac_ct(k), ac_kexc(k), ac_hp(k)&
+&                                       , ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
           CALL PUSHCONTROL1B(1)
         END IF
       END DO
     END DO
+    output_jacobian_1_b = 0.0_4
+    output_jacobian_2_b = 0.0_4
     output_layer_b = 0.0_4
     en_b = 0.0_4
-    jacobian_nn_1_b = 0.0_4
-    jacobian_nn_2_b = 0.0_4
     pn_b = 0.0_4
     DO col=mesh%ncol,1,-1
       DO row=mesh%nrow,1,-1
@@ -17419,11 +17419,11 @@ CONTAINS
           CALL POPREAL4(ac_qt(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_B(output_layer(:, k), &
 &                                         output_layer_b(:, k), &
-&                                         jacobian_nn_1(:, k), &
-&                                         jacobian_nn_1_b(:, k), &
-&                                         jacobian_nn_2(:, k), &
-&                                         jacobian_nn_2_b(:, k), pn(k), &
-&                                         pn_b(k), en(k), en_b(k), &
+&                                         output_jacobian_1(:, k), &
+&                                         output_jacobian_1_b(:, k), &
+&                                         output_jacobian_2(:, k), &
+&                                         output_jacobian_2_b(:, k), pn(&
+&                                         k), pn_b(k), en(k), en_b(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_b(k), ac_ct(k), ac_ct_b(&
 &                                         k), ac_kexc(k), ac_kexc_b(k), &
@@ -17440,8 +17440,8 @@ CONTAINS
         IF (branch .NE. 0) THEN
           IF (branch .EQ. 1) THEN
             k = mesh%rowcol_to_ind_ac(row, col)
-            jacobian_nn_2_b(:, k) = 0.0_4
-            jacobian_nn_1_b(:, k) = 0.0_4
+            output_jacobian_2_b(:, k) = 0.0_4
+            output_jacobian_1_b(:, k) = 0.0_4
             output_layer_b(:, k) = 0.0_4
           ELSE
             k = mesh%rowcol_to_ind_ac(row, col)
@@ -17451,13 +17451,13 @@ CONTAINS
 &                                     weight_3_b, bias_3, bias_3_b, &
 &                                     input_layer, input_layer_b, &
 &                                     output_layer(:, k), output_layer_b&
-&                                     (:, k), jacobian_nn_1(:, k), &
-&                                     jacobian_nn_1_b(:, k), &
-&                                     jacobian_nn_2(:, k), &
-&                                     jacobian_nn_2_b(:, k))
+&                                     (:, k), output_jacobian_1(:, k), &
+&                                     output_jacobian_1_b(:, k), &
+&                                     output_jacobian_2(:, k), &
+&                                     output_jacobian_2_b(:, k))
             output_layer_b(:, k) = 0.0_4
-            jacobian_nn_1_b(:, k) = 0.0_4
-            jacobian_nn_2_b(:, k) = 0.0_4
+            output_jacobian_1_b(:, k) = 0.0_4
+            output_jacobian_2_b(:, k) = 0.0_4
             CALL POPREAL4ARRAY(input_layer, setup%neurons(1))
             ac_hp_b(k) = ac_hp_b(k) + input_layer_b(1)
             ac_ht_b(k) = ac_ht_b(k) + input_layer_b(2)
@@ -17520,9 +17520,9 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     INTEGER :: row, col, k, time_step_returns
     REAL(sp) :: imperviousness, l
@@ -17558,12 +17558,12 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
-&                                   , k))
+&                                   output_jacobian_1(:, k), &
+&                                   output_jacobian_2(:, k))
           ELSE
             output_layer(:, k) = 0._sp
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17577,11 +17577,11 @@ CONTAINS
           imperviousness = input_data%physio_data%imperviousness(row, &
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn_1(:, k), &
-&                                       jacobian_nn_2(:, k), pn(k), en(k&
-&                                       ), imperviousness, ac_cp(k), &
-&                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
-&                                       ac_ht(k), ac_qt(k), l)
+&                                       output_jacobian_1(:, k), &
+&                                       output_jacobian_2(:, k), pn(k), &
+&                                       en(k), imperviousness, ac_cp(k)&
+&                                       , ac_ct(k), ac_kexc(k), ac_hp(k)&
+&                                       , ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
           ac_qt(k) = ac_qt(k)*1e-3_sp*mesh%dx(row, col)*mesh%dy(row, col&
 &           )/setup%dt

--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -12893,18 +12893,19 @@ CONTAINS
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_d
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_d
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(SIZE(bias_1)) :: temp
+    REAL(sp), DIMENSION(SIZE(bias_2)) :: temp0
     CALL DOT_PRODUCT_2D_1D_D(weight_1, weight_1_d, input_layer, &
 &                      input_layer_d, inter_layer_1, inter_layer_1_d)
     inter_layer_1_d = inter_layer_1_d + bias_1_d
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1 = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_d = 0.01_sp*inter_layer_1_d
-      inter_layer_1 = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_d = (inter_layer_1*EXP(-inter_layer_1)/temp+1.0)*&
+&     inter_layer_1_d/temp
+    inter_layer_1 = inter_layer_1/temp
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D_D(weight_2, weight_2_d, inter_layer_1, &
@@ -12912,12 +12913,11 @@ CONTAINS
 &                       )
       inter_layer_2_d = inter_layer_2_d + bias_2_d
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2 = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_d = 0.01_sp*inter_layer_2_d
-        inter_layer_2 = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_d = (inter_layer_2*EXP(-inter_layer_2)/temp0+1.0)*&
+&       inter_layer_2_d/temp0
+      inter_layer_2 = inter_layer_2/temp0
       CALL DOT_PRODUCT_2D_1D_D(weight_3, weight_3_d, inter_layer_2, &
 &                        inter_layer_2_d, output_layer, output_layer_d)
 ! TanH
@@ -12966,28 +12966,24 @@ CONTAINS
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_b
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_b
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(SIZE(bias_1)) :: temp
+    REAL(sp), DIMENSION(SIZE(bias_2)) :: temp0
     REAL(sp), DIMENSION(SIZE(bias_3, 1)) :: temp_b
     REAL(sp), DIMENSION(SIZE(bias_2, 1)) :: temp_b0
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
+! SiLU
     CALL PUSHREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) inter_layer_1 = &
-&       inter_layer_1
-    CALL PUSHREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) inter_layer_1&
-&      = 0.01_sp*inter_layer_1
+    inter_layer_1 = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
+! SiLU
       CALL PUSHREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) inter_layer_2 = &
-&         inter_layer_2
-      CALL PUSHREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) &
-&       inter_layer_2 = 0.01_sp*inter_layer_2
+      inter_layer_2 = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2, output_layer)
 ! TanH
       temp_b = (1.0-TANH(output_layer+bias_3)**2)*output_layer_b
@@ -12996,9 +12992,9 @@ CONTAINS
       CALL DOT_PRODUCT_2D_1D_B(weight_3, weight_3_b, inter_layer_2, &
 &                        inter_layer_2_b, output_layer, output_layer_b)
       CALL POPREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      CALL POPREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) &
-&       inter_layer_2_b = 0.01_sp*inter_layer_2_b
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_b = (1.0/temp0+EXP(-inter_layer_2)*inter_layer_2/&
+&       temp0**2)*inter_layer_2_b
       bias_2_b = bias_2_b + inter_layer_2_b
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1, &
 &                        inter_layer_1_b, inter_layer_2, inter_layer_2_b&
@@ -13013,10 +13009,10 @@ CONTAINS
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1, &
 &                        inter_layer_1_b, output_layer, output_layer_b)
     END IF
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) &
-&     inter_layer_1_b = 0.01_sp*inter_layer_1_b
     CALL POPREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    CALL POPREAL4ARRAY(inter_layer_1, SIZE(bias_1))
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_b = (1.0/temp+EXP(-inter_layer_1)*inter_layer_1/temp**&
+&     2)*inter_layer_1_b
     bias_1_b = bias_1_b + inter_layer_1_b
     CALL DOT_PRODUCT_2D_1D_B(weight_1, weight_1_b, input_layer, &
 &                      input_layer_b, inter_layer_1, inter_layer_1_b)
@@ -13036,24 +13032,18 @@ CONTAINS
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1 = inter_layer_1
-    ELSEWHERE
-      inter_layer_1 = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1 = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2 = inter_layer_2
-      ELSEWHERE
-        inter_layer_2 = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2 = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2, output_layer)
 ! TanH
       output_layer = TANH(output_layer + bias_3)
@@ -13066,13 +13056,15 @@ CONTAINS
   END SUBROUTINE FORWARD_MLP
 
 !  Differentiation of forward_and_backward_mlp in forward (tangent) mode (with options fixinterface noISIZE context):
-!   variations   of useful results: output_layer output_jacobian
+!   variations   of useful results: output_jacobian_1 output_jacobian_2
+!                output_layer
 !   with respect to varying inputs: bias_1 bias_2 bias_3 input_layer
 !                weight_1 weight_2 weight_3
   SUBROUTINE FORWARD_AND_BACKWARD_MLP_D(weight_1, weight_1_d, bias_1, &
 &   bias_1_d, weight_2, weight_2_d, bias_2, bias_2_d, weight_3, &
 &   weight_3_d, bias_3, bias_3_d, input_layer, input_layer_d, &
-&   output_layer, output_layer_d, output_jacobian, output_jacobian_d)
+&   output_layer, output_layer_d, output_jacobian_1, output_jacobian_1_d&
+&   , output_jacobian_2, output_jacobian_2_d)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1_d
@@ -13090,35 +13082,42 @@ CONTAINS
     REAL(sp), DIMENSION(:), INTENT(IN) :: input_layer_d
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer_d
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian_d
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1_d
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2_d
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_d, &
-&   inter_layer_1_tf_d, layer_1_gradient_d
+&   inter_layer_1_tf_d, inter_layer_1_grad_d, layer_1_grad_d
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_d, &
-&   inter_layer_2_tf_d, layer_2_gradient_d
+&   inter_layer_2_tf_d, inter_layer_2_grad_d, layer_2_grad_d
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
-    output_jacobian = 0._sp
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
+    REAL(sp), DIMENSION(size(bias_1)) :: temp
+    REAL(sp), DIMENSION(size(bias_2)) :: temp0
+    output_jacobian_1 = 0._sp
+    output_jacobian_2 = 0._sp
     CALL DOT_PRODUCT_2D_1D_D(weight_1, weight_1_d, input_layer, &
 &                      input_layer_d, inter_layer_1, inter_layer_1_d)
     inter_layer_1_d = inter_layer_1_d + bias_1_d
     inter_layer_1 = inter_layer_1 + bias_1
-    inter_layer_1_tf_d = 0.0_4
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf_d = inter_layer_1_d
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf_d = 0.01_sp*inter_layer_1_d
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_tf_d = (inter_layer_1*EXP(-inter_layer_1)/temp+1.0)*&
+&     inter_layer_1_d/temp
+    inter_layer_1_tf = inter_layer_1/temp
+! Derivative of SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_grad_d = inter_layer_1_tf_d + ((1._sp-inter_layer_1_tf&
+&     )*EXP(-inter_layer_1)*inter_layer_1_d/temp-inter_layer_1_tf_d)/&
+&     temp
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/&
+&     temp
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D_D(weight_2, weight_2_d, inter_layer_1_tf, &
@@ -13126,14 +13125,18 @@ CONTAINS
 &                        inter_layer_2_d)
       inter_layer_2_d = inter_layer_2_d + bias_2_d
       inter_layer_2 = inter_layer_2 + bias_2
-      inter_layer_2_tf_d = 0.0_4
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf_d = inter_layer_2_d
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf_d = 0.01_sp*inter_layer_2_d
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_tf_d = (inter_layer_2*EXP(-inter_layer_2)/temp0+1.0)&
+&       *inter_layer_2_d/temp0
+      inter_layer_2_tf = inter_layer_2/temp0
+! Derivative of SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_grad_d = inter_layer_2_tf_d + ((1._sp-&
+&       inter_layer_2_tf)*EXP(-inter_layer_2)*inter_layer_2_d/temp0-&
+&       inter_layer_2_tf_d)/temp0
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/&
+&       temp0
       CALL DOT_PRODUCT_2D_1D_D(weight_3, weight_3_d, inter_layer_2_tf, &
 &                        inter_layer_2_tf_d, output_layer, &
 &                        output_layer_d)
@@ -13141,49 +13144,45 @@ CONTAINS
       output_layer_d = (1.0-TANH(output_layer+bias_3)**2)*(&
 &       output_layer_d+bias_3_d)
       output_layer = TANH(output_layer + bias_3)
-      output_jacobian_d = 0.0_4
+      output_jacobian_1_d = 0.0_4
+      output_jacobian_2_d = 0.0_4
+      layer_2_grad_d = 0.0_4
 ! Compute Jacobian matrix of output wrt input MLP
       DO i=1,SIZE(output_layer)
-        layer_2_gradient_d = 0.0_4
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient_d(j) = (1._sp-output_layer(i)**2)*weight_3_d(&
-&           i, j) - weight_3(i, j)*2*output_layer(i)*output_layer_d(i)
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) THEN
-            layer_2_gradient_d(j) = 0.01_sp*layer_2_gradient_d(j)
-            layer_2_gradient(j) = layer_2_gradient(j)*0.01_sp
-          END IF
+          layer_2_grad_d(j) = (1._sp-output_layer(i)**2)*weight_3_d(i, j&
+&           ) - weight_3(i, j)*2*output_layer(i)*output_layer_d(i)
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          layer_2_grad_d(j) = inter_layer_2_grad(j)*layer_2_grad_d(j) + &
+&           layer_2_grad(j)*inter_layer_2_grad_d(j)
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
-        layer_1_gradient_d = 0.0_4
 ! Gradient of second layer wrt first layer
+        layer_1_grad = 0._sp
+        layer_1_grad_d = 0.0_4
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient_d(j) = layer_1_gradient_d(j) + weight_2(k, &
-&             j)*layer_2_gradient_d(k) + layer_2_gradient(k)*weight_2_d(&
-&             k, j)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad_d(j) = layer_1_grad_d(j) + weight_2(k, j)*&
+&             layer_2_grad_d(k) + layer_2_grad(k)*weight_2_d(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient_d(j) = 0.01_sp*layer_1_gradient_d(j)
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-          END IF
+          layer_1_grad_d(j) = inter_layer_1_grad(j)*layer_1_grad_d(j) + &
+&           layer_1_grad(j)*inter_layer_1_grad_d(j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian_d(i, j) = output_jacobian_d(i, j) + weight_1&
-&             (k, j)*layer_1_gradient_d(k) + layer_1_gradient(k)*&
-&             weight_1_d(k, j)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1_d(i) = output_jacobian_1_d(i) + weight_1(k, &
+&           1)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2_d(i) = output_jacobian_2_d(i) + weight_1(k, &
+&           2)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 2)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_2_gradient = 0._sp
-        layer_1_gradient = 0._sp
       END DO
     ELSE
 ! Case with 2 layers
@@ -13193,46 +13192,46 @@ CONTAINS
       output_layer_d = (1.0-TANH(output_layer+bias_2)**2)*(&
 &       output_layer_d+bias_2_d)
       output_layer = TANH(output_layer + bias_2)
-      output_jacobian_d = 0.0_4
+      output_jacobian_1_d = 0.0_4
+      output_jacobian_2_d = 0.0_4
+      layer_1_grad_d = 0.0_4
 ! Compute Jacobian matrix of output wrt input MLP
       DO i=1,SIZE(output_layer)
-        layer_1_gradient_d = 0.0_4
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient_d(j) = (1._sp-output_layer(i)**2)*weight_2_d(&
-&           i, j) - weight_2(i, j)*2*output_layer(i)*output_layer_d(i)
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient_d(j) = 0.01_sp*layer_1_gradient_d(j)
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-          END IF
+          layer_1_grad_d(j) = (1._sp-output_layer(i)**2)*weight_2_d(i, j&
+&           ) - weight_2(i, j)*2*output_layer(i)*output_layer_d(i)
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          layer_1_grad_d(j) = inter_layer_1_grad(j)*layer_1_grad_d(j) + &
+&           layer_1_grad(j)*inter_layer_1_grad_d(j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian_d(i, j) = output_jacobian_d(i, j) + weight_1&
-&             (k, j)*layer_1_gradient_d(k) + layer_1_gradient(k)*&
-&             weight_1_d(k, j)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1_d(i) = output_jacobian_1_d(i) + weight_1(k, &
+&           1)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2_d(i) = output_jacobian_2_d(i) + weight_1(k, &
+&           2)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 2)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_1_gradient = 0._sp
       END DO
     END IF
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP_D
 
 !  Differentiation of forward_and_backward_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context):
-!   gradient     of useful results: output_layer bias_1 bias_2
-!                bias_3 output_jacobian weight_1 weight_2 weight_3
+!   gradient     of useful results: output_jacobian_1 output_jacobian_2
+!                output_layer bias_1 bias_2 bias_3 weight_1 weight_2
+!                weight_3
 !   with respect to varying inputs: bias_1 bias_2 bias_3 input_layer
 !                weight_1 weight_2 weight_3
   SUBROUTINE FORWARD_AND_BACKWARD_MLP_B(weight_1, weight_1_b, bias_1, &
 &   bias_1_b, weight_2, weight_2_b, bias_2, bias_2_b, weight_3, &
 &   weight_3_b, bias_3, bias_3_b, input_layer, input_layer_b, &
-&   output_layer, output_layer_b, output_jacobian, output_jacobian_b)
+&   output_layer, output_layer_b, output_jacobian_1, output_jacobian_1_b&
+&   , output_jacobian_2, output_jacobian_2_b)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:, :) :: weight_1_b
@@ -13250,24 +13249,27 @@ CONTAINS
     REAL(sp), DIMENSION(:) :: input_layer_b
     REAL(sp), DIMENSION(:) :: output_layer
     REAL(sp), DIMENSION(:) :: output_layer_b
-    REAL(sp), DIMENSION(:, :) :: output_jacobian
-    REAL(sp), DIMENSION(:, :) :: output_jacobian_b
+    REAL(sp), DIMENSION(:) :: output_jacobian_1
+    REAL(sp), DIMENSION(:) :: output_jacobian_1_b
+    REAL(sp), DIMENSION(:) :: output_jacobian_2
+    REAL(sp), DIMENSION(:) :: output_jacobian_2_b
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_b, &
-&   inter_layer_1_tf_b, layer_1_gradient_b
+&   inter_layer_1_tf_b, inter_layer_1_grad_b, layer_1_grad_b
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_b, &
-&   inter_layer_2_tf_b, layer_2_gradient_b
+&   inter_layer_2_tf_b, inter_layer_2_grad_b, layer_2_grad_b
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(size(bias_1)) :: temp
+    REAL(sp), DIMENSION(size(bias_2)) :: temp0
     REAL(sp), DIMENSION(SIZE(bias_3, 1)) :: temp_b
     REAL(sp), DIMENSION(SIZE(bias_2, 1)) :: temp_b0
     INTEGER :: ad_to
-    INTEGER :: branch
     INTEGER :: ad_to0
     INTEGER :: ad_to1
     INTEGER :: ad_to2
@@ -13275,26 +13277,23 @@ CONTAINS
     INTEGER :: ad_to4
     INTEGER :: ad_to5
     INTEGER :: ad_to6
-    INTEGER :: ad_to7
-    INTEGER :: ad_to8
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1_tf = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
+! Derivative of SiLU
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/(&
+&     1._sp+EXP(-inter_layer_1))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1_tf, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2_tf = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)&
+&       ))
+! Derivative of SiLU
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/(&
+&       1._sp+EXP(-inter_layer_2))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2_tf, output_layer)
 ! TanH
       CALL PUSHREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13303,84 +13302,74 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) THEN
-            layer_2_gradient(j) = layer_2_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_2_grad(j))
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          CALL PUSHREAL4(layer_2_grad(j))
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of second layer wrt first layer
+        CALL PUSHREAL4ARRAY(layer_1_grad, SIZE(bias_1))
+        layer_1_grad = 0._sp
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
           CALL PUSHINTEGER4(k - 1)
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
+        DO k=1,SIZE(inter_layer_1)
 
-          END DO
-          CALL PUSHINTEGER4(k - 1)
         END DO
-        CALL PUSHINTEGER4(j - 1)
-! Reset tmp gradients
-        CALL PUSHREAL4ARRAY(layer_2_gradient, SIZE(bias_2))
-        layer_2_gradient = 0._sp
-        CALL PUSHREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient = 0._sp
+        CALL PUSHINTEGER4(k - 1)
       END DO
-      ad_to4 = i - 1
-      DO i=ad_to4,1,-1
-        CALL POPREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        CALL POPREAL4ARRAY(layer_2_gradient, SIZE(bias_2))
-        layer_1_gradient_b = 0.0_4
-        CALL POPINTEGER4(ad_to3)
-        DO j=ad_to3,1,-1
-          CALL POPINTEGER4(ad_to2)
-          DO k=ad_to2,1,-1
-            layer_1_gradient_b(k) = layer_1_gradient_b(k) + weight_1(k, &
-&             j)*output_jacobian_b(i, j)
-            weight_1_b(k, j) = weight_1_b(k, j) + layer_1_gradient(k)*&
-&             output_jacobian_b(i, j)
-          END DO
+      ad_to3 = i - 1
+      inter_layer_1_grad_b = 0.0_4
+      layer_2_grad_b = 0.0_4
+      inter_layer_2_grad_b = 0.0_4
+      DO i=ad_to3,1,-1
+        layer_1_grad_b = 0.0_4
+        CALL POPINTEGER4(ad_to2)
+        DO k=ad_to2,1,-1
+          layer_1_grad_b(k) = layer_1_grad_b(k) + weight_1(k, 2)*&
+&           output_jacobian_2_b(i) + weight_1(k, 1)*output_jacobian_1_b(&
+&           i)
+          weight_1_b(k, 2) = weight_1_b(k, 2) + layer_1_grad(k)*&
+&           output_jacobian_2_b(i)
+          weight_1_b(k, 1) = weight_1_b(k, 1) + layer_1_grad(k)*&
+&           output_jacobian_1_b(i)
         END DO
-        layer_2_gradient_b = 0.0_4
         CALL POPINTEGER4(ad_to1)
         DO j=ad_to1,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_1_gradient_b(j) = 0.01_sp*&
-&             layer_1_gradient_b(j)
+          CALL POPREAL4(layer_1_grad(j))
+          inter_layer_1_grad_b(j) = inter_layer_1_grad_b(j) + &
+&           layer_1_grad(j)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = inter_layer_1_grad(j)*layer_1_grad_b(j)
           CALL POPINTEGER4(ad_to0)
           DO k=ad_to0,1,-1
-            layer_2_gradient_b(k) = layer_2_gradient_b(k) + weight_2(k, &
-&             j)*layer_1_gradient_b(j)
-            weight_2_b(k, j) = weight_2_b(k, j) + layer_2_gradient(k)*&
-&             layer_1_gradient_b(j)
+            layer_2_grad_b(k) = layer_2_grad_b(k) + weight_2(k, j)*&
+&             layer_1_grad_b(j)
+            weight_2_b(k, j) = weight_2_b(k, j) + layer_2_grad(k)*&
+&             layer_1_grad_b(j)
           END DO
         END DO
+        CALL POPREAL4ARRAY(layer_1_grad, SIZE(bias_1))
         CALL POPINTEGER4(ad_to)
         DO j=ad_to,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_2_gradient_b(j) = 0.01_sp*&
-&             layer_2_gradient_b(j)
+          CALL POPREAL4(layer_2_grad(j))
+          inter_layer_2_grad_b(j) = inter_layer_2_grad_b(j) + &
+&           layer_2_grad(j)*layer_2_grad_b(j)
+          layer_2_grad_b(j) = inter_layer_2_grad(j)*layer_2_grad_b(j)
+          CALL POPREAL4(layer_2_grad(j))
           output_layer_b(i) = output_layer_b(i) - 2*output_layer(i)*&
-&           weight_3(i, j)*layer_2_gradient_b(j)
+&           weight_3(i, j)*layer_2_grad_b(j)
           weight_3_b(i, j) = weight_3_b(i, j) + (1._sp-output_layer(i)**&
-&           2)*layer_2_gradient_b(j)
-          layer_2_gradient_b(j) = 0.0_4
+&           2)*layer_2_grad_b(j)
+          layer_2_grad_b(j) = 0.0_4
         END DO
       END DO
       CALL POPREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13391,12 +13380,14 @@ CONTAINS
 &                        inter_layer_2_tf_b, output_layer, &
 &                        output_layer_b)
       inter_layer_2_b = 0.0_4
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_b = 0.01_sp*inter_layer_2_tf_b
-        inter_layer_2_tf_b = 0.0_4
-      ELSEWHERE
-        inter_layer_2_b = inter_layer_2_b + inter_layer_2_tf_b
-      END WHERE
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_tf_b = inter_layer_2_tf_b + (1.0-1.0/temp0)*&
+&       inter_layer_2_grad_b
+      inter_layer_2_b = EXP(-inter_layer_2)*(1._sp-inter_layer_2_tf)*&
+&       inter_layer_2_grad_b/temp0**2
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_b = inter_layer_2_b + (1.0/temp0+EXP(-inter_layer_2)&
+&       *inter_layer_2/temp0**2)*inter_layer_2_tf_b
       bias_2_b = bias_2_b + inter_layer_2_b
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1_tf, &
 &                        inter_layer_1_tf_b, inter_layer_2, &
@@ -13410,52 +13401,44 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
+        DO k=1,SIZE(inter_layer_1)
 
-          END DO
-          CALL PUSHINTEGER4(k - 1)
         END DO
-        CALL PUSHINTEGER4(j - 1)
-! Reset tmp gradients
-        CALL PUSHREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient = 0._sp
+        CALL PUSHINTEGER4(k - 1)
       END DO
-      ad_to8 = i - 1
-      DO i=ad_to8,1,-1
-        CALL POPREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient_b = 0.0_4
-        CALL POPINTEGER4(ad_to7)
-        DO j=ad_to7,1,-1
-          CALL POPINTEGER4(ad_to6)
-          DO k=ad_to6,1,-1
-            layer_1_gradient_b(k) = layer_1_gradient_b(k) + weight_1(k, &
-&             j)*output_jacobian_b(i, j)
-            weight_1_b(k, j) = weight_1_b(k, j) + layer_1_gradient(k)*&
-&             output_jacobian_b(i, j)
-          END DO
-        END DO
+      ad_to6 = i - 1
+      inter_layer_1_grad_b = 0.0_4
+      layer_1_grad_b = 0.0_4
+      DO i=ad_to6,1,-1
         CALL POPINTEGER4(ad_to5)
-        DO j=ad_to5,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_1_gradient_b(j) = 0.01_sp*&
-&             layer_1_gradient_b(j)
+        DO k=ad_to5,1,-1
+          layer_1_grad_b(k) = layer_1_grad_b(k) + weight_1(k, 2)*&
+&           output_jacobian_2_b(i) + weight_1(k, 1)*output_jacobian_1_b(&
+&           i)
+          weight_1_b(k, 2) = weight_1_b(k, 2) + layer_1_grad(k)*&
+&           output_jacobian_2_b(i)
+          weight_1_b(k, 1) = weight_1_b(k, 1) + layer_1_grad(k)*&
+&           output_jacobian_1_b(i)
+        END DO
+        CALL POPINTEGER4(ad_to4)
+        DO j=ad_to4,1,-1
+          CALL POPREAL4(layer_1_grad(j))
+          inter_layer_1_grad_b(j) = inter_layer_1_grad_b(j) + &
+&           layer_1_grad(j)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = inter_layer_1_grad(j)*layer_1_grad_b(j)
+          CALL POPREAL4(layer_1_grad(j))
           output_layer_b(i) = output_layer_b(i) - 2*output_layer(i)*&
-&           weight_2(i, j)*layer_1_gradient_b(j)
+&           weight_2(i, j)*layer_1_grad_b(j)
           weight_2_b(i, j) = weight_2_b(i, j) + (1._sp-output_layer(i)**&
-&           2)*layer_1_gradient_b(j)
-          layer_1_gradient_b(j) = 0.0_4
+&           2)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = 0.0_4
         END DO
       END DO
       CALL POPREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13467,19 +13450,22 @@ CONTAINS
 &                        output_layer_b)
     END IF
     inter_layer_1_b = 0.0_4
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_b = 0.01_sp*inter_layer_1_tf_b
-      inter_layer_1_tf_b = 0.0_4
-    ELSEWHERE
-      inter_layer_1_b = inter_layer_1_b + inter_layer_1_tf_b
-    END WHERE
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_tf_b = inter_layer_1_tf_b + (1.0-1.0/temp)*&
+&     inter_layer_1_grad_b
+    inter_layer_1_b = EXP(-inter_layer_1)*(1._sp-inter_layer_1_tf)*&
+&     inter_layer_1_grad_b/temp**2
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_b = inter_layer_1_b + (1.0/temp+EXP(-inter_layer_1)*&
+&     inter_layer_1/temp**2)*inter_layer_1_tf_b
     bias_1_b = bias_1_b + inter_layer_1_b
     CALL DOT_PRODUCT_2D_1D_B(weight_1, weight_1_b, input_layer, &
 &                      input_layer_b, inter_layer_1, inter_layer_1_b)
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP_B
 
   SUBROUTINE FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, bias_2&
-&   , weight_3, bias_3, input_layer, output_layer, output_jacobian)
+&   , weight_3, bias_3, input_layer, output_layer, output_jacobian_1, &
+&   output_jacobian_2)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:), INTENT(IN) :: bias_1
@@ -13489,34 +13475,35 @@ CONTAINS
     REAL(sp), DIMENSION(:), INTENT(IN) :: bias_3
     REAL(sp), DIMENSION(:), INTENT(IN) :: input_layer
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
-    output_jacobian = 0._sp
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
+    output_jacobian_1 = 0._sp
+    output_jacobian_2 = 0._sp
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1_tf = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
+! Derivative of SiLU
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/(&
+&     1._sp+EXP(-inter_layer_1))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1_tf, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2_tf = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)&
+&       ))
+! Derivative of SiLU
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/(&
+&       1._sp+EXP(-inter_layer_2))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2_tf, output_layer)
 ! TanH
       output_layer = TANH(output_layer + bias_3)
@@ -13524,30 +13511,25 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) layer_2_gradient(j) = &
-&             layer_2_gradient(j)*0.01_sp
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
 ! Gradient of second layer wrt first layer
+        layer_1_grad = 0._sp
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
-          IF (inter_layer_1(j) .LT. 0._sp) layer_1_gradient(j) = &
-&             layer_1_gradient(j)*0.01_sp
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_2_gradient = 0._sp
-        layer_1_gradient = 0._sp
       END DO
     ELSE
 ! Case with 2 layers
@@ -13557,20 +13539,16 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) layer_1_gradient(j) = &
-&             layer_1_gradient(j)*0.01_sp
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_1_gradient = 0._sp
       END DO
     END IF
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP
@@ -15150,19 +15128,23 @@ CONTAINS
 
 !  Differentiation of gr_production_transfer_ode_mlp in forward (tangent) mode (with options fixinterface noISIZE context):
 !   variations   of useful results: q hp ht pn
-!   with respect to varying inputs: kexc hp ht en jacobian_nn fq
-!                cp pn ct
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D(fq, fq_d, jacobian_nn, &
-&   jacobian_nn_d, pn, pn_d, en, en_d, imperviousness, cp, cp_d, ct, &
-&   ct_d, kexc, kexc_d, hp, hp_d, ht, ht_d, q, q_d, l)
+!   with respect to varying inputs: kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D(fq, fq_d, jacobian_nn_1, &
+&   jacobian_nn_1_d, jacobian_nn_2, jacobian_nn_2_d, pn, pn_d, en, en_d&
+&   , imperviousness, cp, cp_d, ct, ct_d, kexc, kexc_d, hp, hp_d, ht, &
+&   ht_d, q, q_d, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq_d
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn_d
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1_d
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2_d
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp), INTENT(IN) :: en_d, cp_d, ct_d, kexc_d
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
@@ -15228,50 +15210,51 @@ CONTAINS
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
-      temp1 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp0 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
+      temp1 = jacobian_nn_1(1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp0 = jacobian_nn_1(2)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2)&
+&       +1._sp)
       temp = pn*temp1 - en*temp0
       jacob_d(1, 1) = -(dt*(inv_cp*(temp1*pn_d+pn*((1-hp**2)*&
-&       jacobian_nn_d(1, 1)-jacobian_nn(1, 1)*2*hp*hp_d-2._sp*((fq(1)+&
-&       1._sp)*hp_d+hp*fq_d(1)))-temp0*en_d-en*(hp*(2._sp-hp)*&
-&       jacobian_nn_d(2, 1)+jacobian_nn(2, 1)*(2._sp-2*hp)*hp_d+2._sp*((&
-&       1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp*inv_cp_d))
+&       jacobian_nn_1_d(1)-jacobian_nn_1(1)*2*hp*hp_d-2._sp*((fq(1)+&
+&       1._sp)*hp_d+hp*fq_d(1)))-temp0*en_d-en*((2._sp-hp)*(hp*&
+&       jacobian_nn_1_d(2)+jacobian_nn_1(2)*hp_d)-jacobian_nn_1(2)*hp*&
+&       hp_d+2._sp*((1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp*&
+&       inv_cp_d))
       jacob(1, 1) = 1._sp - dt*(temp*inv_cp)
 ! -dt*nabla_ht(fhp)
-      temp1 = jacobian_nn(2, 2)*(-hp+2._sp)
-      temp0 = pn*jacobian_nn(1, 2)*(-(hp*hp)+1) - temp1*en*hp
-      jacob_d(1, 2) = -(dt*(inv_cp*((1-hp**2)*(jacobian_nn(1, 2)*pn_d+pn&
-&       *jacobian_nn_d(1, 2))-pn*jacobian_nn(1, 2)*2*hp*hp_d-en*hp*((&
-&       2._sp-hp)*jacobian_nn_d(2, 2)-jacobian_nn(2, 2)*hp_d)-temp1*(hp*&
-&       en_d+en*hp_d))+temp0*inv_cp_d))
-      jacob(1, 2) = -(dt*(temp0*inv_cp))
+      temp1 = pn*jacobian_nn_2(1)*(-(hp*hp)+1) - en*hp*jacobian_nn_2(2)*&
+&       (-hp+2._sp)
+      jacob_d(1, 2) = -(dt*(inv_cp*((1-hp**2)*(jacobian_nn_2(1)*pn_d+pn*&
+&       jacobian_nn_2_d(1))-pn*jacobian_nn_2(1)*2*hp*hp_d-jacobian_nn_2(&
+&       2)*(2._sp-hp)*(hp*en_d+en*hp_d)-en*hp*((2._sp-hp)*&
+&       jacobian_nn_2_d(2)-jacobian_nn_2(2)*hp_d))+temp1*inv_cp_d))
+      jacob(1, 2) = -(dt*(temp1*inv_cp))
 ! -dt*nabla_hp(fht)
-      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn_1(1)*hp
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn(4, 1)*ct*temp0 + &
-&       jacobian_nn(3, 1)*kexc*temp
+      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn_1(4)*ct*temp0 + &
+&       jacobian_nn_1(3)*kexc*temp
       jacob_d(2, 1) = -(dt*(inv_ct*(0.9_sp*(temp1*(hp*pn_d+pn*hp_d)+pn*&
-&       hp*(2._sp*fq_d(1)+hp*jacobian_nn_d(1, 1)+jacobian_nn(1, 1)*hp_d)&
-&       )-0.25_sp*(temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)&
-&       +jacobian_nn(4, 1)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_d(3, &
-&       1)+jacobian_nn(3, 1)*kexc_d)+jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
-&       2.5*ht_d)+temp2*inv_ct_d))
+&       hp*(2._sp*fq_d(1)+hp*jacobian_nn_1_d(1)+jacobian_nn_1(1)*hp_d))-&
+&       0.25_sp*(temp0*(ct*jacobian_nn_1_d(4)+jacobian_nn_1(4)*ct_d)+&
+&       jacobian_nn_1(4)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_1_d(3)+&
+&       jacobian_nn_1(3)*kexc_d)+jacobian_nn_1(3)*kexc*3.5_sp*ht**2.5*&
+&       ht_d)+temp2*inv_ct_d))
       jacob(2, 1) = -(dt*(temp2*inv_ct))
 ! 1 - dt*nabla_ht(fht)
       temp3 = ht**2.5
-      temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn_2(3)*ht
       temp1 = ht**4
-      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
-      temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn(1, 2)*pn*(hp*hp) - &
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn_2(4)*ht
+      temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn_2(1)*pn*(hp*hp) - &
 &       temp0*ct*temp1
       jacob_d(2, 2) = -(dt*(inv_ct*(temp3*(kexc*(3.5_sp*fq_d(3)+ht*&
-&       jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*ht_d)+temp2*kexc_d)+temp2*&
-&       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_d(1, 2)+&
-&       jacobian_nn(1, 2)*pn_d)+jacobian_nn(1, 2)*pn*2*hp*hp_d)-ct*temp1&
-&       *(1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_d(4, 2)+jacobian_nn(4&
-&       , 2)*ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
+&       jacobian_nn_2_d(3)+jacobian_nn_2(3)*ht_d)+temp2*kexc_d)+temp2*&
+&       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_2_d(1)+&
+&       jacobian_nn_2(1)*pn_d)+jacobian_nn_2(1)*pn*2*hp*hp_d)-ct*temp1*(&
+&       1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_2_d(4)+jacobian_nn_2(4)*&
+&       ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
       jacob(2, 2) = 1._sp - dt*(temp4*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -15316,21 +15299,25 @@ CONTAINS
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D
 
 !  Differentiation of gr_production_transfer_ode_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context):
-!   gradient     of useful results: q kexc hp ht en jacobian_nn
-!                fq cp pn ct
-!   with respect to varying inputs: kexc hp ht en jacobian_nn fq
-!                cp pn ct
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B(fq, fq_b, jacobian_nn, &
-&   jacobian_nn_b, pn, pn_b, en, en_b, imperviousness, cp, cp_b, ct, &
-&   ct_b, kexc, kexc_b, hp, hp_b, ht, ht_b, q, q_b, l)
+!   gradient     of useful results: q kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+!   with respect to varying inputs: kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B(fq, fq_b, jacobian_nn_1, &
+&   jacobian_nn_1_b, jacobian_nn_2, jacobian_nn_2_b, pn, pn_b, en, en_b&
+&   , imperviousness, cp, cp_b, ct, ct_b, kexc, kexc_b, hp, hp_b, ht, &
+&   ht_b, q, q_b, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     REAL(sp), DIMENSION(4) :: fq_b
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
-    REAL(sp), DIMENSION(SIZE(fq), 4) :: jacobian_nn_b
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+    REAL(sp), DIMENSION(SIZE(fq)) :: jacobian_nn_1_b
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
+    REAL(sp), DIMENSION(SIZE(fq)) :: jacobian_nn_2_b
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp) :: en_b, cp_b, ct_b, kexc_b
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
@@ -15389,23 +15376,23 @@ CONTAINS
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       CALL PUSHREAL4(jacob(1, 1))
-      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
-&       *(1._sp+fq(1)))-en*(jacobian_nn(2, 1)*hp*(2._sp-hp)+2._sp*(1._sp&
-&       -hp)*(1._sp+fq(2))))*inv_cp
+      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn_1(1)*(1-hp**2)-2._sp*hp*&
+&       (1._sp+fq(1)))-en*(jacobian_nn_1(2)*hp*(2._sp-hp)+2._sp*(1._sp-&
+&       hp)*(1._sp+fq(2))))*inv_cp
 ! -dt*nabla_ht(fhp)
       CALL PUSHREAL4(jacob(1, 2))
-      jacob(1, 2) = -(dt*(pn*jacobian_nn(1, 2)*(1-hp**2)-en*jacobian_nn(&
-&       2, 2)*hp*(2._sp-hp))*inv_cp)
+      jacob(1, 2) = -(dt*(pn*jacobian_nn_2(1)*(1-hp**2)-en*jacobian_nn_2&
+&       (2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
       CALL PUSHREAL4(jacob(2, 1))
-      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+&
+&       jacobian_nn_1(1)*hp)-0.25_sp*jacobian_nn_1(4)*ct*ht**5+&
+&       jacobian_nn_1(3)*kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
-      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
-&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn_2(3)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn_2(1)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn_2(4)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15485,12 +15472,12 @@ CONTAINS
 &                                delta_h_b, dh, dh_b)
       CALL POPREAL4(jacob(2, 2))
       temp5 = ht**2.5
-      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn_2(3)*ht
       temp2 = ht**4
       temp1 = ct*temp2
-      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn_2(4)*ht
       temp_b4 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn(1, 2)*&
+      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn_2(1)*&
 &       pn*hp**2)-temp0*temp1)*dt*jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
       temp_b5 = kexc*temp5*temp_b4
@@ -15499,70 +15486,70 @@ CONTAINS
       temp_b0 = -(temp1*temp_b4)
       ct_b = ct_b - temp2*temp0*temp_b4
       fq_b(4) = fq_b(4) + 1.25_sp*temp_b0
-      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*0.25_sp*temp_b0
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b3
-      pn_b = pn_b + jacobian_nn(1, 2)*temp_b3
-      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b5
+      jacobian_nn_2_b(4) = jacobian_nn_2_b(4) + ht*0.25_sp*temp_b0
+      jacobian_nn_2_b(1) = jacobian_nn_2_b(1) + pn*temp_b3
+      pn_b = pn_b + jacobian_nn_2(1)*temp_b3
+      jacobian_nn_2_b(3) = jacobian_nn_2_b(3) + ht*temp_b5
       CALL POPREAL4(jacob(2, 1))
-      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn_1(1)*hp
       temp_b3 = -(inv_ct*dt*jacob_b(2, 1))
       ht_b = ht_b + (2.5*ht**1.5*temp4*kexc-4*ht**3*ct*temp0)*temp_b4 + &
-&       jacobian_nn(4, 2)*0.25_sp*temp_b0 + jacobian_nn(3, 2)*temp_b5 + &
-&       (3.5_sp*ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)&
-&       *ct*0.25_sp)*temp_b3
+&       jacobian_nn_2(4)*0.25_sp*temp_b0 + jacobian_nn_2(3)*temp_b5 + (&
+&       3.5_sp*ht**2.5*jacobian_nn_1(3)*kexc-5*ht**4*jacobian_nn_1(4)*ct&
+&       *0.25_sp)*temp_b3
       temp0 = ht**5
       temp4 = ht**3.5_sp
       temp_b1 = temp2*0.9_sp*temp_b3
       temp_b2 = pn*hp*0.9_sp*temp_b3
+      hp_b = hp_b + 2*hp*jacobian_nn_2(1)*pn*0.9_sp*temp_b4 + &
+&       jacobian_nn_1(1)*temp_b2 + pn*temp_b1
       temp_b = -(temp0*0.25_sp*temp_b3)
-      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp4*temp_b3
-      kexc_b = kexc_b + jacobian_nn(3, 1)*temp4*temp_b3
-      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) + ct*temp_b
+      jacobian_nn_1_b(3) = jacobian_nn_1_b(3) + kexc*temp4*temp_b3
+      kexc_b = kexc_b + jacobian_nn_1(3)*temp4*temp_b3
+      jacobian_nn_1_b(4) = jacobian_nn_1_b(4) + ct*temp_b
       fq_b(1) = fq_b(1) + 2._sp*temp_b2
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b2
+      jacobian_nn_1_b(1) = jacobian_nn_1_b(1) + hp*temp_b2
       CALL POPREAL4(jacob(1, 2))
-      temp1 = en*hp
+      temp1 = jacobian_nn_2(2)*(-hp+2._sp)
       temp_b3 = -(inv_cp*dt*jacob_b(1, 2))
-      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp1*&
-&       temp_b3
+      en_b = en_b - hp*temp1*temp_b3
       CALL POPREAL4(jacob(1, 1))
       CALL POPREAL4(dh(2))
       ht0_b = ht0_b - dh_b(2)
       fht_b = -(dt*dh_b(2))
       inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-0.25_sp*((&
 &       fq(4)+1._sp)*ct*temp)+temp3*(kexc*(fq(3)+1._sp)))*fht_b - (&
-&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn(4, 1)*ct*temp0)+&
-&       jacobian_nn(3, 1)*kexc*temp4)*dt*jacob_b(2, 1)
+&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn_1(4)*ct*temp0)+&
+&       jacobian_nn_1(3)*kexc*temp4)*dt*jacob_b(2, 1)
       jacob_b(2, 1) = 0.0_4
       temp2 = -(hp*hp) + 1
-      pn_b = pn_b + hp*temp_b1 + jacobian_nn(1, 2)*temp2*temp_b3
-      temp0 = jacobian_nn(2, 2)*(-hp+2._sp)
-      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b4 + &
-&       jacobian_nn(1, 1)*temp_b2 + pn*temp_b1 + (jacobian_nn(2, 2)*&
-&       temp1-en*temp0-2*hp*pn*jacobian_nn(1, 2))*temp_b3
-      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp2-temp0*temp1)*dt*&
+      pn_b = pn_b + hp*temp_b1 + jacobian_nn_2(1)*temp2*temp_b3
+      inv_cp_b = inv_cp_b - (pn*jacobian_nn_2(1)*temp2-en*hp*temp1)*dt*&
 &       jacob_b(1, 2)
       jacob_b(1, 2) = 0.0_4
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp2*temp_b3
-      en_b = en_b - hp*temp0*temp_b3
-      temp2 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp1 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
+      jacobian_nn_2_b(1) = jacobian_nn_2_b(1) + pn*temp2*temp_b3
+      temp_b1 = -(en*hp*temp_b3)
+      hp_b = hp_b - (2*hp*pn*jacobian_nn_2(1)+en*temp1)*temp_b3 - &
+&       jacobian_nn_2(2)*temp_b1
+      jacobian_nn_2_b(2) = jacobian_nn_2_b(2) + (2._sp-hp)*temp_b1
+      temp2 = jacobian_nn_1(1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp1 = jacobian_nn_1(2)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2)&
+&       +1._sp)
       temp_b3 = -(inv_cp*dt*jacob_b(1, 1))
       inv_cp_b = inv_cp_b - (pn*temp2-en*temp1)*dt*jacob_b(1, 1)
       jacob_b(1, 1) = 0.0_4
       temp_b2 = pn*temp_b3
       en_b = en_b - temp1*temp_b3
       temp_b1 = -(en*temp_b3)
-      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b1
-      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
-&       fq(2)+1._sp)*2._sp)*temp_b1
+      jacobian_nn_1_b(2) = jacobian_nn_1_b(2) + hp*(2._sp-hp)*temp_b1
+      hp_b = hp_b + (jacobian_nn_1(2)*(2._sp-hp)-jacobian_nn_1(2)*hp-(fq&
+&       (2)+1._sp)*2._sp)*temp_b1
       fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b1
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b2
+      jacobian_nn_1_b(1) = jacobian_nn_1_b(1) + (1-hp**2)*temp_b2
       temp_b1 = inv_ct*fht_b
       fq_b(3) = fq_b(3) + 3.5_sp*temp_b5 + kexc*temp3*temp_b1
       hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1 - (2*hp*&
-&       jacobian_nn(1, 1)+(fq(1)+1._sp)*2._sp)*temp_b2
+&       jacobian_nn_1(1)+(fq(1)+1._sp)*2._sp)*temp_b2
       ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(3)+1._sp)-5*ht**4&
 &       *(fq(4)+1._sp)*ct*0.25_sp)*temp_b1
       dh_b(2) = 0.0_4
@@ -15570,7 +15557,7 @@ CONTAINS
       pn_b = pn_b + temp2*temp_b3 + (fq(1)+1._sp)*temp_b0
       fq_b(1) = fq_b(1) + pn*temp_b0 - hp*2._sp*temp_b2
       temp_b2 = -(temp*0.25_sp*temp_b1)
-      ct_b = ct_b + jacobian_nn(4, 1)*temp_b + (fq(4)+1._sp)*temp_b2
+      ct_b = ct_b + jacobian_nn_1(4)*temp_b + (fq(4)+1._sp)*temp_b2
       kexc_b = kexc_b + (fq(3)+1._sp)*temp3*temp_b1
       fq_b(4) = fq_b(4) + ct*temp_b2
       CALL POPREAL4(dh(1))
@@ -15597,14 +15584,16 @@ CONTAINS
     cp_b = cp_b - inv_cp_b/cp**2
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B
 
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP(fq, jacobian_nn, pn, en, &
-&   imperviousness, cp, ct, kexc, hp, ht, q, l)
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP(fq, jacobian_nn_1, &
+&   jacobian_nn_2, pn, en, imperviousness, cp, ct, kexc, hp, ht, q, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
     REAL(sp), INTENT(OUT) :: l
@@ -15636,20 +15625,20 @@ CONTAINS
 &       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
-      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
-&       *(1._sp+fq(1)))-en*(jacobian_nn(2, 1)*hp*(2._sp-hp)+2._sp*(1._sp&
-&       -hp)*(1._sp+fq(2))))*inv_cp
+      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn_1(1)*(1-hp**2)-2._sp*hp*&
+&       (1._sp+fq(1)))-en*(jacobian_nn_1(2)*hp*(2._sp-hp)+2._sp*(1._sp-&
+&       hp)*(1._sp+fq(2))))*inv_cp
 ! -dt*nabla_ht(fhp)
-      jacob(1, 2) = -(dt*(pn*jacobian_nn(1, 2)*(1-hp**2)-en*jacobian_nn(&
-&       2, 2)*hp*(2._sp-hp))*inv_cp)
+      jacob(1, 2) = -(dt*(pn*jacobian_nn_2(1)*(1-hp**2)-en*jacobian_nn_2&
+&       (2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
-      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+&
+&       jacobian_nn_1(1)*hp)-0.25_sp*jacobian_nn_1(4)*ct*ht**5+&
+&       jacobian_nn_1(3)*kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
-      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
-&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn_2(3)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn_2(1)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn_2(4)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -17161,10 +17150,14 @@ CONTAINS
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_d
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn_d
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1_d
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2_d
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_d, pn_d, en_d
     INTEGER :: row, col, k, time_step_returns
@@ -17198,7 +17191,8 @@ CONTAINS
       END DO
     END DO
     output_layer_d = 0.0_4
-    jacobian_nn_d = 0.0_4
+    jacobian_nn_1_d = 0.0_4
+    jacobian_nn_2_d = 0.0_4
 ! Forward MLP without OPENMP
     DO col=1,mesh%ncol
       DO row=1,mesh%nrow
@@ -17215,11 +17209,17 @@ CONTAINS
 &                                     weight_3_d, bias_3, bias_3_d, &
 &                                     input_layer, input_layer_d, &
 &                                     output_layer(:, k), output_layer_d&
-&                                     (:, k), jacobian_nn(:, :, k), &
-&                                     jacobian_nn_d(:, :, k))
+&                                     (:, k), jacobian_nn_1(:, k), &
+&                                     jacobian_nn_1_d(:, k), &
+&                                     jacobian_nn_2(:, k), &
+&                                     jacobian_nn_2_d(:, k))
           ELSE
             output_layer_d(:, k) = 0.0_4
             output_layer(:, k) = 0._sp
+            jacobian_nn_1_d(:, k) = 0.0_4
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2_d(:, k) = 0.0_4
+            jacobian_nn_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17234,9 +17234,11 @@ CONTAINS
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_D(output_layer(:, k), &
 &                                         output_layer_d(:, k), &
-&                                         jacobian_nn(:, :, k), &
-&                                         jacobian_nn_d(:, :, k), pn(k)&
-&                                         , pn_d(k), en(k), en_d(k), &
+&                                         jacobian_nn_1(:, k), &
+&                                         jacobian_nn_1_d(:, k), &
+&                                         jacobian_nn_2(:, k), &
+&                                         jacobian_nn_2_d(:, k), pn(k), &
+&                                         pn_d(k), en(k), en_d(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_d(k), ac_ct(k), ac_ct_d(&
 &                                         k), ac_kexc(k), ac_kexc_d(k), &
@@ -17307,10 +17309,14 @@ CONTAINS
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_b
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn_b
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1_b
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2_b
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_b, pn_b, en_b
     INTEGER :: row, col, k, time_step_returns
@@ -17356,10 +17362,13 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn(:, :, k))
+&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
+&                                   , k))
             CALL PUSHCONTROL2B(2)
           ELSE
             output_layer(:, k) = 0._sp
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2(:, k) = 0._sp
             CALL PUSHCONTROL2B(1)
           END IF
         END IF
@@ -17380,8 +17389,9 @@ CONTAINS
           CALL PUSHREAL4(ac_hp(k))
           CALL PUSHREAL4(pn(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn(:, :, k), pn(k), en(&
-&                                       k), imperviousness, ac_cp(k), &
+&                                       jacobian_nn_1(:, k), &
+&                                       jacobian_nn_2(:, k), pn(k), en(k&
+&                                       ), imperviousness, ac_cp(k), &
 &                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
 &                                       ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
@@ -17391,7 +17401,8 @@ CONTAINS
     END DO
     output_layer_b = 0.0_4
     en_b = 0.0_4
-    jacobian_nn_b = 0.0_4
+    jacobian_nn_1_b = 0.0_4
+    jacobian_nn_2_b = 0.0_4
     pn_b = 0.0_4
     DO col=mesh%ncol,1,-1
       DO row=mesh%nrow,1,-1
@@ -17408,9 +17419,11 @@ CONTAINS
           CALL POPREAL4(ac_qt(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_B(output_layer(:, k), &
 &                                         output_layer_b(:, k), &
-&                                         jacobian_nn(:, :, k), &
-&                                         jacobian_nn_b(:, :, k), pn(k)&
-&                                         , pn_b(k), en(k), en_b(k), &
+&                                         jacobian_nn_1(:, k), &
+&                                         jacobian_nn_1_b(:, k), &
+&                                         jacobian_nn_2(:, k), &
+&                                         jacobian_nn_2_b(:, k), pn(k), &
+&                                         pn_b(k), en(k), en_b(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_b(k), ac_ct(k), ac_ct_b(&
 &                                         k), ac_kexc(k), ac_kexc_b(k), &
@@ -17427,6 +17440,8 @@ CONTAINS
         IF (branch .NE. 0) THEN
           IF (branch .EQ. 1) THEN
             k = mesh%rowcol_to_ind_ac(row, col)
+            jacobian_nn_2_b(:, k) = 0.0_4
+            jacobian_nn_1_b(:, k) = 0.0_4
             output_layer_b(:, k) = 0.0_4
           ELSE
             k = mesh%rowcol_to_ind_ac(row, col)
@@ -17436,10 +17451,13 @@ CONTAINS
 &                                     weight_3_b, bias_3, bias_3_b, &
 &                                     input_layer, input_layer_b, &
 &                                     output_layer(:, k), output_layer_b&
-&                                     (:, k), jacobian_nn(:, :, k), &
-&                                     jacobian_nn_b(:, :, k))
+&                                     (:, k), jacobian_nn_1(:, k), &
+&                                     jacobian_nn_1_b(:, k), &
+&                                     jacobian_nn_2(:, k), &
+&                                     jacobian_nn_2_b(:, k))
             output_layer_b(:, k) = 0.0_4
-            jacobian_nn_b(:, :, k) = 0.0_4
+            jacobian_nn_1_b(:, k) = 0.0_4
+            jacobian_nn_2_b(:, k) = 0.0_4
             CALL POPREAL4ARRAY(input_layer, setup%neurons(1))
             ac_hp_b(k) = ac_hp_b(k) + input_layer_b(1)
             ac_ht_b(k) = ac_ht_b(k) + input_layer_b(2)
@@ -17501,8 +17519,10 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(1)) :: input_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     INTEGER :: row, col, k, time_step_returns
     REAL(sp) :: imperviousness, l
@@ -17538,9 +17558,12 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn(:, :, k))
+&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
+&                                   , k))
           ELSE
             output_layer(:, k) = 0._sp
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17554,8 +17577,9 @@ CONTAINS
           imperviousness = input_data%physio_data%imperviousness(row, &
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn(:, :, k), pn(k), en(&
-&                                       k), imperviousness, ac_cp(k), &
+&                                       jacobian_nn_1(:, k), &
+&                                       jacobian_nn_2(:, k), pn(k), en(k&
+&                                       ), imperviousness, ac_cp(k), &
 &                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
 &                                       ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s

--- a/smash/fcore/forward/forward_openmp_db.f90
+++ b/smash/fcore/forward/forward_openmp_db.f90
@@ -17393,13 +17393,13 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_d
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1_d
+&   output_jacobian_1_d
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2_d
+&   output_jacobian_2_d
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_d, pn_d, en_d
     INTEGER :: row, col, k, time_step_returns
@@ -17435,9 +17435,9 @@ CONTAINS
         END IF
       END DO
     END DO
+    output_jacobian_1_d = 0.0_4
+    output_jacobian_2_d = 0.0_4
     output_layer_d = 0.0_4
-    jacobian_nn_1_d = 0.0_4
-    jacobian_nn_2_d = 0.0_4
 ! Forward MLP without OPENMP
     DO col=1,mesh%ncol
       DO row=1,mesh%nrow
@@ -17454,17 +17454,17 @@ CONTAINS
 &                                     weight_3_d, bias_3, bias_3_d, &
 &                                     input_layer, input_layer_d, &
 &                                     output_layer(:, k), output_layer_d&
-&                                     (:, k), jacobian_nn_1(:, k), &
-&                                     jacobian_nn_1_d(:, k), &
-&                                     jacobian_nn_2(:, k), &
-&                                     jacobian_nn_2_d(:, k))
+&                                     (:, k), output_jacobian_1(:, k), &
+&                                     output_jacobian_1_d(:, k), &
+&                                     output_jacobian_2(:, k), &
+&                                     output_jacobian_2_d(:, k))
           ELSE
             output_layer_d(:, k) = 0.0_4
             output_layer(:, k) = 0._sp
-            jacobian_nn_1_d(:, k) = 0.0_4
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2_d(:, k) = 0.0_4
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1_d(:, k) = 0.0_4
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2_d(:, k) = 0.0_4
+            output_jacobian_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17479,11 +17479,11 @@ CONTAINS
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_D(output_layer(:, k), &
 &                                         output_layer_d(:, k), &
-&                                         jacobian_nn_1(:, k), &
-&                                         jacobian_nn_1_d(:, k), &
-&                                         jacobian_nn_2(:, k), &
-&                                         jacobian_nn_2_d(:, k), pn(k), &
-&                                         pn_d(k), en(k), en_d(k), &
+&                                         output_jacobian_1(:, k), &
+&                                         output_jacobian_1_d(:, k), &
+&                                         output_jacobian_2(:, k), &
+&                                         output_jacobian_2_d(:, k), pn(&
+&                                         k), pn_d(k), en(k), en_d(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_d(k), ac_ct(k), ac_ct_d(&
 &                                         k), ac_kexc(k), ac_kexc_d(k), &
@@ -17555,13 +17555,13 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_b
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1_b
+&   output_jacobian_1_b
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2_b
+&   output_jacobian_2_b
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_b, pn_b, en_b
     INTEGER :: row, col, k, time_step_returns
@@ -17616,13 +17616,13 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
-&                                   , k))
+&                                   output_jacobian_1(:, k), &
+&                                   output_jacobian_2(:, k))
             CALL PUSHCONTROL2B(2)
           ELSE
             output_layer(:, k) = 0._sp
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2(:, k) = 0._sp
             CALL PUSHCONTROL2B(1)
           END IF
         END IF
@@ -17643,20 +17643,20 @@ CONTAINS
           CALL PUSHREAL4(ac_hp(k))
           CALL PUSHREAL4(pn(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn_1(:, k), &
-&                                       jacobian_nn_2(:, k), pn(k), en(k&
-&                                       ), imperviousness, ac_cp(k), &
-&                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
-&                                       ac_ht(k), ac_qt(k), l)
+&                                       output_jacobian_1(:, k), &
+&                                       output_jacobian_2(:, k), pn(k), &
+&                                       en(k), imperviousness, ac_cp(k)&
+&                                       , ac_ct(k), ac_kexc(k), ac_hp(k)&
+&                                       , ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
           CALL PUSHCONTROL1B(1)
         END IF
       END DO
     END DO
+    output_jacobian_1_b = 0.0_4
+    output_jacobian_2_b = 0.0_4
     output_layer_b = 0.0_4
     en_b = 0.0_4
-    jacobian_nn_1_b = 0.0_4
-    jacobian_nn_2_b = 0.0_4
     pn_b = 0.0_4
     DO col=mesh%ncol,1,-1
       DO row=mesh%nrow,1,-1
@@ -17673,11 +17673,11 @@ CONTAINS
           CALL POPREAL4(ac_qt(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_B(output_layer(:, k), &
 &                                         output_layer_b(:, k), &
-&                                         jacobian_nn_1(:, k), &
-&                                         jacobian_nn_1_b(:, k), &
-&                                         jacobian_nn_2(:, k), &
-&                                         jacobian_nn_2_b(:, k), pn(k), &
-&                                         pn_b(k), en(k), en_b(k), &
+&                                         output_jacobian_1(:, k), &
+&                                         output_jacobian_1_b(:, k), &
+&                                         output_jacobian_2(:, k), &
+&                                         output_jacobian_2_b(:, k), pn(&
+&                                         k), pn_b(k), en(k), en_b(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_b(k), ac_ct(k), ac_ct_b(&
 &                                         k), ac_kexc(k), ac_kexc_b(k), &
@@ -17694,8 +17694,8 @@ CONTAINS
         IF (branch .NE. 0) THEN
           IF (branch .EQ. 1) THEN
             k = mesh%rowcol_to_ind_ac(row, col)
-            jacobian_nn_2_b(:, k) = 0.0_4
-            jacobian_nn_1_b(:, k) = 0.0_4
+            output_jacobian_2_b(:, k) = 0.0_4
+            output_jacobian_1_b(:, k) = 0.0_4
             output_layer_b(:, k) = 0.0_4
           ELSE
             k = mesh%rowcol_to_ind_ac(row, col)
@@ -17705,13 +17705,13 @@ CONTAINS
 &                                     weight_3_b, bias_3, bias_3_b, &
 &                                     input_layer, input_layer_b, &
 &                                     output_layer(:, k), output_layer_b&
-&                                     (:, k), jacobian_nn_1(:, k), &
-&                                     jacobian_nn_1_b(:, k), &
-&                                     jacobian_nn_2(:, k), &
-&                                     jacobian_nn_2_b(:, k))
+&                                     (:, k), output_jacobian_1(:, k), &
+&                                     output_jacobian_1_b(:, k), &
+&                                     output_jacobian_2(:, k), &
+&                                     output_jacobian_2_b(:, k))
             output_layer_b(:, k) = 0.0_4
-            jacobian_nn_1_b(:, k) = 0.0_4
-            jacobian_nn_2_b(:, k) = 0.0_4
+            output_jacobian_1_b(:, k) = 0.0_4
+            output_jacobian_2_b(:, k) = 0.0_4
             CALL POPREAL4ARRAY(input_layer, setup%neurons(1))
             ac_hp_b(k) = ac_hp_b(k) + input_layer_b(1)
             ac_ht_b(k) = ac_ht_b(k) + input_layer_b(2)
@@ -17784,9 +17784,9 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_1
+&   output_jacobian_1
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
-&   jacobian_nn_2
+&   output_jacobian_2
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     INTEGER :: row, col, k, time_step_returns
     REAL(sp) :: imperviousness, l
@@ -17825,12 +17825,12 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
-&                                   , k))
+&                                   output_jacobian_1(:, k), &
+&                                   output_jacobian_2(:, k))
           ELSE
             output_layer(:, k) = 0._sp
-            jacobian_nn_1(:, k) = 0._sp
-            jacobian_nn_2(:, k) = 0._sp
+            output_jacobian_1(:, k) = 0._sp
+            output_jacobian_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17844,11 +17844,11 @@ CONTAINS
           imperviousness = input_data%physio_data%imperviousness(row, &
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn_1(:, k), &
-&                                       jacobian_nn_2(:, k), pn(k), en(k&
-&                                       ), imperviousness, ac_cp(k), &
-&                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
-&                                       ac_ht(k), ac_qt(k), l)
+&                                       output_jacobian_1(:, k), &
+&                                       output_jacobian_2(:, k), pn(k), &
+&                                       en(k), imperviousness, ac_cp(k)&
+&                                       , ac_ct(k), ac_kexc(k), ac_hp(k)&
+&                                       , ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
           ac_qt(k) = ac_qt(k)*1e-3_sp*mesh%dx(row, col)*mesh%dy(row, col&
 &           )/setup%dt

--- a/smash/fcore/forward/forward_openmp_db.f90
+++ b/smash/fcore/forward/forward_openmp_db.f90
@@ -12895,18 +12895,19 @@ CONTAINS
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_d
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_d
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(SIZE(bias_1)) :: temp
+    REAL(sp), DIMENSION(SIZE(bias_2)) :: temp0
     CALL DOT_PRODUCT_2D_1D_D(weight_1, weight_1_d, input_layer, &
 &                      input_layer_d, inter_layer_1, inter_layer_1_d)
     inter_layer_1_d = inter_layer_1_d + bias_1_d
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1 = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_d = 0.01_sp*inter_layer_1_d
-      inter_layer_1 = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_d = (inter_layer_1*EXP(-inter_layer_1)/temp+1.0)*&
+&     inter_layer_1_d/temp
+    inter_layer_1 = inter_layer_1/temp
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D_D(weight_2, weight_2_d, inter_layer_1, &
@@ -12914,12 +12915,11 @@ CONTAINS
 &                       )
       inter_layer_2_d = inter_layer_2_d + bias_2_d
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2 = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_d = 0.01_sp*inter_layer_2_d
-        inter_layer_2 = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_d = (inter_layer_2*EXP(-inter_layer_2)/temp0+1.0)*&
+&       inter_layer_2_d/temp0
+      inter_layer_2 = inter_layer_2/temp0
       CALL DOT_PRODUCT_2D_1D_D(weight_3, weight_3_d, inter_layer_2, &
 &                        inter_layer_2_d, output_layer, output_layer_d)
 ! TanH
@@ -12968,28 +12968,24 @@ CONTAINS
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_b
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_b
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(SIZE(bias_1)) :: temp
+    REAL(sp), DIMENSION(SIZE(bias_2)) :: temp0
     REAL(sp), DIMENSION(SIZE(bias_3, 1)) :: temp_b
     REAL(sp), DIMENSION(SIZE(bias_2, 1)) :: temp_b0
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
+! SiLU
     CALL PUSHREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) inter_layer_1 = &
-&       inter_layer_1
-    CALL PUSHREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) inter_layer_1&
-&      = 0.01_sp*inter_layer_1
+    inter_layer_1 = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
+! SiLU
       CALL PUSHREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) inter_layer_2 = &
-&         inter_layer_2
-      CALL PUSHREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) &
-&       inter_layer_2 = 0.01_sp*inter_layer_2
+      inter_layer_2 = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2, output_layer)
 ! TanH
       temp_b = (1.0-TANH(output_layer+bias_3)**2)*output_layer_b
@@ -12998,9 +12994,9 @@ CONTAINS
       CALL DOT_PRODUCT_2D_1D_B(weight_3, weight_3_b, inter_layer_2, &
 &                        inter_layer_2_b, output_layer, output_layer_b)
       CALL POPREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      CALL POPREAL4ARRAY(inter_layer_2, SIZE(bias_2))
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) &
-&       inter_layer_2_b = 0.01_sp*inter_layer_2_b
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_b = (1.0/temp0+EXP(-inter_layer_2)*inter_layer_2/&
+&       temp0**2)*inter_layer_2_b
       bias_2_b = bias_2_b + inter_layer_2_b
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1, &
 &                        inter_layer_1_b, inter_layer_2, inter_layer_2_b&
@@ -13015,10 +13011,10 @@ CONTAINS
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1, &
 &                        inter_layer_1_b, output_layer, output_layer_b)
     END IF
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) &
-&     inter_layer_1_b = 0.01_sp*inter_layer_1_b
     CALL POPREAL4ARRAY(inter_layer_1, SIZE(bias_1))
-    CALL POPREAL4ARRAY(inter_layer_1, SIZE(bias_1))
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_b = (1.0/temp+EXP(-inter_layer_1)*inter_layer_1/temp**&
+&     2)*inter_layer_1_b
     bias_1_b = bias_1_b + inter_layer_1_b
     CALL DOT_PRODUCT_2D_1D_B(weight_1, weight_1_b, input_layer, &
 &                      input_layer_b, inter_layer_1, inter_layer_1_b)
@@ -13038,24 +13034,18 @@ CONTAINS
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1 = inter_layer_1
-    ELSEWHERE
-      inter_layer_1 = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1 = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2 = inter_layer_2
-      ELSEWHERE
-        inter_layer_2 = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2 = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2, output_layer)
 ! TanH
       output_layer = TANH(output_layer + bias_3)
@@ -13068,13 +13058,15 @@ CONTAINS
   END SUBROUTINE FORWARD_MLP
 
 !  Differentiation of forward_and_backward_mlp in forward (tangent) mode (with options fixinterface noISIZE context OpenMP):
-!   variations   of useful results: output_layer output_jacobian
+!   variations   of useful results: output_jacobian_1 output_jacobian_2
+!                output_layer
 !   with respect to varying inputs: bias_1 bias_2 bias_3 input_layer
 !                weight_1 weight_2 weight_3
   SUBROUTINE FORWARD_AND_BACKWARD_MLP_D(weight_1, weight_1_d, bias_1, &
 &   bias_1_d, weight_2, weight_2_d, bias_2, bias_2_d, weight_3, &
 &   weight_3_d, bias_3, bias_3_d, input_layer, input_layer_d, &
-&   output_layer, output_layer_d, output_jacobian, output_jacobian_d)
+&   output_layer, output_layer_d, output_jacobian_1, output_jacobian_1_d&
+&   , output_jacobian_2, output_jacobian_2_d)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1_d
@@ -13092,35 +13084,42 @@ CONTAINS
     REAL(sp), DIMENSION(:), INTENT(IN) :: input_layer_d
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer_d
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian_d
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1_d
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2_d
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_d, &
-&   inter_layer_1_tf_d, layer_1_gradient_d
+&   inter_layer_1_tf_d, inter_layer_1_grad_d, layer_1_grad_d
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_d, &
-&   inter_layer_2_tf_d, layer_2_gradient_d
+&   inter_layer_2_tf_d, inter_layer_2_grad_d, layer_2_grad_d
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
-    output_jacobian = 0._sp
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
+    REAL(sp), DIMENSION(size(bias_1)) :: temp
+    REAL(sp), DIMENSION(size(bias_2)) :: temp0
+    output_jacobian_1 = 0._sp
+    output_jacobian_2 = 0._sp
     CALL DOT_PRODUCT_2D_1D_D(weight_1, weight_1_d, input_layer, &
 &                      input_layer_d, inter_layer_1, inter_layer_1_d)
     inter_layer_1_d = inter_layer_1_d + bias_1_d
     inter_layer_1 = inter_layer_1 + bias_1
-    inter_layer_1_tf_d = 0.0_4
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf_d = inter_layer_1_d
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf_d = 0.01_sp*inter_layer_1_d
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_tf_d = (inter_layer_1*EXP(-inter_layer_1)/temp+1.0)*&
+&     inter_layer_1_d/temp
+    inter_layer_1_tf = inter_layer_1/temp
+! Derivative of SiLU
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_grad_d = inter_layer_1_tf_d + ((1._sp-inter_layer_1_tf&
+&     )*EXP(-inter_layer_1)*inter_layer_1_d/temp-inter_layer_1_tf_d)/&
+&     temp
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/&
+&     temp
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D_D(weight_2, weight_2_d, inter_layer_1_tf, &
@@ -13128,14 +13127,18 @@ CONTAINS
 &                        inter_layer_2_d)
       inter_layer_2_d = inter_layer_2_d + bias_2_d
       inter_layer_2 = inter_layer_2 + bias_2
-      inter_layer_2_tf_d = 0.0_4
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf_d = inter_layer_2_d
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf_d = 0.01_sp*inter_layer_2_d
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_tf_d = (inter_layer_2*EXP(-inter_layer_2)/temp0+1.0)&
+&       *inter_layer_2_d/temp0
+      inter_layer_2_tf = inter_layer_2/temp0
+! Derivative of SiLU
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_grad_d = inter_layer_2_tf_d + ((1._sp-&
+&       inter_layer_2_tf)*EXP(-inter_layer_2)*inter_layer_2_d/temp0-&
+&       inter_layer_2_tf_d)/temp0
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/&
+&       temp0
       CALL DOT_PRODUCT_2D_1D_D(weight_3, weight_3_d, inter_layer_2_tf, &
 &                        inter_layer_2_tf_d, output_layer, &
 &                        output_layer_d)
@@ -13143,49 +13146,45 @@ CONTAINS
       output_layer_d = (1.0-TANH(output_layer+bias_3)**2)*(&
 &       output_layer_d+bias_3_d)
       output_layer = TANH(output_layer + bias_3)
-      output_jacobian_d = 0.0_4
+      output_jacobian_1_d = 0.0_4
+      output_jacobian_2_d = 0.0_4
+      layer_2_grad_d = 0.0_4
 ! Compute Jacobian matrix of output wrt input MLP
       DO i=1,SIZE(output_layer)
-        layer_2_gradient_d = 0.0_4
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient_d(j) = (1._sp-output_layer(i)**2)*weight_3_d(&
-&           i, j) - weight_3(i, j)*2*output_layer(i)*output_layer_d(i)
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) THEN
-            layer_2_gradient_d(j) = 0.01_sp*layer_2_gradient_d(j)
-            layer_2_gradient(j) = layer_2_gradient(j)*0.01_sp
-          END IF
+          layer_2_grad_d(j) = (1._sp-output_layer(i)**2)*weight_3_d(i, j&
+&           ) - weight_3(i, j)*2*output_layer(i)*output_layer_d(i)
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          layer_2_grad_d(j) = inter_layer_2_grad(j)*layer_2_grad_d(j) + &
+&           layer_2_grad(j)*inter_layer_2_grad_d(j)
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
-        layer_1_gradient_d = 0.0_4
 ! Gradient of second layer wrt first layer
+        layer_1_grad = 0._sp
+        layer_1_grad_d = 0.0_4
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient_d(j) = layer_1_gradient_d(j) + weight_2(k, &
-&             j)*layer_2_gradient_d(k) + layer_2_gradient(k)*weight_2_d(&
-&             k, j)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad_d(j) = layer_1_grad_d(j) + weight_2(k, j)*&
+&             layer_2_grad_d(k) + layer_2_grad(k)*weight_2_d(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient_d(j) = 0.01_sp*layer_1_gradient_d(j)
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-          END IF
+          layer_1_grad_d(j) = inter_layer_1_grad(j)*layer_1_grad_d(j) + &
+&           layer_1_grad(j)*inter_layer_1_grad_d(j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian_d(i, j) = output_jacobian_d(i, j) + weight_1&
-&             (k, j)*layer_1_gradient_d(k) + layer_1_gradient(k)*&
-&             weight_1_d(k, j)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1_d(i) = output_jacobian_1_d(i) + weight_1(k, &
+&           1)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2_d(i) = output_jacobian_2_d(i) + weight_1(k, &
+&           2)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 2)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_2_gradient = 0._sp
-        layer_1_gradient = 0._sp
       END DO
     ELSE
 ! Case with 2 layers
@@ -13195,46 +13194,46 @@ CONTAINS
       output_layer_d = (1.0-TANH(output_layer+bias_2)**2)*(&
 &       output_layer_d+bias_2_d)
       output_layer = TANH(output_layer + bias_2)
-      output_jacobian_d = 0.0_4
+      output_jacobian_1_d = 0.0_4
+      output_jacobian_2_d = 0.0_4
+      layer_1_grad_d = 0.0_4
 ! Compute Jacobian matrix of output wrt input MLP
       DO i=1,SIZE(output_layer)
-        layer_1_gradient_d = 0.0_4
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient_d(j) = (1._sp-output_layer(i)**2)*weight_2_d(&
-&           i, j) - weight_2(i, j)*2*output_layer(i)*output_layer_d(i)
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient_d(j) = 0.01_sp*layer_1_gradient_d(j)
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-          END IF
+          layer_1_grad_d(j) = (1._sp-output_layer(i)**2)*weight_2_d(i, j&
+&           ) - weight_2(i, j)*2*output_layer(i)*output_layer_d(i)
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          layer_1_grad_d(j) = inter_layer_1_grad(j)*layer_1_grad_d(j) + &
+&           layer_1_grad(j)*inter_layer_1_grad_d(j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian_d(i, j) = output_jacobian_d(i, j) + weight_1&
-&             (k, j)*layer_1_gradient_d(k) + layer_1_gradient(k)*&
-&             weight_1_d(k, j)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1_d(i) = output_jacobian_1_d(i) + weight_1(k, &
+&           1)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2_d(i) = output_jacobian_2_d(i) + weight_1(k, &
+&           2)*layer_1_grad_d(k) + layer_1_grad(k)*weight_1_d(k, 2)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_1_gradient = 0._sp
       END DO
     END IF
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP_D
 
 !  Differentiation of forward_and_backward_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context OpenMP):
-!   gradient     of useful results: output_layer bias_1 bias_2
-!                bias_3 output_jacobian weight_1 weight_2 weight_3
+!   gradient     of useful results: output_jacobian_1 output_jacobian_2
+!                output_layer bias_1 bias_2 bias_3 weight_1 weight_2
+!                weight_3
 !   with respect to varying inputs: bias_1 bias_2 bias_3 input_layer
 !                weight_1 weight_2 weight_3
   SUBROUTINE FORWARD_AND_BACKWARD_MLP_B(weight_1, weight_1_b, bias_1, &
 &   bias_1_b, weight_2, weight_2_b, bias_2, bias_2_b, weight_3, &
 &   weight_3_b, bias_3, bias_3_b, input_layer, input_layer_b, &
-&   output_layer, output_layer_b, output_jacobian, output_jacobian_b)
+&   output_layer, output_layer_b, output_jacobian_1, output_jacobian_1_b&
+&   , output_jacobian_2, output_jacobian_2_b)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:, :) :: weight_1_b
@@ -13252,24 +13251,27 @@ CONTAINS
     REAL(sp), DIMENSION(:) :: input_layer_b
     REAL(sp), DIMENSION(:) :: output_layer
     REAL(sp), DIMENSION(:) :: output_layer_b
-    REAL(sp), DIMENSION(:, :) :: output_jacobian
-    REAL(sp), DIMENSION(:, :) :: output_jacobian_b
+    REAL(sp), DIMENSION(:) :: output_jacobian_1
+    REAL(sp), DIMENSION(:) :: output_jacobian_1_b
+    REAL(sp), DIMENSION(:) :: output_jacobian_2
+    REAL(sp), DIMENSION(:) :: output_jacobian_2_b
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1_b, &
-&   inter_layer_1_tf_b, layer_1_gradient_b
+&   inter_layer_1_tf_b, inter_layer_1_grad_b, layer_1_grad_b
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2_b, &
-&   inter_layer_2_tf_b, layer_2_gradient_b
+&   inter_layer_2_tf_b, inter_layer_2_grad_b, layer_2_grad_b
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
+    REAL(sp), DIMENSION(size(bias_1)) :: temp
+    REAL(sp), DIMENSION(size(bias_2)) :: temp0
     REAL(sp), DIMENSION(SIZE(bias_3, 1)) :: temp_b
     REAL(sp), DIMENSION(SIZE(bias_2, 1)) :: temp_b0
     INTEGER :: ad_to
-    INTEGER :: branch
     INTEGER :: ad_to0
     INTEGER :: ad_to1
     INTEGER :: ad_to2
@@ -13277,26 +13279,23 @@ CONTAINS
     INTEGER :: ad_to4
     INTEGER :: ad_to5
     INTEGER :: ad_to6
-    INTEGER :: ad_to7
-    INTEGER :: ad_to8
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1_tf = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
+! Derivative of SiLU
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/(&
+&     1._sp+EXP(-inter_layer_1))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1_tf, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2_tf = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)&
+&       ))
+! Derivative of SiLU
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/(&
+&       1._sp+EXP(-inter_layer_2))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2_tf, output_layer)
 ! TanH
       CALL PUSHREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13305,84 +13304,74 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) THEN
-            layer_2_gradient(j) = layer_2_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_2_grad(j))
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          CALL PUSHREAL4(layer_2_grad(j))
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of second layer wrt first layer
+        CALL PUSHREAL4ARRAY(layer_1_grad, SIZE(bias_1))
+        layer_1_grad = 0._sp
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
           CALL PUSHINTEGER4(k - 1)
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
+        DO k=1,SIZE(inter_layer_1)
 
-          END DO
-          CALL PUSHINTEGER4(k - 1)
         END DO
-        CALL PUSHINTEGER4(j - 1)
-! Reset tmp gradients
-        CALL PUSHREAL4ARRAY(layer_2_gradient, SIZE(bias_2))
-        layer_2_gradient = 0._sp
-        CALL PUSHREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient = 0._sp
+        CALL PUSHINTEGER4(k - 1)
       END DO
-      ad_to4 = i - 1
-      DO i=ad_to4,1,-1
-        CALL POPREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        CALL POPREAL4ARRAY(layer_2_gradient, SIZE(bias_2))
-        layer_1_gradient_b = 0.0_4
-        CALL POPINTEGER4(ad_to3)
-        DO j=ad_to3,1,-1
-          CALL POPINTEGER4(ad_to2)
-          DO k=ad_to2,1,-1
-            layer_1_gradient_b(k) = layer_1_gradient_b(k) + weight_1(k, &
-&             j)*output_jacobian_b(i, j)
-            weight_1_b(k, j) = weight_1_b(k, j) + layer_1_gradient(k)*&
-&             output_jacobian_b(i, j)
-          END DO
+      ad_to3 = i - 1
+      inter_layer_1_grad_b = 0.0_4
+      layer_2_grad_b = 0.0_4
+      inter_layer_2_grad_b = 0.0_4
+      DO i=ad_to3,1,-1
+        layer_1_grad_b = 0.0_4
+        CALL POPINTEGER4(ad_to2)
+        DO k=ad_to2,1,-1
+          layer_1_grad_b(k) = layer_1_grad_b(k) + weight_1(k, 2)*&
+&           output_jacobian_2_b(i) + weight_1(k, 1)*output_jacobian_1_b(&
+&           i)
+          weight_1_b(k, 2) = weight_1_b(k, 2) + layer_1_grad(k)*&
+&           output_jacobian_2_b(i)
+          weight_1_b(k, 1) = weight_1_b(k, 1) + layer_1_grad(k)*&
+&           output_jacobian_1_b(i)
         END DO
-        layer_2_gradient_b = 0.0_4
         CALL POPINTEGER4(ad_to1)
         DO j=ad_to1,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_1_gradient_b(j) = 0.01_sp*&
-&             layer_1_gradient_b(j)
+          CALL POPREAL4(layer_1_grad(j))
+          inter_layer_1_grad_b(j) = inter_layer_1_grad_b(j) + &
+&           layer_1_grad(j)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = inter_layer_1_grad(j)*layer_1_grad_b(j)
           CALL POPINTEGER4(ad_to0)
           DO k=ad_to0,1,-1
-            layer_2_gradient_b(k) = layer_2_gradient_b(k) + weight_2(k, &
-&             j)*layer_1_gradient_b(j)
-            weight_2_b(k, j) = weight_2_b(k, j) + layer_2_gradient(k)*&
-&             layer_1_gradient_b(j)
+            layer_2_grad_b(k) = layer_2_grad_b(k) + weight_2(k, j)*&
+&             layer_1_grad_b(j)
+            weight_2_b(k, j) = weight_2_b(k, j) + layer_2_grad(k)*&
+&             layer_1_grad_b(j)
           END DO
         END DO
+        CALL POPREAL4ARRAY(layer_1_grad, SIZE(bias_1))
         CALL POPINTEGER4(ad_to)
         DO j=ad_to,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_2_gradient_b(j) = 0.01_sp*&
-&             layer_2_gradient_b(j)
+          CALL POPREAL4(layer_2_grad(j))
+          inter_layer_2_grad_b(j) = inter_layer_2_grad_b(j) + &
+&           layer_2_grad(j)*layer_2_grad_b(j)
+          layer_2_grad_b(j) = inter_layer_2_grad(j)*layer_2_grad_b(j)
+          CALL POPREAL4(layer_2_grad(j))
           output_layer_b(i) = output_layer_b(i) - 2*output_layer(i)*&
-&           weight_3(i, j)*layer_2_gradient_b(j)
+&           weight_3(i, j)*layer_2_grad_b(j)
           weight_3_b(i, j) = weight_3_b(i, j) + (1._sp-output_layer(i)**&
-&           2)*layer_2_gradient_b(j)
-          layer_2_gradient_b(j) = 0.0_4
+&           2)*layer_2_grad_b(j)
+          layer_2_grad_b(j) = 0.0_4
         END DO
       END DO
       CALL POPREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13393,12 +13382,14 @@ CONTAINS
 &                        inter_layer_2_tf_b, output_layer, &
 &                        output_layer_b)
       inter_layer_2_b = 0.0_4
-      WHERE (.NOT.0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_b = 0.01_sp*inter_layer_2_tf_b
-        inter_layer_2_tf_b = 0.0_4
-      ELSEWHERE
-        inter_layer_2_b = inter_layer_2_b + inter_layer_2_tf_b
-      END WHERE
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_tf_b = inter_layer_2_tf_b + (1.0-1.0/temp0)*&
+&       inter_layer_2_grad_b
+      inter_layer_2_b = EXP(-inter_layer_2)*(1._sp-inter_layer_2_tf)*&
+&       inter_layer_2_grad_b/temp0**2
+      temp0 = EXP(-inter_layer_2) + 1._sp
+      inter_layer_2_b = inter_layer_2_b + (1.0/temp0+EXP(-inter_layer_2)&
+&       *inter_layer_2/temp0**2)*inter_layer_2_tf_b
       bias_2_b = bias_2_b + inter_layer_2_b
       CALL DOT_PRODUCT_2D_1D_B(weight_2, weight_2_b, inter_layer_1_tf, &
 &                        inter_layer_1_tf_b, inter_layer_2, &
@@ -13412,52 +13403,44 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) THEN
-            layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
-            CALL PUSHCONTROL1B(1)
-          ELSE
-            CALL PUSHCONTROL1B(0)
-          END IF
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          CALL PUSHREAL4(layer_1_grad(j))
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
         CALL PUSHINTEGER4(j - 1)
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
+        DO k=1,SIZE(inter_layer_1)
 
-          END DO
-          CALL PUSHINTEGER4(k - 1)
         END DO
-        CALL PUSHINTEGER4(j - 1)
-! Reset tmp gradients
-        CALL PUSHREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient = 0._sp
+        CALL PUSHINTEGER4(k - 1)
       END DO
-      ad_to8 = i - 1
-      DO i=ad_to8,1,-1
-        CALL POPREAL4ARRAY(layer_1_gradient, SIZE(bias_1))
-        layer_1_gradient_b = 0.0_4
-        CALL POPINTEGER4(ad_to7)
-        DO j=ad_to7,1,-1
-          CALL POPINTEGER4(ad_to6)
-          DO k=ad_to6,1,-1
-            layer_1_gradient_b(k) = layer_1_gradient_b(k) + weight_1(k, &
-&             j)*output_jacobian_b(i, j)
-            weight_1_b(k, j) = weight_1_b(k, j) + layer_1_gradient(k)*&
-&             output_jacobian_b(i, j)
-          END DO
-        END DO
+      ad_to6 = i - 1
+      inter_layer_1_grad_b = 0.0_4
+      layer_1_grad_b = 0.0_4
+      DO i=ad_to6,1,-1
         CALL POPINTEGER4(ad_to5)
-        DO j=ad_to5,1,-1
-          CALL POPCONTROL1B(branch)
-          IF (branch .NE. 0) layer_1_gradient_b(j) = 0.01_sp*&
-&             layer_1_gradient_b(j)
+        DO k=ad_to5,1,-1
+          layer_1_grad_b(k) = layer_1_grad_b(k) + weight_1(k, 2)*&
+&           output_jacobian_2_b(i) + weight_1(k, 1)*output_jacobian_1_b(&
+&           i)
+          weight_1_b(k, 2) = weight_1_b(k, 2) + layer_1_grad(k)*&
+&           output_jacobian_2_b(i)
+          weight_1_b(k, 1) = weight_1_b(k, 1) + layer_1_grad(k)*&
+&           output_jacobian_1_b(i)
+        END DO
+        CALL POPINTEGER4(ad_to4)
+        DO j=ad_to4,1,-1
+          CALL POPREAL4(layer_1_grad(j))
+          inter_layer_1_grad_b(j) = inter_layer_1_grad_b(j) + &
+&           layer_1_grad(j)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = inter_layer_1_grad(j)*layer_1_grad_b(j)
+          CALL POPREAL4(layer_1_grad(j))
           output_layer_b(i) = output_layer_b(i) - 2*output_layer(i)*&
-&           weight_2(i, j)*layer_1_gradient_b(j)
+&           weight_2(i, j)*layer_1_grad_b(j)
           weight_2_b(i, j) = weight_2_b(i, j) + (1._sp-output_layer(i)**&
-&           2)*layer_1_gradient_b(j)
-          layer_1_gradient_b(j) = 0.0_4
+&           2)*layer_1_grad_b(j)
+          layer_1_grad_b(j) = 0.0_4
         END DO
       END DO
       CALL POPREAL4ARRAY(output_layer, SIZE(output_layer, 1))
@@ -13469,19 +13452,22 @@ CONTAINS
 &                        output_layer_b)
     END IF
     inter_layer_1_b = 0.0_4
-    WHERE (.NOT.0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_b = 0.01_sp*inter_layer_1_tf_b
-      inter_layer_1_tf_b = 0.0_4
-    ELSEWHERE
-      inter_layer_1_b = inter_layer_1_b + inter_layer_1_tf_b
-    END WHERE
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_tf_b = inter_layer_1_tf_b + (1.0-1.0/temp)*&
+&     inter_layer_1_grad_b
+    inter_layer_1_b = EXP(-inter_layer_1)*(1._sp-inter_layer_1_tf)*&
+&     inter_layer_1_grad_b/temp**2
+    temp = EXP(-inter_layer_1) + 1._sp
+    inter_layer_1_b = inter_layer_1_b + (1.0/temp+EXP(-inter_layer_1)*&
+&     inter_layer_1/temp**2)*inter_layer_1_tf_b
     bias_1_b = bias_1_b + inter_layer_1_b
     CALL DOT_PRODUCT_2D_1D_B(weight_1, weight_1_b, input_layer, &
 &                      input_layer_b, inter_layer_1, inter_layer_1_b)
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP_B
 
   SUBROUTINE FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, bias_2&
-&   , weight_3, bias_3, input_layer, output_layer, output_jacobian)
+&   , weight_3, bias_3, input_layer, output_layer, output_jacobian_1, &
+&   output_jacobian_2)
     IMPLICIT NONE
     REAL(sp), DIMENSION(:, :), INTENT(IN) :: weight_1
     REAL(sp), DIMENSION(:), INTENT(IN) :: bias_1
@@ -13491,34 +13477,35 @@ CONTAINS
     REAL(sp), DIMENSION(:), INTENT(IN) :: bias_3
     REAL(sp), DIMENSION(:), INTENT(IN) :: input_layer
     REAL(sp), DIMENSION(:), INTENT(OUT) :: output_layer
-    REAL(sp), DIMENSION(:, :), INTENT(OUT) :: output_jacobian
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_1
+    REAL(sp), DIMENSION(:), INTENT(OUT) :: output_jacobian_2
     INTRINSIC SIZE
     REAL(sp), DIMENSION(SIZE(bias_1)) :: inter_layer_1, inter_layer_1_tf&
-&   , layer_1_gradient
+&   , inter_layer_1_grad, layer_1_grad
     REAL(sp), DIMENSION(SIZE(bias_2)) :: inter_layer_2, inter_layer_2_tf&
-&   , layer_2_gradient
+&   , inter_layer_2_grad, layer_2_grad
     INTEGER :: i, j, k
-    INTRINSIC MAX
+    INTRINSIC EXP
     INTRINSIC TANH
-    output_jacobian = 0._sp
-    layer_1_gradient = 0._sp
-    layer_2_gradient = 0._sp
+    output_jacobian_1 = 0._sp
+    output_jacobian_2 = 0._sp
     CALL DOT_PRODUCT_2D_1D(weight_1, input_layer, inter_layer_1)
     inter_layer_1 = inter_layer_1 + bias_1
-    WHERE (0.01_sp*inter_layer_1 .LT. inter_layer_1) 
-      inter_layer_1_tf = inter_layer_1
-    ELSEWHERE
-      inter_layer_1_tf = 0.01_sp*inter_layer_1
-    END WHERE
+! SiLU
+    inter_layer_1_tf = inter_layer_1*(1._sp/(1._sp+EXP(-inter_layer_1)))
+! Derivative of SiLU
+    inter_layer_1_grad = inter_layer_1_tf + (1._sp-inter_layer_1_tf)/(&
+&     1._sp+EXP(-inter_layer_1))
     IF (SIZE(bias_3) .GT. 0) THEN
 ! Case with 3 layers
       CALL DOT_PRODUCT_2D_1D(weight_2, inter_layer_1_tf, inter_layer_2)
       inter_layer_2 = inter_layer_2 + bias_2
-      WHERE (0.01_sp*inter_layer_2 .LT. inter_layer_2) 
-        inter_layer_2_tf = inter_layer_2
-      ELSEWHERE
-        inter_layer_2_tf = 0.01_sp*inter_layer_2
-      END WHERE
+! SiLU
+      inter_layer_2_tf = inter_layer_2*(1._sp/(1._sp+EXP(-inter_layer_2)&
+&       ))
+! Derivative of SiLU
+      inter_layer_2_grad = inter_layer_2_tf + (1._sp-inter_layer_2_tf)/(&
+&       1._sp+EXP(-inter_layer_2))
       CALL DOT_PRODUCT_2D_1D(weight_3, inter_layer_2_tf, output_layer)
 ! TanH
       output_layer = TANH(output_layer + bias_3)
@@ -13526,30 +13513,25 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_2)
 ! Derivative of TanH
-          layer_2_gradient(j) = (1._sp-output_layer(i)**2)*weight_3(i, j&
-&           )
-          IF (inter_layer_2(j) .LT. 0._sp) layer_2_gradient(j) = &
-&             layer_2_gradient(j)*0.01_sp
+          layer_2_grad(j) = (1._sp-output_layer(i)**2)*weight_3(i, j)
+          layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
         END DO
 ! Gradient of second layer wrt first layer
+        layer_1_grad = 0._sp
         DO j=1,SIZE(inter_layer_1)
           DO k=1,SIZE(inter_layer_2)
-            layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient&
-&             (k)*weight_2(k, j)
+            layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2&
+&             (k, j)
           END DO
-          IF (inter_layer_1(j) .LT. 0._sp) layer_1_gradient(j) = &
-&             layer_1_gradient(j)*0.01_sp
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_2_gradient = 0._sp
-        layer_1_gradient = 0._sp
       END DO
     ELSE
 ! Case with 2 layers
@@ -13559,20 +13541,16 @@ CONTAINS
       DO i=1,SIZE(output_layer)
         DO j=1,SIZE(inter_layer_1)
 ! Derivative of TanH
-          layer_1_gradient(j) = (1._sp-output_layer(i)**2)*weight_2(i, j&
-&           )
-          IF (inter_layer_1(j) .LT. 0._sp) layer_1_gradient(j) = &
-&             layer_1_gradient(j)*0.01_sp
+          layer_1_grad(j) = (1._sp-output_layer(i)**2)*weight_2(i, j)
+          layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
         END DO
 ! Gradient of first layer wrt input layer
-        DO j=1,SIZE(input_layer)
-          DO k=1,SIZE(inter_layer_1)
-            output_jacobian(i, j) = output_jacobian(i, j) + &
-&             layer_1_gradient(k)*weight_1(k, j)
-          END DO
+        DO k=1,SIZE(inter_layer_1)
+          output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*&
+&           weight_1(k, 1)
+          output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*&
+&           weight_1(k, 2)
         END DO
-! Reset tmp gradients
-        layer_1_gradient = 0._sp
       END DO
     END IF
   END SUBROUTINE FORWARD_AND_BACKWARD_MLP
@@ -15199,19 +15177,23 @@ CONTAINS
 !  Differentiation of gr_production_transfer_ode_mlp in forward (tangent) mode (with options fixinterface noISIZE context OpenMP)
 !:
 !   variations   of useful results: q hp ht pn
-!   with respect to varying inputs: kexc hp ht en jacobian_nn fq
-!                cp pn ct
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D(fq, fq_d, jacobian_nn, &
-&   jacobian_nn_d, pn, pn_d, en, en_d, imperviousness, cp, cp_d, ct, &
-&   ct_d, kexc, kexc_d, hp, hp_d, ht, ht_d, q, q_d, l)
+!   with respect to varying inputs: kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_D(fq, fq_d, jacobian_nn_1, &
+&   jacobian_nn_1_d, jacobian_nn_2, jacobian_nn_2_d, pn, pn_d, en, en_d&
+&   , imperviousness, cp, cp_d, ct, ct_d, kexc, kexc_d, hp, hp_d, ht, &
+&   ht_d, q, q_d, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq_d
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn_d
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1_d
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2_d
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp), INTENT(IN) :: en_d, cp_d, ct_d, kexc_d
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
@@ -15277,50 +15259,51 @@ CONTAINS
       dh_d(2) = ht_d - ht0_d - dt*fht_d
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
-      temp1 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp0 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
+      temp1 = jacobian_nn_1(1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp0 = jacobian_nn_1(2)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2)&
+&       +1._sp)
       temp = pn*temp1 - en*temp0
       jacob_d(1, 1) = -(dt*(inv_cp*(temp1*pn_d+pn*((1-hp**2)*&
-&       jacobian_nn_d(1, 1)-jacobian_nn(1, 1)*2*hp*hp_d-2._sp*((fq(1)+&
-&       1._sp)*hp_d+hp*fq_d(1)))-temp0*en_d-en*(hp*(2._sp-hp)*&
-&       jacobian_nn_d(2, 1)+jacobian_nn(2, 1)*(2._sp-2*hp)*hp_d+2._sp*((&
-&       1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp*inv_cp_d))
+&       jacobian_nn_1_d(1)-jacobian_nn_1(1)*2*hp*hp_d-2._sp*((fq(1)+&
+&       1._sp)*hp_d+hp*fq_d(1)))-temp0*en_d-en*((2._sp-hp)*(hp*&
+&       jacobian_nn_1_d(2)+jacobian_nn_1(2)*hp_d)-jacobian_nn_1(2)*hp*&
+&       hp_d+2._sp*((1._sp-hp)*fq_d(2)-(fq(2)+1._sp)*hp_d)))+temp*&
+&       inv_cp_d))
       jacob(1, 1) = 1._sp - dt*(temp*inv_cp)
 ! -dt*nabla_ht(fhp)
-      temp1 = jacobian_nn(2, 2)*(-hp+2._sp)
-      temp0 = pn*jacobian_nn(1, 2)*(-(hp*hp)+1) - temp1*en*hp
-      jacob_d(1, 2) = -(dt*(inv_cp*((1-hp**2)*(jacobian_nn(1, 2)*pn_d+pn&
-&       *jacobian_nn_d(1, 2))-pn*jacobian_nn(1, 2)*2*hp*hp_d-en*hp*((&
-&       2._sp-hp)*jacobian_nn_d(2, 2)-jacobian_nn(2, 2)*hp_d)-temp1*(hp*&
-&       en_d+en*hp_d))+temp0*inv_cp_d))
-      jacob(1, 2) = -(dt*(temp0*inv_cp))
+      temp1 = pn*jacobian_nn_2(1)*(-(hp*hp)+1) - en*hp*jacobian_nn_2(2)*&
+&       (-hp+2._sp)
+      jacob_d(1, 2) = -(dt*(inv_cp*((1-hp**2)*(jacobian_nn_2(1)*pn_d+pn*&
+&       jacobian_nn_2_d(1))-pn*jacobian_nn_2(1)*2*hp*hp_d-jacobian_nn_2(&
+&       2)*(2._sp-hp)*(hp*en_d+en*hp_d)-en*hp*((2._sp-hp)*&
+&       jacobian_nn_2_d(2)-jacobian_nn_2(2)*hp_d))+temp1*inv_cp_d))
+      jacob(1, 2) = -(dt*(temp1*inv_cp))
 ! -dt*nabla_hp(fht)
-      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp1 = 2._sp*(fq(1)+1._sp) + jacobian_nn_1(1)*hp
       temp0 = ht**5
       temp = ht**3.5_sp
-      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn(4, 1)*ct*temp0 + &
-&       jacobian_nn(3, 1)*kexc*temp
+      temp2 = 0.9_sp*pn*hp*temp1 - 0.25_sp*jacobian_nn_1(4)*ct*temp0 + &
+&       jacobian_nn_1(3)*kexc*temp
       jacob_d(2, 1) = -(dt*(inv_ct*(0.9_sp*(temp1*(hp*pn_d+pn*hp_d)+pn*&
-&       hp*(2._sp*fq_d(1)+hp*jacobian_nn_d(1, 1)+jacobian_nn(1, 1)*hp_d)&
-&       )-0.25_sp*(temp0*(ct*jacobian_nn_d(4, 1)+jacobian_nn(4, 1)*ct_d)&
-&       +jacobian_nn(4, 1)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_d(3, &
-&       1)+jacobian_nn(3, 1)*kexc_d)+jacobian_nn(3, 1)*kexc*3.5_sp*ht**&
-&       2.5*ht_d)+temp2*inv_ct_d))
+&       hp*(2._sp*fq_d(1)+hp*jacobian_nn_1_d(1)+jacobian_nn_1(1)*hp_d))-&
+&       0.25_sp*(temp0*(ct*jacobian_nn_1_d(4)+jacobian_nn_1(4)*ct_d)+&
+&       jacobian_nn_1(4)*ct*5*ht**4*ht_d)+temp*(kexc*jacobian_nn_1_d(3)+&
+&       jacobian_nn_1(3)*kexc_d)+jacobian_nn_1(3)*kexc*3.5_sp*ht**2.5*&
+&       ht_d)+temp2*inv_ct_d))
       jacob(2, 1) = -(dt*(temp2*inv_ct))
 ! 1 - dt*nabla_ht(fht)
       temp3 = ht**2.5
-      temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp2 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn_2(3)*ht
       temp1 = ht**4
-      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
-      temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn(1, 2)*pn*(hp*hp) - &
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn_2(4)*ht
+      temp4 = temp2*kexc*temp3 + 0.9_sp*jacobian_nn_2(1)*pn*(hp*hp) - &
 &       temp0*ct*temp1
       jacob_d(2, 2) = -(dt*(inv_ct*(temp3*(kexc*(3.5_sp*fq_d(3)+ht*&
-&       jacobian_nn_d(3, 2)+jacobian_nn(3, 2)*ht_d)+temp2*kexc_d)+temp2*&
-&       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_d(1, 2)+&
-&       jacobian_nn(1, 2)*pn_d)+jacobian_nn(1, 2)*pn*2*hp*hp_d)-ct*temp1&
-&       *(1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_d(4, 2)+jacobian_nn(4&
-&       , 2)*ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
+&       jacobian_nn_2_d(3)+jacobian_nn_2(3)*ht_d)+temp2*kexc_d)+temp2*&
+&       kexc*2.5*ht**1.5*ht_d+0.9_sp*(hp**2*(pn*jacobian_nn_2_d(1)+&
+&       jacobian_nn_2(1)*pn_d)+jacobian_nn_2(1)*pn*2*hp*hp_d)-ct*temp1*(&
+&       1.25_sp*fq_d(4)+0.25_sp*(ht*jacobian_nn_2_d(4)+jacobian_nn_2(4)*&
+&       ht_d))-temp0*(temp1*ct_d+ct*4*ht**3*ht_d))+temp4*inv_ct_d))
       jacob(2, 2) = 1._sp - dt*(temp4*inv_ct)
       CALL SOLVE_LINEAR_SYSTEM_2VARS_D(jacob, jacob_d, delta_h, &
 &                                delta_h_d, dh, dh_d)
@@ -15366,21 +15349,25 @@ CONTAINS
 
 !  Differentiation of gr_production_transfer_ode_mlp in reverse (adjoint) mode (with options fixinterface noISIZE context OpenMP)
 !:
-!   gradient     of useful results: q kexc hp ht en jacobian_nn
-!                fq cp pn ct
-!   with respect to varying inputs: kexc hp ht en jacobian_nn fq
-!                cp pn ct
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B(fq, fq_b, jacobian_nn, &
-&   jacobian_nn_b, pn, pn_b, en, en_b, imperviousness, cp, cp_b, ct, &
-&   ct_b, kexc, kexc_b, hp, hp_b, ht, ht_b, q, q_b, l)
+!   gradient     of useful results: q kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+!   with respect to varying inputs: kexc hp ht en jacobian_nn_1
+!                jacobian_nn_2 fq cp pn ct
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B(fq, fq_b, jacobian_nn_1, &
+&   jacobian_nn_1_b, jacobian_nn_2, jacobian_nn_2_b, pn, pn_b, en, en_b&
+&   , imperviousness, cp, cp_b, ct, ct_b, kexc, kexc_b, hp, hp_b, ht, &
+&   ht_b, q, q_b, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     REAL(sp), DIMENSION(4) :: fq_b
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
-    REAL(sp), DIMENSION(SIZE(fq), 4) :: jacobian_nn_b
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+    REAL(sp), DIMENSION(SIZE(fq)) :: jacobian_nn_1_b
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
+    REAL(sp), DIMENSION(SIZE(fq)) :: jacobian_nn_2_b
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp) :: en_b, cp_b, ct_b, kexc_b
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
@@ -15439,23 +15426,23 @@ CONTAINS
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
       CALL PUSHREAL4(jacob(1, 1))
-      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
-&       *(1._sp+fq(1)))-en*(jacobian_nn(2, 1)*hp*(2._sp-hp)+2._sp*(1._sp&
-&       -hp)*(1._sp+fq(2))))*inv_cp
+      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn_1(1)*(1-hp**2)-2._sp*hp*&
+&       (1._sp+fq(1)))-en*(jacobian_nn_1(2)*hp*(2._sp-hp)+2._sp*(1._sp-&
+&       hp)*(1._sp+fq(2))))*inv_cp
 ! -dt*nabla_ht(fhp)
       CALL PUSHREAL4(jacob(1, 2))
-      jacob(1, 2) = -(dt*(pn*jacobian_nn(1, 2)*(1-hp**2)-en*jacobian_nn(&
-&       2, 2)*hp*(2._sp-hp))*inv_cp)
+      jacob(1, 2) = -(dt*(pn*jacobian_nn_2(1)*(1-hp**2)-en*jacobian_nn_2&
+&       (2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
       CALL PUSHREAL4(jacob(2, 1))
-      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+&
+&       jacobian_nn_1(1)*hp)-0.25_sp*jacobian_nn_1(4)*ct*ht**5+&
+&       jacobian_nn_1(3)*kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
       CALL PUSHREAL4(jacob(2, 2))
-      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
-&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn_2(3)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn_2(1)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn_2(4)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       CALL PUSHREAL4(hp)
       hp = hp + delta_h(1)
@@ -15535,12 +15522,12 @@ CONTAINS
 &                                delta_h_b, dh, dh_b)
       CALL POPREAL4(jacob(2, 2))
       temp5 = ht**2.5
-      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn(3, 2)*ht
+      temp4 = 3.5_sp*(fq(3)+1._sp) + jacobian_nn_2(3)*ht
       temp2 = ht**4
       temp1 = ct*temp2
-      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn(4, 2)*ht
+      temp0 = 1.25_sp*(fq(4)+1._sp) + 0.25_sp*jacobian_nn_2(4)*ht
       temp_b4 = -(inv_ct*dt*jacob_b(2, 2))
-      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn(1, 2)*&
+      inv_ct_b = inv_ct_b - (temp4*kexc*temp5+0.9_sp*(jacobian_nn_2(1)*&
 &       pn*hp**2)-temp0*temp1)*dt*jacob_b(2, 2)
       jacob_b(2, 2) = 0.0_4
       temp_b5 = kexc*temp5*temp_b4
@@ -15549,70 +15536,70 @@ CONTAINS
       temp_b0 = -(temp1*temp_b4)
       ct_b = ct_b - temp2*temp0*temp_b4
       fq_b(4) = fq_b(4) + 1.25_sp*temp_b0
-      jacobian_nn_b(4, 2) = jacobian_nn_b(4, 2) + ht*0.25_sp*temp_b0
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp_b3
-      pn_b = pn_b + jacobian_nn(1, 2)*temp_b3
-      jacobian_nn_b(3, 2) = jacobian_nn_b(3, 2) + ht*temp_b5
+      jacobian_nn_2_b(4) = jacobian_nn_2_b(4) + ht*0.25_sp*temp_b0
+      jacobian_nn_2_b(1) = jacobian_nn_2_b(1) + pn*temp_b3
+      pn_b = pn_b + jacobian_nn_2(1)*temp_b3
+      jacobian_nn_2_b(3) = jacobian_nn_2_b(3) + ht*temp_b5
       CALL POPREAL4(jacob(2, 1))
-      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn(1, 1)*hp
+      temp2 = 2._sp*(fq(1)+1._sp) + jacobian_nn_1(1)*hp
       temp_b3 = -(inv_ct*dt*jacob_b(2, 1))
       ht_b = ht_b + (2.5*ht**1.5*temp4*kexc-4*ht**3*ct*temp0)*temp_b4 + &
-&       jacobian_nn(4, 2)*0.25_sp*temp_b0 + jacobian_nn(3, 2)*temp_b5 + &
-&       (3.5_sp*ht**2.5*jacobian_nn(3, 1)*kexc-5*ht**4*jacobian_nn(4, 1)&
-&       *ct*0.25_sp)*temp_b3
+&       jacobian_nn_2(4)*0.25_sp*temp_b0 + jacobian_nn_2(3)*temp_b5 + (&
+&       3.5_sp*ht**2.5*jacobian_nn_1(3)*kexc-5*ht**4*jacobian_nn_1(4)*ct&
+&       *0.25_sp)*temp_b3
       temp0 = ht**5
       temp4 = ht**3.5_sp
       temp_b1 = temp2*0.9_sp*temp_b3
       temp_b2 = pn*hp*0.9_sp*temp_b3
+      hp_b = hp_b + 2*hp*jacobian_nn_2(1)*pn*0.9_sp*temp_b4 + &
+&       jacobian_nn_1(1)*temp_b2 + pn*temp_b1
       temp_b = -(temp0*0.25_sp*temp_b3)
-      jacobian_nn_b(3, 1) = jacobian_nn_b(3, 1) + kexc*temp4*temp_b3
-      kexc_b = kexc_b + jacobian_nn(3, 1)*temp4*temp_b3
-      jacobian_nn_b(4, 1) = jacobian_nn_b(4, 1) + ct*temp_b
+      jacobian_nn_1_b(3) = jacobian_nn_1_b(3) + kexc*temp4*temp_b3
+      kexc_b = kexc_b + jacobian_nn_1(3)*temp4*temp_b3
+      jacobian_nn_1_b(4) = jacobian_nn_1_b(4) + ct*temp_b
       fq_b(1) = fq_b(1) + 2._sp*temp_b2
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + hp*temp_b2
+      jacobian_nn_1_b(1) = jacobian_nn_1_b(1) + hp*temp_b2
       CALL POPREAL4(jacob(1, 2))
-      temp1 = en*hp
+      temp1 = jacobian_nn_2(2)*(-hp+2._sp)
       temp_b3 = -(inv_cp*dt*jacob_b(1, 2))
-      jacobian_nn_b(2, 2) = jacobian_nn_b(2, 2) - (2._sp-hp)*temp1*&
-&       temp_b3
+      en_b = en_b - hp*temp1*temp_b3
       CALL POPREAL4(jacob(1, 1))
       CALL POPREAL4(dh(2))
       ht0_b = ht0_b - dh_b(2)
       fht_b = -(dt*dh_b(2))
       inv_ct_b = inv_ct_b + (0.9_sp*((fq(1)+1._sp)*pn*hp**2)-0.25_sp*((&
 &       fq(4)+1._sp)*ct*temp)+temp3*(kexc*(fq(3)+1._sp)))*fht_b - (&
-&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn(4, 1)*ct*temp0)+&
-&       jacobian_nn(3, 1)*kexc*temp4)*dt*jacob_b(2, 1)
+&       0.9_sp*(pn*hp*temp2)-0.25_sp*(jacobian_nn_1(4)*ct*temp0)+&
+&       jacobian_nn_1(3)*kexc*temp4)*dt*jacob_b(2, 1)
       jacob_b(2, 1) = 0.0_4
       temp2 = -(hp*hp) + 1
-      pn_b = pn_b + hp*temp_b1 + jacobian_nn(1, 2)*temp2*temp_b3
-      temp0 = jacobian_nn(2, 2)*(-hp+2._sp)
-      hp_b = hp_b + 2*hp*jacobian_nn(1, 2)*pn*0.9_sp*temp_b4 + &
-&       jacobian_nn(1, 1)*temp_b2 + pn*temp_b1 + (jacobian_nn(2, 2)*&
-&       temp1-en*temp0-2*hp*pn*jacobian_nn(1, 2))*temp_b3
-      inv_cp_b = inv_cp_b - (pn*jacobian_nn(1, 2)*temp2-temp0*temp1)*dt*&
+      pn_b = pn_b + hp*temp_b1 + jacobian_nn_2(1)*temp2*temp_b3
+      inv_cp_b = inv_cp_b - (pn*jacobian_nn_2(1)*temp2-en*hp*temp1)*dt*&
 &       jacob_b(1, 2)
       jacob_b(1, 2) = 0.0_4
-      jacobian_nn_b(1, 2) = jacobian_nn_b(1, 2) + pn*temp2*temp_b3
-      en_b = en_b - hp*temp0*temp_b3
-      temp2 = jacobian_nn(1, 1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
-      temp1 = jacobian_nn(2, 1)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2&
-&       )+1._sp)
+      jacobian_nn_2_b(1) = jacobian_nn_2_b(1) + pn*temp2*temp_b3
+      temp_b1 = -(en*hp*temp_b3)
+      hp_b = hp_b - (2*hp*pn*jacobian_nn_2(1)+en*temp1)*temp_b3 - &
+&       jacobian_nn_2(2)*temp_b1
+      jacobian_nn_2_b(2) = jacobian_nn_2_b(2) + (2._sp-hp)*temp_b1
+      temp2 = jacobian_nn_1(1)*(-(hp*hp)+1) - 2._sp*hp*(fq(1)+1._sp)
+      temp1 = jacobian_nn_1(2)*hp*(-hp+2._sp) + 2._sp*(-hp+1._sp)*(fq(2)&
+&       +1._sp)
       temp_b3 = -(inv_cp*dt*jacob_b(1, 1))
       inv_cp_b = inv_cp_b - (pn*temp2-en*temp1)*dt*jacob_b(1, 1)
       jacob_b(1, 1) = 0.0_4
       temp_b2 = pn*temp_b3
       en_b = en_b - temp1*temp_b3
       temp_b1 = -(en*temp_b3)
-      jacobian_nn_b(2, 1) = jacobian_nn_b(2, 1) + hp*(2._sp-hp)*temp_b1
-      hp_b = hp_b + ((2._sp-hp)*jacobian_nn(2, 1)-hp*jacobian_nn(2, 1)-(&
-&       fq(2)+1._sp)*2._sp)*temp_b1
+      jacobian_nn_1_b(2) = jacobian_nn_1_b(2) + hp*(2._sp-hp)*temp_b1
+      hp_b = hp_b + (jacobian_nn_1(2)*(2._sp-hp)-jacobian_nn_1(2)*hp-(fq&
+&       (2)+1._sp)*2._sp)*temp_b1
       fq_b(2) = fq_b(2) + (1._sp-hp)*2._sp*temp_b1
-      jacobian_nn_b(1, 1) = jacobian_nn_b(1, 1) + (1-hp**2)*temp_b2
+      jacobian_nn_1_b(1) = jacobian_nn_1_b(1) + (1-hp**2)*temp_b2
       temp_b1 = inv_ct*fht_b
       fq_b(3) = fq_b(3) + 3.5_sp*temp_b5 + kexc*temp3*temp_b1
       hp_b = hp_b + 2*hp*(fq(1)+1._sp)*pn*0.9_sp*temp_b1 - (2*hp*&
-&       jacobian_nn(1, 1)+(fq(1)+1._sp)*2._sp)*temp_b2
+&       jacobian_nn_1(1)+(fq(1)+1._sp)*2._sp)*temp_b2
       ht_b = ht_b + dh_b(2) + (3.5_sp*ht**2.5*kexc*(fq(3)+1._sp)-5*ht**4&
 &       *(fq(4)+1._sp)*ct*0.25_sp)*temp_b1
       dh_b(2) = 0.0_4
@@ -15620,7 +15607,7 @@ CONTAINS
       pn_b = pn_b + temp2*temp_b3 + (fq(1)+1._sp)*temp_b0
       fq_b(1) = fq_b(1) + pn*temp_b0 - hp*2._sp*temp_b2
       temp_b2 = -(temp*0.25_sp*temp_b1)
-      ct_b = ct_b + jacobian_nn(4, 1)*temp_b + (fq(4)+1._sp)*temp_b2
+      ct_b = ct_b + jacobian_nn_1(4)*temp_b + (fq(4)+1._sp)*temp_b2
       kexc_b = kexc_b + (fq(3)+1._sp)*temp3*temp_b1
       fq_b(4) = fq_b(4) + ct*temp_b2
       CALL POPREAL4(dh(1))
@@ -15647,14 +15634,16 @@ CONTAINS
     cp_b = cp_b - inv_cp_b/cp**2
   END SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP_B
 
-  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP(fq, jacobian_nn, pn, en, &
-&   imperviousness, cp, ct, kexc, hp, ht, q, l)
+  SUBROUTINE GR_PRODUCTION_TRANSFER_ODE_MLP(fq, jacobian_nn_1, &
+&   jacobian_nn_2, pn, en, imperviousness, cp, ct, kexc, hp, ht, q, l)
     IMPLICIT NONE
 ! fixed NN output size
     REAL(sp), DIMENSION(4), INTENT(IN) :: fq
     INTRINSIC SIZE
-! fixed NN input size
-    REAL(sp), DIMENSION(SIZE(fq), 4), INTENT(IN) :: jacobian_nn
+! grad wrt hp
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_1
+! grad wrt ht
+    REAL(sp), DIMENSION(SIZE(fq)), INTENT(IN) :: jacobian_nn_2
     REAL(sp), INTENT(IN) :: en, imperviousness, cp, ct, kexc
     REAL(sp), INTENT(INOUT) :: pn, hp, ht, q
     REAL(sp), INTENT(OUT) :: l
@@ -15686,20 +15675,20 @@ CONTAINS
 &       5+kexc*ht**3.5_sp*(1._sp+fq(3)))*inv_ct
       dh(2) = ht - ht0 - dt*fht
 ! 1 - dt*nabla_hp(fhp)
-      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1-hp**2)-2._sp*hp&
-&       *(1._sp+fq(1)))-en*(jacobian_nn(2, 1)*hp*(2._sp-hp)+2._sp*(1._sp&
-&       -hp)*(1._sp+fq(2))))*inv_cp
+      jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn_1(1)*(1-hp**2)-2._sp*hp*&
+&       (1._sp+fq(1)))-en*(jacobian_nn_1(2)*hp*(2._sp-hp)+2._sp*(1._sp-&
+&       hp)*(1._sp+fq(2))))*inv_cp
 ! -dt*nabla_ht(fhp)
-      jacob(1, 2) = -(dt*(pn*jacobian_nn(1, 2)*(1-hp**2)-en*jacobian_nn(&
-&       2, 2)*hp*(2._sp-hp))*inv_cp)
+      jacob(1, 2) = -(dt*(pn*jacobian_nn_2(1)*(1-hp**2)-en*jacobian_nn_2&
+&       (2)*hp*(2._sp-hp))*inv_cp)
 ! -dt*nabla_hp(fht)
-      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+jacobian_nn(&
-&       1, 1)*hp)-0.25_sp*jacobian_nn(4, 1)*ct*ht**5+jacobian_nn(3, 1)*&
-&       kexc*ht**3.5_sp)*inv_ct)
+      jacob(2, 1) = -(dt*(0.9_sp*pn*hp*(2._sp*(1._sp+fq(1))+&
+&       jacobian_nn_1(1)*hp)-0.25_sp*jacobian_nn_1(4)*ct*ht**5+&
+&       jacobian_nn_1(3)*kexc*ht**3.5_sp)*inv_ct)
 ! 1 - dt*nabla_ht(fht)
-      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn(3, 2)*&
-&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn(1, 2)*pn*hp**2-(1.25_sp*(&
-&       1._sp+fq(4))+0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+      jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp+fq(3))+jacobian_nn_2(3)*&
+&       ht)*kexc*ht**2.5+0.9_sp*jacobian_nn_2(1)*pn*hp**2-(1.25_sp*(&
+&       1._sp+fq(4))+0.25_sp*jacobian_nn_2(4)*ht)*ct*ht**4)*inv_ct
       CALL SOLVE_LINEAR_SYSTEM_2VARS(jacob, delta_h, dh)
       hp = hp + delta_h(1)
       IF (hp .LE. 0._sp) hp = 1.e-6_sp
@@ -17403,10 +17392,14 @@ CONTAINS
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_d
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn_d
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1_d
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2_d
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_d, pn_d, en_d
     INTEGER :: row, col, k, time_step_returns
@@ -17443,7 +17436,8 @@ CONTAINS
       END DO
     END DO
     output_layer_d = 0.0_4
-    jacobian_nn_d = 0.0_4
+    jacobian_nn_1_d = 0.0_4
+    jacobian_nn_2_d = 0.0_4
 ! Forward MLP without OPENMP
     DO col=1,mesh%ncol
       DO row=1,mesh%nrow
@@ -17460,11 +17454,17 @@ CONTAINS
 &                                     weight_3_d, bias_3, bias_3_d, &
 &                                     input_layer, input_layer_d, &
 &                                     output_layer(:, k), output_layer_d&
-&                                     (:, k), jacobian_nn(:, :, k), &
-&                                     jacobian_nn_d(:, :, k))
+&                                     (:, k), jacobian_nn_1(:, k), &
+&                                     jacobian_nn_1_d(:, k), &
+&                                     jacobian_nn_2(:, k), &
+&                                     jacobian_nn_2_d(:, k))
           ELSE
             output_layer_d(:, k) = 0.0_4
             output_layer(:, k) = 0._sp
+            jacobian_nn_1_d(:, k) = 0.0_4
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2_d(:, k) = 0.0_4
+            jacobian_nn_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17479,9 +17479,11 @@ CONTAINS
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_D(output_layer(:, k), &
 &                                         output_layer_d(:, k), &
-&                                         jacobian_nn(:, :, k), &
-&                                         jacobian_nn_d(:, :, k), pn(k)&
-&                                         , pn_d(k), en(k), en_d(k), &
+&                                         jacobian_nn_1(:, k), &
+&                                         jacobian_nn_1_d(:, k), &
+&                                         jacobian_nn_2(:, k), &
+&                                         jacobian_nn_2_d(:, k), pn(k), &
+&                                         pn_d(k), en(k), en_d(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_d(k), ac_ct(k), ac_ct_d(&
 &                                         k), ac_kexc(k), ac_kexc_d(k), &
@@ -17552,10 +17554,14 @@ CONTAINS
 &   output_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer_b
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn_b
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1_b
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2_b
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp_b, pn_b, en_b
     INTEGER :: row, col, k, time_step_returns
@@ -17610,10 +17616,13 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn(:, :, k))
+&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
+&                                   , k))
             CALL PUSHCONTROL2B(2)
           ELSE
             output_layer(:, k) = 0._sp
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2(:, k) = 0._sp
             CALL PUSHCONTROL2B(1)
           END IF
         END IF
@@ -17634,8 +17643,9 @@ CONTAINS
           CALL PUSHREAL4(ac_hp(k))
           CALL PUSHREAL4(pn(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn(:, :, k), pn(k), en(&
-&                                       k), imperviousness, ac_cp(k), &
+&                                       jacobian_nn_1(:, k), &
+&                                       jacobian_nn_2(:, k), pn(k), en(k&
+&                                       ), imperviousness, ac_cp(k), &
 &                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
 &                                       ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s
@@ -17645,7 +17655,8 @@ CONTAINS
     END DO
     output_layer_b = 0.0_4
     en_b = 0.0_4
-    jacobian_nn_b = 0.0_4
+    jacobian_nn_1_b = 0.0_4
+    jacobian_nn_2_b = 0.0_4
     pn_b = 0.0_4
     DO col=mesh%ncol,1,-1
       DO row=mesh%nrow,1,-1
@@ -17662,9 +17673,11 @@ CONTAINS
           CALL POPREAL4(ac_qt(k))
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP_B(output_layer(:, k), &
 &                                         output_layer_b(:, k), &
-&                                         jacobian_nn(:, :, k), &
-&                                         jacobian_nn_b(:, :, k), pn(k)&
-&                                         , pn_b(k), en(k), en_b(k), &
+&                                         jacobian_nn_1(:, k), &
+&                                         jacobian_nn_1_b(:, k), &
+&                                         jacobian_nn_2(:, k), &
+&                                         jacobian_nn_2_b(:, k), pn(k), &
+&                                         pn_b(k), en(k), en_b(k), &
 &                                         imperviousness, ac_cp(k), &
 &                                         ac_cp_b(k), ac_ct(k), ac_ct_b(&
 &                                         k), ac_kexc(k), ac_kexc_b(k), &
@@ -17681,6 +17694,8 @@ CONTAINS
         IF (branch .NE. 0) THEN
           IF (branch .EQ. 1) THEN
             k = mesh%rowcol_to_ind_ac(row, col)
+            jacobian_nn_2_b(:, k) = 0.0_4
+            jacobian_nn_1_b(:, k) = 0.0_4
             output_layer_b(:, k) = 0.0_4
           ELSE
             k = mesh%rowcol_to_ind_ac(row, col)
@@ -17690,10 +17705,13 @@ CONTAINS
 &                                     weight_3_b, bias_3, bias_3_b, &
 &                                     input_layer, input_layer_b, &
 &                                     output_layer(:, k), output_layer_b&
-&                                     (:, k), jacobian_nn(:, :, k), &
-&                                     jacobian_nn_b(:, :, k))
+&                                     (:, k), jacobian_nn_1(:, k), &
+&                                     jacobian_nn_1_b(:, k), &
+&                                     jacobian_nn_2(:, k), &
+&                                     jacobian_nn_2_b(:, k))
             output_layer_b(:, k) = 0.0_4
-            jacobian_nn_b(:, :, k) = 0.0_4
+            jacobian_nn_1_b(:, k) = 0.0_4
+            jacobian_nn_2_b(:, k) = 0.0_4
             CALL POPREAL4ARRAY(input_layer, setup%neurons(1))
             ac_hp_b(k) = ac_hp_b(k) + input_layer_b(1)
             ac_ht_b(k) = ac_ht_b(k) + input_layer_b(2)
@@ -17765,8 +17783,10 @@ CONTAINS
     REAL(sp), DIMENSION(setup%neurons(1)) :: input_layer
     REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
 &   output_layer
-    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), setup%neurons(1&
-&   ), mesh%nac) :: jacobian_nn
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_1
+    REAL(sp), DIMENSION(setup%neurons(setup%n_layers+1), mesh%nac) :: &
+&   jacobian_nn_2
     REAL(sp), DIMENSION(mesh%nac) :: ac_prcp, ac_pet, pn, en
     INTEGER :: row, col, k, time_step_returns
     REAL(sp) :: imperviousness, l
@@ -17805,9 +17825,12 @@ CONTAINS
             CALL FORWARD_AND_BACKWARD_MLP(weight_1, bias_1, weight_2, &
 &                                   bias_2, weight_3, bias_3, &
 &                                   input_layer, output_layer(:, k), &
-&                                   jacobian_nn(:, :, k))
+&                                   jacobian_nn_1(:, k), jacobian_nn_2(:&
+&                                   , k))
           ELSE
             output_layer(:, k) = 0._sp
+            jacobian_nn_1(:, k) = 0._sp
+            jacobian_nn_2(:, k) = 0._sp
           END IF
         END IF
       END DO
@@ -17821,8 +17844,9 @@ CONTAINS
           imperviousness = input_data%physio_data%imperviousness(row, &
 &           col)
           CALL GR_PRODUCTION_TRANSFER_ODE_MLP(output_layer(:, k), &
-&                                       jacobian_nn(:, :, k), pn(k), en(&
-&                                       k), imperviousness, ac_cp(k), &
+&                                       jacobian_nn_1(:, k), &
+&                                       jacobian_nn_2(:, k), pn(k), en(k&
+&                                       ), imperviousness, ac_cp(k), &
 &                                       ac_ct(k), ac_kexc(k), ac_hp(k), &
 &                                       ac_ht(k), ac_qt(k), l)
 ! Transform from mm/dt to m3/s

--- a/smash/fcore/operator/md_gr_operator.f90
+++ b/smash/fcore/operator/md_gr_operator.f90
@@ -848,8 +848,8 @@ contains
 
         real(sp), dimension(setup%neurons(1)) :: input_layer
         real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: output_layer
-        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: jacobian_nn_1
-        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: jacobian_nn_2
+        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: output_jacobian_1
+        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: output_jacobian_2
         real(sp), dimension(mesh%nac) :: ac_prcp, ac_pet, pn, en
         integer :: row, col, k, time_step_returns
         real(sp) :: imperviousness, l
@@ -901,12 +901,12 @@ contains
 
                     input_layer(:) = (/ac_hp(k), ac_ht(k), pn(k), en(k)/)
                     call forward_and_backward_mlp(weight_1, bias_1, weight_2, bias_2, weight_3, bias_3, &
-                    & input_layer, output_layer(:, k), jacobian_nn_1(:, k), jacobian_nn_2(:, k))
+                    & input_layer, output_layer(:, k), output_jacobian_1(:, k), output_jacobian_2(:, k))
 
                 else
                     output_layer(:, k) = 0._sp
-                    jacobian_nn_1(:, k) = 0._sp
-                    jacobian_nn_2(:, k) = 0._sp
+                    output_jacobian_1(:, k) = 0._sp
+                    output_jacobian_2(:, k) = 0._sp
 
                 end if
 
@@ -923,7 +923,7 @@ contains
 
                 imperviousness = input_data%physio_data%imperviousness(row, col)
 
-                call gr_production_transfer_ode_mlp(output_layer(:, k), jacobian_nn_1(:, k), jacobian_nn_2(:, k), &
+                call gr_production_transfer_ode_mlp(output_layer(:, k), output_jacobian_1(:, k), output_jacobian_2(:, k), &
                 & pn(k), en(k), imperviousness, ac_cp(k), ac_ct(k), ac_kexc(k), ac_hp(k), ac_ht(k), ac_qt(k), l)
 
                 ! Transform from mm/dt to m3/s

--- a/smash/fcore/operator/md_gr_operator.f90
+++ b/smash/fcore/operator/md_gr_operator.f90
@@ -288,13 +288,15 @@ contains
 
     end subroutine gr_production_transfer_ode
 
-    subroutine gr_production_transfer_ode_mlp(fq, jacobian_nn, pn, en, imperviousness, cp, ct, kexc, hp, ht, q, l)
+    subroutine gr_production_transfer_ode_mlp(fq, jacobian_nn_1, jacobian_nn_2, pn, en, imperviousness, &
+    & cp, ct, kexc, hp, ht, q, l)
         !% Solve state-space neural ODE system with implicit Euler
 
         implicit none
 
         real(sp), dimension(4), intent(in) :: fq  ! fixed NN output size
-        real(sp), dimension(size(fq), 4), intent(in) :: jacobian_nn  ! fixed NN input size
+        real(sp), dimension(size(fq)), intent(in) :: jacobian_nn_1  ! grad wrt hp
+        real(sp), dimension(size(fq)), intent(in) :: jacobian_nn_2  ! grad wrt ht
         real(sp), intent(in) :: en, imperviousness, cp, ct, kexc
         real(sp), intent(inout) :: pn, hp, ht, q
         real(sp), intent(out) :: l
@@ -332,21 +334,21 @@ contains
             dh(2) = ht - ht0 - dt*fht
 
             ! 1 - dt*nabla_hp(fhp)
-            jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn(1, 1)*(1 - hp**2) - 2._sp*hp*(1._sp + fq(1))) &
-            & - en*(jacobian_nn(2, 1)*hp*(2._sp - hp) + 2._sp*(1._sp - hp)*(1._sp + fq(2))))*inv_cp
+            jacob(1, 1) = 1._sp - dt*(pn*(jacobian_nn_1(1)*(1 - hp**2) - 2._sp*hp*(1._sp + fq(1))) &
+            & - en*(jacobian_nn_1(2)*hp*(2._sp - hp) + 2._sp*(1._sp - hp)*(1._sp + fq(2))))*inv_cp
 
             ! -dt*nabla_ht(fhp)
-            jacob(1, 2) = -dt*(pn*jacobian_nn(1, 2)*(1 - hp**2) &
-            & - en*jacobian_nn(2, 2)*hp*(2._sp - hp))*inv_cp
+            jacob(1, 2) = -dt*(pn*jacobian_nn_2(1)*(1 - hp**2) &
+            & - en*jacobian_nn_2(2)*hp*(2._sp - hp))*inv_cp
 
             ! -dt*nabla_hp(fht)
-            jacob(2, 1) = -dt*(0.9_sp*pn*hp*(2._sp*(1._sp + fq(1)) + jacobian_nn(1, 1)*hp) &
-            & - 0.25_sp*jacobian_nn(4, 1)*ct*ht**5 + jacobian_nn(3, 1)*kexc*ht**3.5_sp)*inv_ct
+            jacob(2, 1) = -dt*(0.9_sp*pn*hp*(2._sp*(1._sp + fq(1)) + jacobian_nn_1(1)*hp) &
+            & - 0.25_sp*jacobian_nn_1(4)*ct*ht**5 + jacobian_nn_1(3)*kexc*ht**3.5_sp)*inv_ct
 
             ! 1 - dt*nabla_ht(fht)
-            jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp + fq(3)) + jacobian_nn(3, 2)*ht)*kexc*ht**2.5 &
-            & + 0.9_sp*jacobian_nn(1, 2)*pn*hp**2 &
-            & - (1.25_sp*(1._sp + fq(4)) + 0.25_sp*jacobian_nn(4, 2)*ht)*ct*ht**4)*inv_ct
+            jacob(2, 2) = 1._sp - dt*((3.5_sp*(1._sp + fq(3)) + jacobian_nn_2(3)*ht)*kexc*ht**2.5 &
+            & + 0.9_sp*jacobian_nn_2(1)*pn*hp**2 &
+            & - (1.25_sp*(1._sp + fq(4)) + 0.25_sp*jacobian_nn_2(4)*ht)*ct*ht**4)*inv_ct
 
             call solve_linear_system_2vars(jacob, delta_h, dh)
 
@@ -846,7 +848,8 @@ contains
 
         real(sp), dimension(setup%neurons(1)) :: input_layer
         real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: output_layer
-        real(sp), dimension(setup%neurons(setup%n_layers + 1), setup%neurons(1), mesh%nac) :: jacobian_nn
+        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: jacobian_nn_1
+        real(sp), dimension(setup%neurons(setup%n_layers + 1), mesh%nac) :: jacobian_nn_2
         real(sp), dimension(mesh%nac) :: ac_prcp, ac_pet, pn, en
         integer :: row, col, k, time_step_returns
         real(sp) :: imperviousness, l
@@ -898,10 +901,12 @@ contains
 
                     input_layer(:) = (/ac_hp(k), ac_ht(k), pn(k), en(k)/)
                     call forward_and_backward_mlp(weight_1, bias_1, weight_2, bias_2, weight_3, bias_3, &
-                    & input_layer, output_layer(:, k), jacobian_nn(:, :, k))
+                    & input_layer, output_layer(:, k), jacobian_nn_1(:, k), jacobian_nn_2(:, k))
 
                 else
                     output_layer(:, k) = 0._sp
+                    jacobian_nn_1(:, k) = 0._sp
+                    jacobian_nn_2(:, k) = 0._sp
 
                 end if
 
@@ -918,8 +923,8 @@ contains
 
                 imperviousness = input_data%physio_data%imperviousness(row, col)
 
-                call gr_production_transfer_ode_mlp(output_layer(:, k), jacobian_nn(:, :, k), pn(k), en(k), &
-                & imperviousness, ac_cp(k), ac_ct(k), ac_kexc(k), ac_hp(k), ac_ht(k), ac_qt(k), l)
+                call gr_production_transfer_ode_mlp(output_layer(:, k), jacobian_nn_1(:, k), jacobian_nn_2(:, k), &
+                & pn(k), en(k), imperviousness, ac_cp(k), ac_ct(k), ac_kexc(k), ac_hp(k), ac_ht(k), ac_qt(k), l)
 
                 ! Transform from mm/dt to m3/s
                 ac_qt(k) = ac_qt(k)*1e-3_sp*mesh%dx(row, col)*mesh%dy(row, col)/setup%dt

--- a/smash/fcore/operator/md_neural_network.f90
+++ b/smash/fcore/operator/md_neural_network.f90
@@ -37,13 +37,13 @@ contains
 
         call dot_product_2d_1d(weight_1, input_layer, inter_layer_1)
         inter_layer_1 = inter_layer_1 + bias_1
-        inter_layer_1 = max(0.01_sp*inter_layer_1, inter_layer_1) ! Leaky ReLU
+        inter_layer_1 = inter_layer_1*(1._sp/(1._sp + exp(-inter_layer_1))) ! SiLU
 
         if (size(bias_3) .gt. 0) then  ! Case with 3 layers
 
             call dot_product_2d_1d(weight_2, inter_layer_1, inter_layer_2)
             inter_layer_2 = inter_layer_2 + bias_2
-            inter_layer_2 = max(0.01_sp*inter_layer_2, inter_layer_2) ! Leaky ReLU
+            inter_layer_2 = inter_layer_2*(1._sp/(1._sp + exp(-inter_layer_2))) ! SiLU
 
             call dot_product_2d_1d(weight_3, inter_layer_2, output_layer)
             output_layer = tanh(output_layer + bias_3) ! TanH
@@ -58,8 +58,9 @@ contains
     end subroutine forward_mlp
 
     subroutine forward_and_backward_mlp(weight_1, bias_1, weight_2, bias_2, weight_3, bias_3, &
-    & input_layer, output_layer, output_jacobian)
+    & input_layer, output_layer, output_jacobian_1, output_jacobian_2)
         !% The forward pass and backward pass of the MLP used in hydrological model structure
+        !% also get the jacobian of outputs wrt the first two inputs
 
         implicit none
 
@@ -75,24 +76,28 @@ contains
         real(sp), dimension(:), intent(in)    :: input_layer
 
         real(sp), dimension(:), intent(out)   :: output_layer
-        real(sp), dimension(:, :), intent(out) :: output_jacobian
+        real(sp), dimension(:), intent(out) :: output_jacobian_1
+        real(sp), dimension(:), intent(out) :: output_jacobian_2
 
-        real(sp), dimension(size(bias_1)) :: inter_layer_1, inter_layer_1_tf, layer_1_gradient
-        real(sp), dimension(size(bias_2)) :: inter_layer_2, inter_layer_2_tf, layer_2_gradient
+        real(sp), dimension(size(bias_1)) :: inter_layer_1, inter_layer_1_tf, inter_layer_1_grad, layer_1_grad
+        real(sp), dimension(size(bias_2)) :: inter_layer_2, inter_layer_2_tf, inter_layer_2_grad, layer_2_grad
         integer :: i, j, k
 
-        output_jacobian = 0._sp
-        layer_1_gradient = 0._sp
-        layer_2_gradient = 0._sp
+        output_jacobian_1 = 0._sp
+        output_jacobian_2 = 0._sp
 
         call dot_product_2d_1d(weight_1, input_layer, inter_layer_1)
         inter_layer_1 = inter_layer_1 + bias_1
-        inter_layer_1_tf = max(0.01_sp*inter_layer_1, inter_layer_1) ! Leaky ReLU
+        inter_layer_1_tf = inter_layer_1*(1._sp/(1._sp + exp(-inter_layer_1))) ! SiLU
+        inter_layer_1_grad = inter_layer_1_tf + &
+        & (1._sp - inter_layer_1_tf)/(1._sp + exp(-inter_layer_1))  ! Derivative of SiLU
 
         if (size(bias_3) .gt. 0) then  ! Case with 3 layers
             call dot_product_2d_1d(weight_2, inter_layer_1_tf, inter_layer_2)
             inter_layer_2 = inter_layer_2 + bias_2
-            inter_layer_2_tf = max(0.01_sp*inter_layer_2, inter_layer_2) ! Leaky ReLU
+            inter_layer_2_tf = inter_layer_2*(1._sp/(1._sp + exp(-inter_layer_2))) ! SiLU
+            inter_layer_2_grad = inter_layer_2_tf + &
+            & (1._sp - inter_layer_2_tf)/(1._sp + exp(-inter_layer_2))  ! Derivative of SiLU
 
             call dot_product_2d_1d(weight_3, inter_layer_2_tf, output_layer)
             output_layer = tanh(output_layer + bias_3)  ! TanH
@@ -100,28 +105,24 @@ contains
             ! Compute Jacobian matrix of output wrt input MLP
             do i = 1, size(output_layer)
                 do j = 1, size(inter_layer_2)
-                    layer_2_gradient(j) = (1._sp - output_layer(i)**2)*weight_3(i, j)  ! Derivative of TanH
-                    if (inter_layer_2(j) .lt. 0._sp) layer_2_gradient(j) = layer_2_gradient(j)*0.01_sp
+                    layer_2_grad(j) = (1._sp - output_layer(i)**2)*weight_3(i, j)  ! Derivative of TanH
+                    layer_2_grad(j) = layer_2_grad(j)*inter_layer_2_grad(j)
                 end do
 
                 ! Gradient of second layer wrt first layer
+                layer_1_grad = 0._sp
                 do j = 1, size(inter_layer_1)
                     do k = 1, size(inter_layer_2)
-                        layer_1_gradient(j) = layer_1_gradient(j) + layer_2_gradient(k)*weight_2(k, j)
+                        layer_1_grad(j) = layer_1_grad(j) + layer_2_grad(k)*weight_2(k, j)
                     end do
-                    if (inter_layer_1(j) .lt. 0._sp) layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
+                    layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
                 end do
 
                 ! Gradient of first layer wrt input layer
-                do j = 1, size(input_layer)
-                    do k = 1, size(inter_layer_1)
-                        output_jacobian(i, j) = output_jacobian(i, j) + layer_1_gradient(k)*weight_1(k, j)
-                    end do
+                do k = 1, size(inter_layer_1)
+                    output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*weight_1(k, 1)
+                    output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*weight_1(k, 2)
                 end do
-
-                ! Reset tmp gradients
-                layer_2_gradient = 0._sp
-                layer_1_gradient = 0._sp
             end do
 
         else  ! Case with 2 layers
@@ -131,19 +132,15 @@ contains
             ! Compute Jacobian matrix of output wrt input MLP
             do i = 1, size(output_layer)
                 do j = 1, size(inter_layer_1)
-                    layer_1_gradient(j) = (1._sp - output_layer(i)**2)*weight_2(i, j)  ! Derivative of TanH
-                    if (inter_layer_1(j) .lt. 0._sp) layer_1_gradient(j) = layer_1_gradient(j)*0.01_sp
+                    layer_1_grad(j) = (1._sp - output_layer(i)**2)*weight_2(i, j)  ! Derivative of TanH
+                    layer_1_grad(j) = layer_1_grad(j)*inter_layer_1_grad(j)
                 end do
 
                 ! Gradient of first layer wrt input layer
-                do j = 1, size(input_layer)
-                    do k = 1, size(inter_layer_1)
-                        output_jacobian(i, j) = output_jacobian(i, j) + layer_1_gradient(k)*weight_1(k, j)
-                    end do
+                do k = 1, size(inter_layer_1)
+                    output_jacobian_1(i) = output_jacobian_1(i) + layer_1_grad(k)*weight_1(k, 1)
+                    output_jacobian_2(i) = output_jacobian_2(i) + layer_1_grad(k)*weight_1(k, 2)
                 end do
-
-                ! Reset tmp gradients
-                layer_1_gradient = 0._sp
             end do
 
         end if

--- a/smash/tests/core/simulation/test_bayesian_optimize.py
+++ b/smash/tests/core/simulation/test_bayesian_optimize.py
@@ -88,4 +88,9 @@ def test_custom_bayesian_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-03), key
+        if key == "sim_q":
+            atol = 1e-01  # sim_q with high tolerance for high values
+        else:
+            atol = 1e-03
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol), key

--- a/smash/tests/core/simulation/test_bayesian_optimize.py
+++ b/smash/tests/core/simulation/test_bayesian_optimize.py
@@ -76,7 +76,7 @@ def generic_custom_bayesian_optimize(model: smash.Model, **kwargs) -> dict:
         instance = smash.bayesian_optimize(model, **inner_kwargs)
 
         qsim = instance.response.q[:].flatten()
-        qsim = qsim[::10]  # extract values at every 10th position
+        qsim = qsim[qsim > np.quantile(qsim, 0.95)]  # extract values depassing 0.95-quantile
 
         res[f"custom_bayesian_optimize.{model.setup.structure}.custom_set_{i + 1}.sim_q"] = qsim
 

--- a/smash/tests/core/simulation/test_bayesian_optimize.py
+++ b/smash/tests/core/simulation/test_bayesian_optimize.py
@@ -88,7 +88,7 @@ def test_custom_bayesian_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        if key == "sim_q":
+        if key.split(".")[-1] == "sim_q":
             atol = 1e-01  # sim_q with high tolerance for high values
         else:
             atol = 1e-03

--- a/smash/tests/core/simulation/test_estimate.py
+++ b/smash/tests/core/simulation/test_estimate.py
@@ -77,4 +77,9 @@ def test_multiset_estimate():
 
     for key, value in res.items():
         # % Check qsim in run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-03, equal_nan=True), key
+        if key == "sim_q":
+            atol = 1e-01  # sim_q with high tolerance for high values
+        else:
+            atol = 1e-03
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol, equal_nan=True), key

--- a/smash/tests/core/simulation/test_estimate.py
+++ b/smash/tests/core/simulation/test_estimate.py
@@ -65,7 +65,7 @@ def generic_multiset_estimate(model: smash.Model, **kwargs) -> dict:
             res[f"multiset_estimate.set_{i + 1}.lcurve_multiset.{key}"] = np.array(value, ndmin=1)
 
         qsim = instance.response.q[:].flatten()
-        qsim = qsim[::10]  # extract values at every 10th position
+        qsim = qsim[qsim > np.quantile(qsim, 0.95)]  # extract values depassing 0.95-quantile
 
         res[f"multiset_estimate.set_{i + 1}.sim_q"] = qsim
 

--- a/smash/tests/core/simulation/test_estimate.py
+++ b/smash/tests/core/simulation/test_estimate.py
@@ -77,7 +77,7 @@ def test_multiset_estimate():
 
     for key, value in res.items():
         # % Check qsim in run
-        if key == "sim_q":
+        if key.split(".")[-1] == "sim_q":
             atol = 1e-01  # sim_q with high tolerance for high values
         else:
             atol = 1e-03

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -79,7 +79,7 @@ def test_optimize():
 
     for key, value in res.items():
         # % Check qsim in run
-        if key == "sim_q":
+        if key.split(".")[-1] == "sim_q":
             atol = 1e-01  # sim_q with high tolerance for high values
         else:
             atol = 1e-03
@@ -93,7 +93,7 @@ def test_sparse_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        if key == "sim_q":
+        if key.split(".")[-1] == "sim_q":
             atol = 1e-01  # sim_q with high tolerance for high values
         else:
             atol = 1e-03
@@ -328,7 +328,7 @@ def test_custom_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        if key == "sim_q":
+        if key.split(".")[-1] == "sim_q":
             atol = 1e-01  # sim_q with high tolerance for high values
         else:
             atol = 1e-03

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -32,6 +32,7 @@ def generic_optimize(model_structure: list[smash.Model], **kwargs) -> dict:
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
             model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
+            model.set_nn_parameters_weight([w*0.2 for w in model.get_nn_parameters_weight()])
 
         for mp in MAPPING:
             if mp == "ann":

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -31,7 +31,7 @@ def generic_optimize(model_structure: list[smash.Model], **kwargs) -> dict:
 
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
-            model.set_nn_parameters_weight(initializer="normal", random_state=11)
+            model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
 
         for mp in MAPPING:
             if mp == "ann":
@@ -67,7 +67,7 @@ def generic_optimize(model_structure: list[smash.Model], **kwargs) -> dict:
             res[f"optimize.{model.setup.structure}.{mp}.control_vector"] = ret.control_vector
 
             qsim = instance.response.q[:].flatten()
-            qsim = qsim[::10]  # extract values at every 10th position
+            qsim = qsim[qsim > np.quantile(qsim, 0.95)]  # extract values depassing 0.95-quantile
 
             res[f"optimize.{model.setup.structure}.{mp}.sim_q"] = qsim
 
@@ -296,7 +296,7 @@ def generic_custom_optimize(model: smash.Model, **kwargs) -> dict:
         instance = smash.optimize(model, **inner_kwargs)
 
         qsim = instance.response.q[:].flatten()
-        qsim = qsim[::10]  # extract values at every 10th position
+        qsim = qsim[qsim > np.quantile(qsim, 0.95)]  # extract values depassing 0.95-quantile
 
         res[f"custom_optimize.{model.setup.structure}.custom_set_{i + 1}.sim_q"] = qsim
 

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -79,7 +79,12 @@ def test_optimize():
 
     for key, value in res.items():
         # % Check qsim in run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-03, equal_nan=True), key
+        if key == "sim_q":
+            atol = 1e-01  # sim_q with high tolerance for high values
+        else:
+            atol = 1e-03
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol, equal_nan=True), key
 
 
 def test_sparse_optimize():
@@ -88,7 +93,12 @@ def test_sparse_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-03, equal_nan=True), "sparse." + key
+        if key == "sim_q":
+            atol = 1e-01  # sim_q with high tolerance for high values
+        else:
+            atol = 1e-03
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol, equal_nan=True), "sparse." + key
 
 
 def generic_custom_optimize(model: smash.Model, **kwargs) -> dict:
@@ -318,4 +328,9 @@ def test_custom_optimize():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-03), key
+        if key == "sim_q":
+            atol = 1e-01  # sim_q with high tolerance for high values
+        else:
+            atol = 1e-03
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol), key

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -31,8 +31,7 @@ def generic_optimize(model_structure: list[smash.Model], **kwargs) -> dict:
 
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
-            model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
-            model.set_nn_parameters_weight([w*0.2 for w in model.get_nn_parameters_weight()])
+            model.set_nn_parameters_weight(initializer="normal", random_state=11)
 
         for mp in MAPPING:
             if mp == "ann":

--- a/smash/tests/core/simulation/test_run.py
+++ b/smash/tests/core/simulation/test_run.py
@@ -21,8 +21,7 @@ def generic_forward_run(model_structure: list[smash.Model], **kwargs) -> dict:
 
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
-            model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
-            model.set_nn_parameters_weight([w*0.2 for w in model.get_nn_parameters_weight()])
+            model.set_nn_parameters_weight(initializer="normal", random_state=11)
 
         instance, ret = smash.forward_run(
             model,

--- a/smash/tests/core/simulation/test_run.py
+++ b/smash/tests/core/simulation/test_run.py
@@ -58,7 +58,12 @@ def test_forward_run():
 
     for key, value in res.items():
         # % Check qsim in run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-06, equal_nan=True), key
+        if key in ("sim_q", "q_domain"):
+            atol = 1e-02  # sim_q and q_domain with high tolerance
+        else:
+            atol = 1e-06
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol, equal_nan=True), key
 
 
 def test_sparse_forward_run():
@@ -66,7 +71,12 @@ def test_sparse_forward_run():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        assert np.allclose(value, pytest.baseline[key][:], atol=1e-06, equal_nan=True), "sparse." + key
+        if key in ("sim_q", "q_domain"):
+            atol = 1e-02  # sim_q and q_domain with high tolerance
+        else:
+            atol = 1e-06
+
+        assert np.allclose(value, pytest.baseline[key][:], atol=atol, equal_nan=True), "sparse." + key
 
 
 def test_multiple_forward_run():

--- a/smash/tests/core/simulation/test_run.py
+++ b/smash/tests/core/simulation/test_run.py
@@ -22,6 +22,7 @@ def generic_forward_run(model_structure: list[smash.Model], **kwargs) -> dict:
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
             model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
+            model.set_nn_parameters_weight([w*0.2 for w in model.get_nn_parameters_weight()])
 
         instance, ret = smash.forward_run(
             model,

--- a/smash/tests/core/simulation/test_run.py
+++ b/smash/tests/core/simulation/test_run.py
@@ -58,7 +58,7 @@ def test_forward_run():
 
     for key, value in res.items():
         # % Check qsim in run
-        if key in ("sim_q", "q_domain"):
+        if key.split(".")[-1] in ("sim_q", "q_domain"):
             atol = 1e-02  # sim_q and q_domain with high tolerance
         else:
             atol = 1e-06
@@ -71,7 +71,7 @@ def test_sparse_forward_run():
 
     for key, value in res.items():
         # % Check qsim in sparse storage run
-        if key in ("sim_q", "q_domain"):
+        if key.split(".")[-1] in ("sim_q", "q_domain"):
             atol = 1e-02  # sim_q and q_domain with high tolerance
         else:
             atol = 1e-06

--- a/smash/tests/core/simulation/test_run.py
+++ b/smash/tests/core/simulation/test_run.py
@@ -21,7 +21,7 @@ def generic_forward_run(model_structure: list[smash.Model], **kwargs) -> dict:
 
         # % Hybrid forward hydrological model with NN
         if model.setup.n_layers > 0:
-            model.set_nn_parameters_weight(initializer="normal", random_state=11)
+            model.set_nn_parameters_weight(initializer="glorot_normal", random_state=11)
 
         instance, ret = smash.forward_run(
             model,
@@ -37,7 +37,7 @@ def generic_forward_run(model_structure: list[smash.Model], **kwargs) -> dict:
         mask = model.mesh.active_cell == 0
 
         qsim = instance.response.q[:].flatten()
-        qsim = qsim[::10]  # extract values at every 10th position
+        qsim = qsim[qsim > np.quantile(qsim, 0.95)]  # extract values depassing 0.95-quantile
 
         res[f"forward_run.{instance.setup.structure}.sim_q"] = qsim
         res[f"forward_run.{instance.setup.structure}.cost"] = np.array(ret.cost, ndmin=1)

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,8 +1,8 @@
-commit 050d0c49b02080ec564b83e32cde03372b63bff6
+commit caab49d9e1d0ff850cffa247801267fa8b487013
 Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
-Date:   Sat Mar 1 18:48:12 2025 +0100
+Date:   Sat Mar 1 22:42:02 2025 +0100
 
-    FIX: decrease initialize weight NN to avoid precision issue with exp function
+    Fix baseline
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -23,56 +23,56 @@ bbox_mesh.xmin                                                 |NON MODIFIED
 bbox_mesh.xres                                                 |NON MODIFIED
 bbox_mesh.ymax                                                 |NON MODIFIED
 bbox_mesh.yres                                                 |NON MODIFIED
-custom_bayesian_optimize.zero-gr4-lr.custom_set_1.sim_q        |NON MODIFIED
-custom_bayesian_optimize.zero-gr4-lr.custom_set_2.sim_q        |NON MODIFIED
-custom_bayesian_optimize.zero-gr4-lr.custom_set_3.sim_q        |NON MODIFIED
-custom_bayesian_optimize.zero-gr4-lr.custom_set_4.sim_q        |NON MODIFIED
+custom_bayesian_optimize.zero-gr4-lr.custom_set_1.sim_q        |MODIFIED
+custom_bayesian_optimize.zero-gr4-lr.custom_set_2.sim_q        |MODIFIED
+custom_bayesian_optimize.zero-gr4-lr.custom_set_3.sim_q        |MODIFIED
+custom_bayesian_optimize.zero-gr4-lr.custom_set_4.sim_q        |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_1.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_1.iter_cost             |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_1.iter_projg            |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_1.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_1.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_10.iter_control         |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_10.iter_cost            |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_10.iter_projg           |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_10.sim_q                |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_10.sim_q                |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_11.iter_control         |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_11.iter_cost            |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_11.iter_projg           |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_11.sim_q                |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_11.sim_q                |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_12.iter_control         |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_12.iter_cost            |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_12.iter_projg           |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_12.sim_q                |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_12.sim_q                |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_13.iter_control         |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_13.iter_cost            |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_13.iter_projg           |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_13.sim_q                |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_13.sim_q                |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_2.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_2.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_2.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_2.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_3.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_3.iter_cost             |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_3.iter_projg            |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_3.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_3.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_4.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_4.iter_cost             |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_4.iter_projg            |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_4.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_4.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_5.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_5.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_5.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_5.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_6.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_6.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_6.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_6.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_7.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_7.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_7.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_7.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_8.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_8.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_8.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_8.sim_q                 |MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_9.iter_control          |NON MODIFIED
 custom_optimize.zero-gr4-lr.custom_set_9.iter_cost             |NON MODIFIED
-custom_optimize.zero-gr4-lr.custom_set_9.sim_q                 |NON MODIFIED
+custom_optimize.zero-gr4-lr.custom_set_9.sim_q                 |MODIFIED
 evaluation.kge                                                 |NON MODIFIED
 evaluation.lgrm                                                |NON MODIFIED
 evaluation.mae                                                 |NON MODIFIED
@@ -87,14 +87,14 @@ forward_run.zero-gr4-kw.q_domain                               |NON MODIFIED
 forward_run.zero-gr4-kw.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr4-kw.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr4-kw.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr4-kw.sim_q                                  |NON MODIFIED
+forward_run.zero-gr4-kw.sim_q                                  |MODIFIED
 forward_run.zero-gr4-lag0.cost                                 |NON MODIFIED
 forward_run.zero-gr4-lag0.jobs                                 |NON MODIFIED
 forward_run.zero-gr4-lag0.q_domain                             |NON MODIFIED
 forward_run.zero-gr4-lag0.rr_states.hi                         |NON MODIFIED
 forward_run.zero-gr4-lag0.rr_states.hp                         |NON MODIFIED
 forward_run.zero-gr4-lag0.rr_states.ht                         |NON MODIFIED
-forward_run.zero-gr4-lag0.sim_q                                |NON MODIFIED
+forward_run.zero-gr4-lag0.sim_q                                |MODIFIED
 forward_run.zero-gr4-lr.cost                                   |NON MODIFIED
 forward_run.zero-gr4-lr.jobs                                   |NON MODIFIED
 forward_run.zero-gr4-lr.q_domain                               |NON MODIFIED
@@ -102,7 +102,7 @@ forward_run.zero-gr4-lr.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr4-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr4-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr4-lr.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr4-lr.sim_q                                  |NON MODIFIED
+forward_run.zero-gr4-lr.sim_q                                  |MODIFIED
 forward_run.zero-gr4_mlp-kw.cost                               |MODIFIED
 forward_run.zero-gr4_mlp-kw.jobs                               |MODIFIED
 forward_run.zero-gr4_mlp-kw.q_domain                           |MODIFIED
@@ -131,14 +131,14 @@ forward_run.zero-gr4_ode-kw.q_domain                           |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_ode-kw.sim_q                              |NON MODIFIED
+forward_run.zero-gr4_ode-kw.sim_q                              |MODIFIED
 forward_run.zero-gr4_ode-lag0.cost                             |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.jobs                             |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.q_domain                         |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hi                     |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hp                     |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.sim_q                            |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.sim_q                            |MODIFIED
 forward_run.zero-gr4_ode-lr.cost                               |NON MODIFIED
 forward_run.zero-gr4_ode-lr.jobs                               |NON MODIFIED
 forward_run.zero-gr4_ode-lr.q_domain                           |NON MODIFIED
@@ -146,7 +146,7 @@ forward_run.zero-gr4_ode-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_ode-lr.sim_q                              |NON MODIFIED
+forward_run.zero-gr4_ode-lr.sim_q                              |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.cost                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.jobs                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.q_domain                       |MODIFIED
@@ -175,14 +175,14 @@ forward_run.zero-gr4_ri-kw.q_domain                            |NON MODIFIED
 forward_run.zero-gr4_ri-kw.rr_states.hi                        |NON MODIFIED
 forward_run.zero-gr4_ri-kw.rr_states.hp                        |NON MODIFIED
 forward_run.zero-gr4_ri-kw.rr_states.ht                        |NON MODIFIED
-forward_run.zero-gr4_ri-kw.sim_q                               |NON MODIFIED
+forward_run.zero-gr4_ri-kw.sim_q                               |MODIFIED
 forward_run.zero-gr4_ri-lag0.cost                              |NON MODIFIED
 forward_run.zero-gr4_ri-lag0.jobs                              |NON MODIFIED
 forward_run.zero-gr4_ri-lag0.q_domain                          |NON MODIFIED
 forward_run.zero-gr4_ri-lag0.rr_states.hi                      |NON MODIFIED
 forward_run.zero-gr4_ri-lag0.rr_states.hp                      |NON MODIFIED
 forward_run.zero-gr4_ri-lag0.rr_states.ht                      |NON MODIFIED
-forward_run.zero-gr4_ri-lag0.sim_q                             |NON MODIFIED
+forward_run.zero-gr4_ri-lag0.sim_q                             |MODIFIED
 forward_run.zero-gr4_ri-lr.cost                                |NON MODIFIED
 forward_run.zero-gr4_ri-lr.jobs                                |NON MODIFIED
 forward_run.zero-gr4_ri-lr.q_domain                            |NON MODIFIED
@@ -190,21 +190,21 @@ forward_run.zero-gr4_ri-lr.rr_states.hi                        |NON MODIFIED
 forward_run.zero-gr4_ri-lr.rr_states.hlr                       |NON MODIFIED
 forward_run.zero-gr4_ri-lr.rr_states.hp                        |NON MODIFIED
 forward_run.zero-gr4_ri-lr.rr_states.ht                        |NON MODIFIED
-forward_run.zero-gr4_ri-lr.sim_q                               |NON MODIFIED
+forward_run.zero-gr4_ri-lr.sim_q                               |MODIFIED
 forward_run.zero-gr5-kw.cost                                   |NON MODIFIED
 forward_run.zero-gr5-kw.jobs                                   |NON MODIFIED
 forward_run.zero-gr5-kw.q_domain                               |NON MODIFIED
 forward_run.zero-gr5-kw.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr5-kw.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr5-kw.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr5-kw.sim_q                                  |NON MODIFIED
+forward_run.zero-gr5-kw.sim_q                                  |MODIFIED
 forward_run.zero-gr5-lag0.cost                                 |NON MODIFIED
 forward_run.zero-gr5-lag0.jobs                                 |NON MODIFIED
 forward_run.zero-gr5-lag0.q_domain                             |NON MODIFIED
 forward_run.zero-gr5-lag0.rr_states.hi                         |NON MODIFIED
 forward_run.zero-gr5-lag0.rr_states.hp                         |NON MODIFIED
 forward_run.zero-gr5-lag0.rr_states.ht                         |NON MODIFIED
-forward_run.zero-gr5-lag0.sim_q                                |NON MODIFIED
+forward_run.zero-gr5-lag0.sim_q                                |MODIFIED
 forward_run.zero-gr5-lr.cost                                   |NON MODIFIED
 forward_run.zero-gr5-lr.jobs                                   |NON MODIFIED
 forward_run.zero-gr5-lr.q_domain                               |NON MODIFIED
@@ -212,7 +212,7 @@ forward_run.zero-gr5-lr.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr5-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr5-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr5-lr.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr5-lr.sim_q                                  |NON MODIFIED
+forward_run.zero-gr5-lr.sim_q                                  |MODIFIED
 forward_run.zero-gr5_mlp-kw.cost                               |MODIFIED
 forward_run.zero-gr5_mlp-kw.jobs                               |MODIFIED
 forward_run.zero-gr5_mlp-kw.q_domain                           |MODIFIED
@@ -241,14 +241,14 @@ forward_run.zero-gr5_ri-kw.q_domain                            |NON MODIFIED
 forward_run.zero-gr5_ri-kw.rr_states.hi                        |NON MODIFIED
 forward_run.zero-gr5_ri-kw.rr_states.hp                        |NON MODIFIED
 forward_run.zero-gr5_ri-kw.rr_states.ht                        |NON MODIFIED
-forward_run.zero-gr5_ri-kw.sim_q                               |NON MODIFIED
+forward_run.zero-gr5_ri-kw.sim_q                               |MODIFIED
 forward_run.zero-gr5_ri-lag0.cost                              |NON MODIFIED
 forward_run.zero-gr5_ri-lag0.jobs                              |NON MODIFIED
 forward_run.zero-gr5_ri-lag0.q_domain                          |NON MODIFIED
 forward_run.zero-gr5_ri-lag0.rr_states.hi                      |NON MODIFIED
 forward_run.zero-gr5_ri-lag0.rr_states.hp                      |NON MODIFIED
 forward_run.zero-gr5_ri-lag0.rr_states.ht                      |NON MODIFIED
-forward_run.zero-gr5_ri-lag0.sim_q                             |NON MODIFIED
+forward_run.zero-gr5_ri-lag0.sim_q                             |MODIFIED
 forward_run.zero-gr5_ri-lr.cost                                |NON MODIFIED
 forward_run.zero-gr5_ri-lr.jobs                                |NON MODIFIED
 forward_run.zero-gr5_ri-lr.q_domain                            |NON MODIFIED
@@ -256,7 +256,7 @@ forward_run.zero-gr5_ri-lr.rr_states.hi                        |NON MODIFIED
 forward_run.zero-gr5_ri-lr.rr_states.hlr                       |NON MODIFIED
 forward_run.zero-gr5_ri-lr.rr_states.hp                        |NON MODIFIED
 forward_run.zero-gr5_ri-lr.rr_states.ht                        |NON MODIFIED
-forward_run.zero-gr5_ri-lr.sim_q                               |NON MODIFIED
+forward_run.zero-gr5_ri-lr.sim_q                               |MODIFIED
 forward_run.zero-gr6-kw.cost                                   |NON MODIFIED
 forward_run.zero-gr6-kw.jobs                                   |NON MODIFIED
 forward_run.zero-gr6-kw.q_domain                               |NON MODIFIED
@@ -264,7 +264,7 @@ forward_run.zero-gr6-kw.rr_states.he                           |NON MODIFIED
 forward_run.zero-gr6-kw.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr6-kw.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr6-kw.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr6-kw.sim_q                                  |NON MODIFIED
+forward_run.zero-gr6-kw.sim_q                                  |MODIFIED
 forward_run.zero-gr6-lag0.cost                                 |NON MODIFIED
 forward_run.zero-gr6-lag0.jobs                                 |NON MODIFIED
 forward_run.zero-gr6-lag0.q_domain                             |NON MODIFIED
@@ -272,7 +272,7 @@ forward_run.zero-gr6-lag0.rr_states.he                         |NON MODIFIED
 forward_run.zero-gr6-lag0.rr_states.hi                         |NON MODIFIED
 forward_run.zero-gr6-lag0.rr_states.hp                         |NON MODIFIED
 forward_run.zero-gr6-lag0.rr_states.ht                         |NON MODIFIED
-forward_run.zero-gr6-lag0.sim_q                                |NON MODIFIED
+forward_run.zero-gr6-lag0.sim_q                                |MODIFIED
 forward_run.zero-gr6-lr.cost                                   |NON MODIFIED
 forward_run.zero-gr6-lr.jobs                                   |NON MODIFIED
 forward_run.zero-gr6-lr.q_domain                               |NON MODIFIED
@@ -281,30 +281,30 @@ forward_run.zero-gr6-lr.rr_states.hi                           |NON MODIFIED
 forward_run.zero-gr6-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr6-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr6-lr.rr_states.ht                           |NON MODIFIED
-forward_run.zero-gr6-lr.sim_q                                  |NON MODIFIED
+forward_run.zero-gr6-lr.sim_q                                  |MODIFIED
 forward_run.zero-gr6_mlp-kw.cost                               |MODIFIED
 forward_run.zero-gr6_mlp-kw.jobs                               |MODIFIED
-forward_run.zero-gr6_mlp-kw.q_domain                           |MODIFIED
-forward_run.zero-gr6_mlp-kw.rr_states.he                       |MODIFIED
+forward_run.zero-gr6_mlp-kw.q_domain                           |NON MODIFIED
+forward_run.zero-gr6_mlp-kw.rr_states.he                       |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.hi                       |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.rr_states.hp                       |MODIFIED
+forward_run.zero-gr6_mlp-kw.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.ht                       |MODIFIED
 forward_run.zero-gr6_mlp-kw.sim_q                              |MODIFIED
 forward_run.zero-gr6_mlp-lag0.cost                             |MODIFIED
 forward_run.zero-gr6_mlp-lag0.jobs                             |MODIFIED
-forward_run.zero-gr6_mlp-lag0.q_domain                         |MODIFIED
-forward_run.zero-gr6_mlp-lag0.rr_states.he                     |MODIFIED
+forward_run.zero-gr6_mlp-lag0.q_domain                         |NON MODIFIED
+forward_run.zero-gr6_mlp-lag0.rr_states.he                     |NON MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.hi                     |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.rr_states.hp                     |MODIFIED
+forward_run.zero-gr6_mlp-lag0.rr_states.hp                     |NON MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.ht                     |MODIFIED
 forward_run.zero-gr6_mlp-lag0.sim_q                            |MODIFIED
 forward_run.zero-gr6_mlp-lr.cost                               |MODIFIED
 forward_run.zero-gr6_mlp-lr.jobs                               |MODIFIED
-forward_run.zero-gr6_mlp-lr.q_domain                           |MODIFIED
-forward_run.zero-gr6_mlp-lr.rr_states.he                       |MODIFIED
+forward_run.zero-gr6_mlp-lr.q_domain                           |NON MODIFIED
+forward_run.zero-gr6_mlp-lr.rr_states.he                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.rr_states.hp                       |MODIFIED
+forward_run.zero-gr6_mlp-lr.rr_states.hp                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.ht                       |MODIFIED
 forward_run.zero-gr6_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-grc-kw.cost                                   |NON MODIFIED
@@ -314,7 +314,7 @@ forward_run.zero-grc-kw.rr_states.hi                           |NON MODIFIED
 forward_run.zero-grc-kw.rr_states.hl                           |NON MODIFIED
 forward_run.zero-grc-kw.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grc-kw.rr_states.ht                           |NON MODIFIED
-forward_run.zero-grc-kw.sim_q                                  |NON MODIFIED
+forward_run.zero-grc-kw.sim_q                                  |MODIFIED
 forward_run.zero-grc-lag0.cost                                 |NON MODIFIED
 forward_run.zero-grc-lag0.jobs                                 |NON MODIFIED
 forward_run.zero-grc-lag0.q_domain                             |NON MODIFIED
@@ -322,7 +322,7 @@ forward_run.zero-grc-lag0.rr_states.hi                         |NON MODIFIED
 forward_run.zero-grc-lag0.rr_states.hl                         |NON MODIFIED
 forward_run.zero-grc-lag0.rr_states.hp                         |NON MODIFIED
 forward_run.zero-grc-lag0.rr_states.ht                         |NON MODIFIED
-forward_run.zero-grc-lag0.sim_q                                |NON MODIFIED
+forward_run.zero-grc-lag0.sim_q                                |MODIFIED
 forward_run.zero-grc-lr.cost                                   |NON MODIFIED
 forward_run.zero-grc-lr.jobs                                   |NON MODIFIED
 forward_run.zero-grc-lr.q_domain                               |NON MODIFIED
@@ -331,7 +331,7 @@ forward_run.zero-grc-lr.rr_states.hl                           |NON MODIFIED
 forward_run.zero-grc-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-grc-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grc-lr.rr_states.ht                           |NON MODIFIED
-forward_run.zero-grc-lr.sim_q                                  |NON MODIFIED
+forward_run.zero-grc-lr.sim_q                                  |MODIFIED
 forward_run.zero-grc_mlp-kw.cost                               |MODIFIED
 forward_run.zero-grc_mlp-kw.jobs                               |MODIFIED
 forward_run.zero-grc_mlp-kw.q_domain                           |MODIFIED
@@ -362,20 +362,20 @@ forward_run.zero-grd-kw.jobs                                   |NON MODIFIED
 forward_run.zero-grd-kw.q_domain                               |NON MODIFIED
 forward_run.zero-grd-kw.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grd-kw.rr_states.ht                           |NON MODIFIED
-forward_run.zero-grd-kw.sim_q                                  |NON MODIFIED
+forward_run.zero-grd-kw.sim_q                                  |MODIFIED
 forward_run.zero-grd-lag0.cost                                 |NON MODIFIED
 forward_run.zero-grd-lag0.jobs                                 |NON MODIFIED
 forward_run.zero-grd-lag0.q_domain                             |NON MODIFIED
 forward_run.zero-grd-lag0.rr_states.hp                         |NON MODIFIED
 forward_run.zero-grd-lag0.rr_states.ht                         |NON MODIFIED
-forward_run.zero-grd-lag0.sim_q                                |NON MODIFIED
+forward_run.zero-grd-lag0.sim_q                                |MODIFIED
 forward_run.zero-grd-lr.cost                                   |NON MODIFIED
 forward_run.zero-grd-lr.jobs                                   |NON MODIFIED
 forward_run.zero-grd-lr.q_domain                               |NON MODIFIED
 forward_run.zero-grd-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-grd-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grd-lr.rr_states.ht                           |NON MODIFIED
-forward_run.zero-grd-lr.sim_q                                  |NON MODIFIED
+forward_run.zero-grd-lr.sim_q                                  |MODIFIED
 forward_run.zero-grd_mlp-kw.cost                               |MODIFIED
 forward_run.zero-grd_mlp-kw.jobs                               |MODIFIED
 forward_run.zero-grd_mlp-kw.q_domain                           |MODIFIED
@@ -400,20 +400,20 @@ forward_run.zero-loieau-kw.jobs                                |NON MODIFIED
 forward_run.zero-loieau-kw.q_domain                            |NON MODIFIED
 forward_run.zero-loieau-kw.rr_states.ha                        |NON MODIFIED
 forward_run.zero-loieau-kw.rr_states.hc                        |NON MODIFIED
-forward_run.zero-loieau-kw.sim_q                               |NON MODIFIED
+forward_run.zero-loieau-kw.sim_q                               |MODIFIED
 forward_run.zero-loieau-lag0.cost                              |NON MODIFIED
 forward_run.zero-loieau-lag0.jobs                              |NON MODIFIED
 forward_run.zero-loieau-lag0.q_domain                          |NON MODIFIED
 forward_run.zero-loieau-lag0.rr_states.ha                      |NON MODIFIED
 forward_run.zero-loieau-lag0.rr_states.hc                      |NON MODIFIED
-forward_run.zero-loieau-lag0.sim_q                             |NON MODIFIED
+forward_run.zero-loieau-lag0.sim_q                             |MODIFIED
 forward_run.zero-loieau-lr.cost                                |NON MODIFIED
 forward_run.zero-loieau-lr.jobs                                |NON MODIFIED
 forward_run.zero-loieau-lr.q_domain                            |NON MODIFIED
 forward_run.zero-loieau-lr.rr_states.ha                        |NON MODIFIED
 forward_run.zero-loieau-lr.rr_states.hc                        |NON MODIFIED
 forward_run.zero-loieau-lr.rr_states.hlr                       |NON MODIFIED
-forward_run.zero-loieau-lr.sim_q                               |NON MODIFIED
+forward_run.zero-loieau-lr.sim_q                               |MODIFIED
 forward_run.zero-loieau_mlp-kw.cost                            |MODIFIED
 forward_run.zero-loieau_mlp-kw.jobs                            |MODIFIED
 forward_run.zero-loieau_mlp-kw.q_domain                        |MODIFIED
@@ -440,7 +440,7 @@ forward_run.zero-vic3l-kw.rr_states.hbsl                       |NON MODIFIED
 forward_run.zero-vic3l-kw.rr_states.hcl                        |NON MODIFIED
 forward_run.zero-vic3l-kw.rr_states.hmsl                       |NON MODIFIED
 forward_run.zero-vic3l-kw.rr_states.husl                       |NON MODIFIED
-forward_run.zero-vic3l-kw.sim_q                                |NON MODIFIED
+forward_run.zero-vic3l-kw.sim_q                                |MODIFIED
 forward_run.zero-vic3l-lag0.cost                               |NON MODIFIED
 forward_run.zero-vic3l-lag0.jobs                               |NON MODIFIED
 forward_run.zero-vic3l-lag0.q_domain                           |NON MODIFIED
@@ -448,7 +448,7 @@ forward_run.zero-vic3l-lag0.rr_states.hbsl                     |NON MODIFIED
 forward_run.zero-vic3l-lag0.rr_states.hcl                      |NON MODIFIED
 forward_run.zero-vic3l-lag0.rr_states.hmsl                     |NON MODIFIED
 forward_run.zero-vic3l-lag0.rr_states.husl                     |NON MODIFIED
-forward_run.zero-vic3l-lag0.sim_q                              |NON MODIFIED
+forward_run.zero-vic3l-lag0.sim_q                              |MODIFIED
 forward_run.zero-vic3l-lr.cost                                 |NON MODIFIED
 forward_run.zero-vic3l-lr.jobs                                 |NON MODIFIED
 forward_run.zero-vic3l-lr.q_domain                             |NON MODIFIED
@@ -457,7 +457,7 @@ forward_run.zero-vic3l-lr.rr_states.hcl                        |NON MODIFIED
 forward_run.zero-vic3l-lr.rr_states.hlr                        |NON MODIFIED
 forward_run.zero-vic3l-lr.rr_states.hmsl                       |NON MODIFIED
 forward_run.zero-vic3l-lr.rr_states.husl                       |NON MODIFIED
-forward_run.zero-vic3l-lr.sim_q                                |NON MODIFIED
+forward_run.zero-vic3l-lr.sim_q                                |MODIFIED
 generate_samples.normal                                        |NON MODIFIED
 generate_samples.uniform                                       |NON MODIFIED
 hydrograph_segmentation.by_obs                                 |NON MODIFIED
@@ -1146,12 +1146,12 @@ multiset_estimate.set_1.lcurve_multiset.alpha                  |NON MODIFIED
 multiset_estimate.set_1.lcurve_multiset.alpha_opt              |NON MODIFIED
 multiset_estimate.set_1.lcurve_multiset.cost                   |NON MODIFIED
 multiset_estimate.set_1.lcurve_multiset.mahal_dist             |NON MODIFIED
-multiset_estimate.set_1.sim_q                                  |NON MODIFIED
+multiset_estimate.set_1.sim_q                                  |MODIFIED
 multiset_estimate.set_2.lcurve_multiset.alpha                  |NON MODIFIED
 multiset_estimate.set_2.lcurve_multiset.alpha_opt              |NON MODIFIED
 multiset_estimate.set_2.lcurve_multiset.cost                   |NON MODIFIED
 multiset_estimate.set_2.lcurve_multiset.mahal_dist             |NON MODIFIED
-multiset_estimate.set_2.sim_q                                  |NON MODIFIED
+multiset_estimate.set_2.sim_q                                  |MODIFIED
 net_forward_pass.output                                        |NON MODIFIED
 net_init.bias_layer_1                                          |NON MODIFIED
 net_init.bias_layer_2                                          |NON MODIFIED
@@ -1163,35 +1163,35 @@ net_init.weight_layer_2                                        |NON MODIFIED
 net_init.weight_layer_3                                        |NON MODIFIED
 net_init.weight_layer_4                                        |NON MODIFIED
 optimize.zero-gr4-kw.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr4-kw.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr4-kw.ann.sim_q                                 |MODIFIED
 optimize.zero-gr4-kw.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr4-kw.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr4-kw.distributed.sim_q                         |MODIFIED
 optimize.zero-gr4-kw.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr4-kw.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr4-kw.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr4-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr4-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr4-kw.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr4-kw.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr4-kw.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr4-kw.uniform.sim_q                             |MODIFIED
 optimize.zero-gr4-lag0.ann.control_vector                      |NON MODIFIED
-optimize.zero-gr4-lag0.ann.sim_q                               |NON MODIFIED
+optimize.zero-gr4-lag0.ann.sim_q                               |MODIFIED
 optimize.zero-gr4-lag0.distributed.control_vector              |NON MODIFIED
-optimize.zero-gr4-lag0.distributed.sim_q                       |NON MODIFIED
+optimize.zero-gr4-lag0.distributed.sim_q                       |MODIFIED
 optimize.zero-gr4-lag0.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-gr4-lag0.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-gr4-lag0.multi-linear.sim_q                      |MODIFIED
 optimize.zero-gr4-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr4-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr4-lag0.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-gr4-lag0.uniform.control_vector                  |NON MODIFIED
-optimize.zero-gr4-lag0.uniform.sim_q                           |NON MODIFIED
+optimize.zero-gr4-lag0.uniform.sim_q                           |MODIFIED
 optimize.zero-gr4-lr.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr4-lr.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr4-lr.ann.sim_q                                 |MODIFIED
 optimize.zero-gr4-lr.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr4-lr.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr4-lr.distributed.sim_q                         |MODIFIED
 optimize.zero-gr4-lr.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr4-lr.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr4-lr.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr4-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr4-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr4-lr.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr4-lr.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr4-lr.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr4-lr.uniform.sim_q                             |MODIFIED
 optimize.zero-gr4_mlp-kw.ann.control_vector                    |MODIFIED
 optimize.zero-gr4_mlp-kw.ann.sim_q                             |MODIFIED
 optimize.zero-gr4_mlp-kw.distributed.control_vector            |MODIFIED
@@ -1223,35 +1223,35 @@ optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-gr4_mlp-lr.uniform.control_vector                |MODIFIED
 optimize.zero-gr4_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-gr4_ode-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_ode-kw.ann.sim_q                             |NON MODIFIED
+optimize.zero-gr4_ode-kw.ann.sim_q                             |MODIFIED
 optimize.zero-gr4_ode-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode-kw.distributed.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ode-kw.distributed.sim_q                     |MODIFIED
 optimize.zero-gr4_ode-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |MODIFIED
 optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-gr4_ode-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode-kw.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr4_ode-kw.uniform.sim_q                         |MODIFIED
 optimize.zero-gr4_ode-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-gr4_ode-lag0.ann.sim_q                           |NON MODIFIED
+optimize.zero-gr4_ode-lag0.ann.sim_q                           |MODIFIED
 optimize.zero-gr4_ode-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-gr4_ode-lag0.distributed.sim_q                   |NON MODIFIED
+optimize.zero-gr4_ode-lag0.distributed.sim_q                   |MODIFIED
 optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |MODIFIED
 optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |MODIFIED
 optimize.zero-gr4_ode-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-gr4_ode-lag0.uniform.sim_q                       |NON MODIFIED
+optimize.zero-gr4_ode-lag0.uniform.sim_q                       |MODIFIED
 optimize.zero-gr4_ode-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_ode-lr.ann.sim_q                             |NON MODIFIED
+optimize.zero-gr4_ode-lr.ann.sim_q                             |MODIFIED
 optimize.zero-gr4_ode-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_ode-lr.distributed.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ode-lr.distributed.sim_q                     |MODIFIED
 optimize.zero-gr4_ode-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |MODIFIED
 optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-gr4_ode-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_ode-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr4_ode-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.sim_q                         |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |MODIFIED
@@ -1283,65 +1283,65 @@ optimize.zero-gr4_ode_mlp-lr.multi-polynomial.sim_q            |MODIFIED
 optimize.zero-gr4_ode_mlp-lr.uniform.control_vector            |MODIFIED
 optimize.zero-gr4_ode_mlp-lr.uniform.sim_q                     |MODIFIED
 optimize.zero-gr4_ri-kw.ann.control_vector                     |NON MODIFIED
-optimize.zero-gr4_ri-kw.ann.sim_q                              |NON MODIFIED
+optimize.zero-gr4_ri-kw.ann.sim_q                              |MODIFIED
 optimize.zero-gr4_ri-kw.distributed.control_vector             |NON MODIFIED
-optimize.zero-gr4_ri-kw.distributed.sim_q                      |NON MODIFIED
+optimize.zero-gr4_ri-kw.distributed.sim_q                      |MODIFIED
 optimize.zero-gr4_ri-kw.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-gr4_ri-kw.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ri-kw.multi-linear.sim_q                     |MODIFIED
 optimize.zero-gr4_ri-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr4_ri-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr4_ri-kw.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-gr4_ri-kw.uniform.control_vector                 |NON MODIFIED
-optimize.zero-gr4_ri-kw.uniform.sim_q                          |NON MODIFIED
+optimize.zero-gr4_ri-kw.uniform.sim_q                          |MODIFIED
 optimize.zero-gr4_ri-lag0.ann.control_vector                   |NON MODIFIED
-optimize.zero-gr4_ri-lag0.ann.sim_q                            |NON MODIFIED
+optimize.zero-gr4_ri-lag0.ann.sim_q                            |MODIFIED
 optimize.zero-gr4_ri-lag0.distributed.control_vector           |NON MODIFIED
-optimize.zero-gr4_ri-lag0.distributed.sim_q                    |NON MODIFIED
+optimize.zero-gr4_ri-lag0.distributed.sim_q                    |MODIFIED
 optimize.zero-gr4_ri-lag0.multi-linear.control_vector          |NON MODIFIED
-optimize.zero-gr4_ri-lag0.multi-linear.sim_q                   |NON MODIFIED
+optimize.zero-gr4_ri-lag0.multi-linear.sim_q                   |MODIFIED
 optimize.zero-gr4_ri-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-gr4_ri-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-gr4_ri-lag0.multi-polynomial.sim_q               |MODIFIED
 optimize.zero-gr4_ri-lag0.uniform.control_vector               |NON MODIFIED
-optimize.zero-gr4_ri-lag0.uniform.sim_q                        |NON MODIFIED
+optimize.zero-gr4_ri-lag0.uniform.sim_q                        |MODIFIED
 optimize.zero-gr4_ri-lr.ann.control_vector                     |NON MODIFIED
-optimize.zero-gr4_ri-lr.ann.sim_q                              |NON MODIFIED
+optimize.zero-gr4_ri-lr.ann.sim_q                              |MODIFIED
 optimize.zero-gr4_ri-lr.distributed.control_vector             |NON MODIFIED
-optimize.zero-gr4_ri-lr.distributed.sim_q                      |NON MODIFIED
+optimize.zero-gr4_ri-lr.distributed.sim_q                      |MODIFIED
 optimize.zero-gr4_ri-lr.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-gr4_ri-lr.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ri-lr.multi-linear.sim_q                     |MODIFIED
 optimize.zero-gr4_ri-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr4_ri-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr4_ri-lr.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-gr4_ri-lr.uniform.control_vector                 |NON MODIFIED
-optimize.zero-gr4_ri-lr.uniform.sim_q                          |NON MODIFIED
+optimize.zero-gr4_ri-lr.uniform.sim_q                          |MODIFIED
 optimize.zero-gr5-kw.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr5-kw.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr5-kw.ann.sim_q                                 |MODIFIED
 optimize.zero-gr5-kw.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr5-kw.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr5-kw.distributed.sim_q                         |MODIFIED
 optimize.zero-gr5-kw.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr5-kw.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr5-kw.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr5-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr5-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr5-kw.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr5-kw.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr5-kw.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr5-kw.uniform.sim_q                             |MODIFIED
 optimize.zero-gr5-lag0.ann.control_vector                      |NON MODIFIED
-optimize.zero-gr5-lag0.ann.sim_q                               |NON MODIFIED
+optimize.zero-gr5-lag0.ann.sim_q                               |MODIFIED
 optimize.zero-gr5-lag0.distributed.control_vector              |NON MODIFIED
-optimize.zero-gr5-lag0.distributed.sim_q                       |NON MODIFIED
+optimize.zero-gr5-lag0.distributed.sim_q                       |MODIFIED
 optimize.zero-gr5-lag0.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-gr5-lag0.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-gr5-lag0.multi-linear.sim_q                      |MODIFIED
 optimize.zero-gr5-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr5-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr5-lag0.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-gr5-lag0.uniform.control_vector                  |NON MODIFIED
-optimize.zero-gr5-lag0.uniform.sim_q                           |NON MODIFIED
+optimize.zero-gr5-lag0.uniform.sim_q                           |MODIFIED
 optimize.zero-gr5-lr.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr5-lr.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr5-lr.ann.sim_q                                 |MODIFIED
 optimize.zero-gr5-lr.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr5-lr.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr5-lr.distributed.sim_q                         |MODIFIED
 optimize.zero-gr5-lr.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr5-lr.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr5-lr.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr5-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr5-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr5-lr.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr5-lr.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr5-lr.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr5-lr.uniform.sim_q                             |MODIFIED
 optimize.zero-gr5_mlp-kw.ann.control_vector                    |MODIFIED
 optimize.zero-gr5_mlp-kw.ann.sim_q                             |MODIFIED
 optimize.zero-gr5_mlp-kw.distributed.control_vector            |MODIFIED
@@ -1373,65 +1373,65 @@ optimize.zero-gr5_mlp-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-gr5_mlp-lr.uniform.control_vector                |MODIFIED
 optimize.zero-gr5_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-gr5_ri-kw.ann.control_vector                     |NON MODIFIED
-optimize.zero-gr5_ri-kw.ann.sim_q                              |NON MODIFIED
+optimize.zero-gr5_ri-kw.ann.sim_q                              |MODIFIED
 optimize.zero-gr5_ri-kw.distributed.control_vector             |NON MODIFIED
-optimize.zero-gr5_ri-kw.distributed.sim_q                      |NON MODIFIED
+optimize.zero-gr5_ri-kw.distributed.sim_q                      |MODIFIED
 optimize.zero-gr5_ri-kw.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-gr5_ri-kw.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-gr5_ri-kw.multi-linear.sim_q                     |MODIFIED
 optimize.zero-gr5_ri-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr5_ri-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr5_ri-kw.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-gr5_ri-kw.uniform.control_vector                 |NON MODIFIED
-optimize.zero-gr5_ri-kw.uniform.sim_q                          |NON MODIFIED
+optimize.zero-gr5_ri-kw.uniform.sim_q                          |MODIFIED
 optimize.zero-gr5_ri-lag0.ann.control_vector                   |NON MODIFIED
-optimize.zero-gr5_ri-lag0.ann.sim_q                            |NON MODIFIED
+optimize.zero-gr5_ri-lag0.ann.sim_q                            |MODIFIED
 optimize.zero-gr5_ri-lag0.distributed.control_vector           |NON MODIFIED
-optimize.zero-gr5_ri-lag0.distributed.sim_q                    |NON MODIFIED
+optimize.zero-gr5_ri-lag0.distributed.sim_q                    |MODIFIED
 optimize.zero-gr5_ri-lag0.multi-linear.control_vector          |NON MODIFIED
-optimize.zero-gr5_ri-lag0.multi-linear.sim_q                   |NON MODIFIED
+optimize.zero-gr5_ri-lag0.multi-linear.sim_q                   |MODIFIED
 optimize.zero-gr5_ri-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-gr5_ri-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-gr5_ri-lag0.multi-polynomial.sim_q               |MODIFIED
 optimize.zero-gr5_ri-lag0.uniform.control_vector               |NON MODIFIED
-optimize.zero-gr5_ri-lag0.uniform.sim_q                        |NON MODIFIED
+optimize.zero-gr5_ri-lag0.uniform.sim_q                        |MODIFIED
 optimize.zero-gr5_ri-lr.ann.control_vector                     |NON MODIFIED
-optimize.zero-gr5_ri-lr.ann.sim_q                              |NON MODIFIED
+optimize.zero-gr5_ri-lr.ann.sim_q                              |MODIFIED
 optimize.zero-gr5_ri-lr.distributed.control_vector             |NON MODIFIED
-optimize.zero-gr5_ri-lr.distributed.sim_q                      |NON MODIFIED
+optimize.zero-gr5_ri-lr.distributed.sim_q                      |MODIFIED
 optimize.zero-gr5_ri-lr.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-gr5_ri-lr.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-gr5_ri-lr.multi-linear.sim_q                     |MODIFIED
 optimize.zero-gr5_ri-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr5_ri-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr5_ri-lr.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-gr5_ri-lr.uniform.control_vector                 |NON MODIFIED
-optimize.zero-gr5_ri-lr.uniform.sim_q                          |NON MODIFIED
+optimize.zero-gr5_ri-lr.uniform.sim_q                          |MODIFIED
 optimize.zero-gr6-kw.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr6-kw.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr6-kw.ann.sim_q                                 |MODIFIED
 optimize.zero-gr6-kw.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr6-kw.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr6-kw.distributed.sim_q                         |MODIFIED
 optimize.zero-gr6-kw.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr6-kw.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr6-kw.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr6-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr6-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr6-kw.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr6-kw.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr6-kw.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr6-kw.uniform.sim_q                             |MODIFIED
 optimize.zero-gr6-lag0.ann.control_vector                      |NON MODIFIED
-optimize.zero-gr6-lag0.ann.sim_q                               |NON MODIFIED
+optimize.zero-gr6-lag0.ann.sim_q                               |MODIFIED
 optimize.zero-gr6-lag0.distributed.control_vector              |NON MODIFIED
-optimize.zero-gr6-lag0.distributed.sim_q                       |NON MODIFIED
+optimize.zero-gr6-lag0.distributed.sim_q                       |MODIFIED
 optimize.zero-gr6-lag0.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-gr6-lag0.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-gr6-lag0.multi-linear.sim_q                      |MODIFIED
 optimize.zero-gr6-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr6-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr6-lag0.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-gr6-lag0.uniform.control_vector                  |NON MODIFIED
-optimize.zero-gr6-lag0.uniform.sim_q                           |NON MODIFIED
+optimize.zero-gr6-lag0.uniform.sim_q                           |MODIFIED
 optimize.zero-gr6-lr.ann.control_vector                        |NON MODIFIED
-optimize.zero-gr6-lr.ann.sim_q                                 |NON MODIFIED
+optimize.zero-gr6-lr.ann.sim_q                                 |MODIFIED
 optimize.zero-gr6-lr.distributed.control_vector                |NON MODIFIED
-optimize.zero-gr6-lr.distributed.sim_q                         |NON MODIFIED
+optimize.zero-gr6-lr.distributed.sim_q                         |MODIFIED
 optimize.zero-gr6-lr.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-gr6-lr.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-gr6-lr.multi-linear.sim_q                        |MODIFIED
 optimize.zero-gr6-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr6-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr6-lr.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-gr6-lr.uniform.control_vector                    |NON MODIFIED
-optimize.zero-gr6-lr.uniform.sim_q                             |NON MODIFIED
+optimize.zero-gr6-lr.uniform.sim_q                             |MODIFIED
 optimize.zero-gr6_mlp-kw.ann.control_vector                    |MODIFIED
 optimize.zero-gr6_mlp-kw.ann.sim_q                             |MODIFIED
 optimize.zero-gr6_mlp-kw.distributed.control_vector            |MODIFIED
@@ -1450,7 +1450,7 @@ optimize.zero-gr6_mlp-lag0.multi-linear.control_vector         |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-linear.sim_q                  |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
-optimize.zero-gr6_mlp-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-gr6_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.uniform.sim_q                       |MODIFIED
 optimize.zero-gr6_mlp-lr.ann.control_vector                    |MODIFIED
 optimize.zero-gr6_mlp-lr.ann.sim_q                             |MODIFIED
@@ -1463,35 +1463,35 @@ optimize.zero-gr6_mlp-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-gr6_mlp-lr.uniform.control_vector                |MODIFIED
 optimize.zero-gr6_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-grc-kw.ann.control_vector                        |NON MODIFIED
-optimize.zero-grc-kw.ann.sim_q                                 |NON MODIFIED
+optimize.zero-grc-kw.ann.sim_q                                 |MODIFIED
 optimize.zero-grc-kw.distributed.control_vector                |NON MODIFIED
-optimize.zero-grc-kw.distributed.sim_q                         |NON MODIFIED
+optimize.zero-grc-kw.distributed.sim_q                         |MODIFIED
 optimize.zero-grc-kw.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-grc-kw.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-grc-kw.multi-linear.sim_q                        |MODIFIED
 optimize.zero-grc-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grc-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grc-kw.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-grc-kw.uniform.control_vector                    |NON MODIFIED
-optimize.zero-grc-kw.uniform.sim_q                             |NON MODIFIED
+optimize.zero-grc-kw.uniform.sim_q                             |MODIFIED
 optimize.zero-grc-lag0.ann.control_vector                      |NON MODIFIED
-optimize.zero-grc-lag0.ann.sim_q                               |NON MODIFIED
+optimize.zero-grc-lag0.ann.sim_q                               |MODIFIED
 optimize.zero-grc-lag0.distributed.control_vector              |NON MODIFIED
-optimize.zero-grc-lag0.distributed.sim_q                       |NON MODIFIED
+optimize.zero-grc-lag0.distributed.sim_q                       |MODIFIED
 optimize.zero-grc-lag0.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-grc-lag0.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-grc-lag0.multi-linear.sim_q                      |MODIFIED
 optimize.zero-grc-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-grc-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-grc-lag0.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-grc-lag0.uniform.control_vector                  |NON MODIFIED
-optimize.zero-grc-lag0.uniform.sim_q                           |NON MODIFIED
+optimize.zero-grc-lag0.uniform.sim_q                           |MODIFIED
 optimize.zero-grc-lr.ann.control_vector                        |NON MODIFIED
-optimize.zero-grc-lr.ann.sim_q                                 |NON MODIFIED
+optimize.zero-grc-lr.ann.sim_q                                 |MODIFIED
 optimize.zero-grc-lr.distributed.control_vector                |NON MODIFIED
-optimize.zero-grc-lr.distributed.sim_q                         |NON MODIFIED
+optimize.zero-grc-lr.distributed.sim_q                         |MODIFIED
 optimize.zero-grc-lr.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-grc-lr.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-grc-lr.multi-linear.sim_q                        |MODIFIED
 optimize.zero-grc-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grc-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grc-lr.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-grc-lr.uniform.control_vector                    |NON MODIFIED
-optimize.zero-grc-lr.uniform.sim_q                             |NON MODIFIED
+optimize.zero-grc-lr.uniform.sim_q                             |MODIFIED
 optimize.zero-grc_mlp-kw.ann.control_vector                    |MODIFIED
 optimize.zero-grc_mlp-kw.ann.sim_q                             |MODIFIED
 optimize.zero-grc_mlp-kw.distributed.control_vector            |MODIFIED
@@ -1523,35 +1523,35 @@ optimize.zero-grc_mlp-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-grc_mlp-lr.uniform.control_vector                |MODIFIED
 optimize.zero-grc_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-grd-kw.ann.control_vector                        |NON MODIFIED
-optimize.zero-grd-kw.ann.sim_q                                 |NON MODIFIED
+optimize.zero-grd-kw.ann.sim_q                                 |MODIFIED
 optimize.zero-grd-kw.distributed.control_vector                |NON MODIFIED
-optimize.zero-grd-kw.distributed.sim_q                         |NON MODIFIED
+optimize.zero-grd-kw.distributed.sim_q                         |MODIFIED
 optimize.zero-grd-kw.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-grd-kw.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-grd-kw.multi-linear.sim_q                        |MODIFIED
 optimize.zero-grd-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grd-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grd-kw.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-grd-kw.uniform.control_vector                    |NON MODIFIED
-optimize.zero-grd-kw.uniform.sim_q                             |NON MODIFIED
+optimize.zero-grd-kw.uniform.sim_q                             |MODIFIED
 optimize.zero-grd-lag0.ann.control_vector                      |NON MODIFIED
-optimize.zero-grd-lag0.ann.sim_q                               |NON MODIFIED
+optimize.zero-grd-lag0.ann.sim_q                               |MODIFIED
 optimize.zero-grd-lag0.distributed.control_vector              |NON MODIFIED
-optimize.zero-grd-lag0.distributed.sim_q                       |NON MODIFIED
+optimize.zero-grd-lag0.distributed.sim_q                       |MODIFIED
 optimize.zero-grd-lag0.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-grd-lag0.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-grd-lag0.multi-linear.sim_q                      |MODIFIED
 optimize.zero-grd-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-grd-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-grd-lag0.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-grd-lag0.uniform.control_vector                  |NON MODIFIED
-optimize.zero-grd-lag0.uniform.sim_q                           |NON MODIFIED
+optimize.zero-grd-lag0.uniform.sim_q                           |MODIFIED
 optimize.zero-grd-lr.ann.control_vector                        |NON MODIFIED
-optimize.zero-grd-lr.ann.sim_q                                 |NON MODIFIED
+optimize.zero-grd-lr.ann.sim_q                                 |MODIFIED
 optimize.zero-grd-lr.distributed.control_vector                |NON MODIFIED
-optimize.zero-grd-lr.distributed.sim_q                         |NON MODIFIED
+optimize.zero-grd-lr.distributed.sim_q                         |MODIFIED
 optimize.zero-grd-lr.multi-linear.control_vector               |NON MODIFIED
-optimize.zero-grd-lr.multi-linear.sim_q                        |NON MODIFIED
+optimize.zero-grd-lr.multi-linear.sim_q                        |MODIFIED
 optimize.zero-grd-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grd-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grd-lr.multi-polynomial.sim_q                    |MODIFIED
 optimize.zero-grd-lr.uniform.control_vector                    |NON MODIFIED
-optimize.zero-grd-lr.uniform.sim_q                             |NON MODIFIED
+optimize.zero-grd-lr.uniform.sim_q                             |MODIFIED
 optimize.zero-grd_mlp-kw.ann.control_vector                    |MODIFIED
 optimize.zero-grd_mlp-kw.ann.sim_q                             |MODIFIED
 optimize.zero-grd_mlp-kw.distributed.control_vector            |MODIFIED
@@ -1560,7 +1560,7 @@ optimize.zero-grd_mlp-kw.multi-linear.control_vector           |MODIFIED
 optimize.zero-grd_mlp-kw.multi-linear.sim_q                    |MODIFIED
 optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |MODIFIED
 optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-grd_mlp-kw.uniform.control_vector                |MODIFIED
+optimize.zero-grd_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-grd_mlp-kw.uniform.sim_q                         |MODIFIED
 optimize.zero-grd_mlp-lag0.ann.control_vector                  |MODIFIED
 optimize.zero-grd_mlp-lag0.ann.sim_q                           |MODIFIED
@@ -1570,7 +1570,7 @@ optimize.zero-grd_mlp-lag0.multi-linear.control_vector         |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-linear.sim_q                  |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
-optimize.zero-grd_mlp-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-grd_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-grd_mlp-lag0.uniform.sim_q                       |MODIFIED
 optimize.zero-grd_mlp-lr.ann.control_vector                    |MODIFIED
 optimize.zero-grd_mlp-lr.ann.sim_q                             |MODIFIED
@@ -1580,38 +1580,38 @@ optimize.zero-grd_mlp-lr.multi-linear.control_vector           |MODIFIED
 optimize.zero-grd_mlp-lr.multi-linear.sim_q                    |MODIFIED
 optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |MODIFIED
 optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-grd_mlp-lr.uniform.control_vector                |MODIFIED
+optimize.zero-grd_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-grd_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-loieau-kw.ann.control_vector                     |NON MODIFIED
-optimize.zero-loieau-kw.ann.sim_q                              |NON MODIFIED
+optimize.zero-loieau-kw.ann.sim_q                              |MODIFIED
 optimize.zero-loieau-kw.distributed.control_vector             |NON MODIFIED
-optimize.zero-loieau-kw.distributed.sim_q                      |NON MODIFIED
+optimize.zero-loieau-kw.distributed.sim_q                      |MODIFIED
 optimize.zero-loieau-kw.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-loieau-kw.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-loieau-kw.multi-linear.sim_q                     |MODIFIED
 optimize.zero-loieau-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-loieau-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-loieau-kw.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-loieau-kw.uniform.control_vector                 |NON MODIFIED
-optimize.zero-loieau-kw.uniform.sim_q                          |NON MODIFIED
+optimize.zero-loieau-kw.uniform.sim_q                          |MODIFIED
 optimize.zero-loieau-lag0.ann.control_vector                   |NON MODIFIED
-optimize.zero-loieau-lag0.ann.sim_q                            |NON MODIFIED
+optimize.zero-loieau-lag0.ann.sim_q                            |MODIFIED
 optimize.zero-loieau-lag0.distributed.control_vector           |NON MODIFIED
-optimize.zero-loieau-lag0.distributed.sim_q                    |NON MODIFIED
+optimize.zero-loieau-lag0.distributed.sim_q                    |MODIFIED
 optimize.zero-loieau-lag0.multi-linear.control_vector          |NON MODIFIED
-optimize.zero-loieau-lag0.multi-linear.sim_q                   |NON MODIFIED
+optimize.zero-loieau-lag0.multi-linear.sim_q                   |MODIFIED
 optimize.zero-loieau-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-loieau-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-loieau-lag0.multi-polynomial.sim_q               |MODIFIED
 optimize.zero-loieau-lag0.uniform.control_vector               |NON MODIFIED
-optimize.zero-loieau-lag0.uniform.sim_q                        |NON MODIFIED
+optimize.zero-loieau-lag0.uniform.sim_q                        |MODIFIED
 optimize.zero-loieau-lr.ann.control_vector                     |NON MODIFIED
-optimize.zero-loieau-lr.ann.sim_q                              |NON MODIFIED
+optimize.zero-loieau-lr.ann.sim_q                              |MODIFIED
 optimize.zero-loieau-lr.distributed.control_vector             |NON MODIFIED
-optimize.zero-loieau-lr.distributed.sim_q                      |NON MODIFIED
+optimize.zero-loieau-lr.distributed.sim_q                      |MODIFIED
 optimize.zero-loieau-lr.multi-linear.control_vector            |NON MODIFIED
-optimize.zero-loieau-lr.multi-linear.sim_q                     |NON MODIFIED
+optimize.zero-loieau-lr.multi-linear.sim_q                     |MODIFIED
 optimize.zero-loieau-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-loieau-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-loieau-lr.multi-polynomial.sim_q                 |MODIFIED
 optimize.zero-loieau-lr.uniform.control_vector                 |NON MODIFIED
-optimize.zero-loieau-lr.uniform.sim_q                          |NON MODIFIED
+optimize.zero-loieau-lr.uniform.sim_q                          |MODIFIED
 optimize.zero-loieau_mlp-kw.ann.control_vector                 |MODIFIED
 optimize.zero-loieau_mlp-kw.ann.sim_q                          |MODIFIED
 optimize.zero-loieau_mlp-kw.distributed.control_vector         |MODIFIED
@@ -1643,35 +1643,35 @@ optimize.zero-loieau_mlp-lr.multi-polynomial.sim_q             |MODIFIED
 optimize.zero-loieau_mlp-lr.uniform.control_vector             |MODIFIED
 optimize.zero-loieau_mlp-lr.uniform.sim_q                      |MODIFIED
 optimize.zero-vic3l-kw.ann.control_vector                      |NON MODIFIED
-optimize.zero-vic3l-kw.ann.sim_q                               |NON MODIFIED
+optimize.zero-vic3l-kw.ann.sim_q                               |MODIFIED
 optimize.zero-vic3l-kw.distributed.control_vector              |NON MODIFIED
-optimize.zero-vic3l-kw.distributed.sim_q                       |NON MODIFIED
+optimize.zero-vic3l-kw.distributed.sim_q                       |MODIFIED
 optimize.zero-vic3l-kw.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-vic3l-kw.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-vic3l-kw.multi-linear.sim_q                      |MODIFIED
 optimize.zero-vic3l-kw.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-vic3l-kw.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-vic3l-kw.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-vic3l-kw.uniform.control_vector                  |NON MODIFIED
-optimize.zero-vic3l-kw.uniform.sim_q                           |NON MODIFIED
+optimize.zero-vic3l-kw.uniform.sim_q                           |MODIFIED
 optimize.zero-vic3l-lag0.ann.control_vector                    |NON MODIFIED
-optimize.zero-vic3l-lag0.ann.sim_q                             |NON MODIFIED
+optimize.zero-vic3l-lag0.ann.sim_q                             |MODIFIED
 optimize.zero-vic3l-lag0.distributed.control_vector            |NON MODIFIED
-optimize.zero-vic3l-lag0.distributed.sim_q                     |NON MODIFIED
+optimize.zero-vic3l-lag0.distributed.sim_q                     |MODIFIED
 optimize.zero-vic3l-lag0.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-vic3l-lag0.multi-linear.sim_q                    |NON MODIFIED
+optimize.zero-vic3l-lag0.multi-linear.sim_q                    |MODIFIED
 optimize.zero-vic3l-lag0.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-vic3l-lag0.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-vic3l-lag0.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-vic3l-lag0.uniform.control_vector                |NON MODIFIED
-optimize.zero-vic3l-lag0.uniform.sim_q                         |NON MODIFIED
+optimize.zero-vic3l-lag0.uniform.sim_q                         |MODIFIED
 optimize.zero-vic3l-lr.ann.control_vector                      |NON MODIFIED
-optimize.zero-vic3l-lr.ann.sim_q                               |NON MODIFIED
+optimize.zero-vic3l-lr.ann.sim_q                               |MODIFIED
 optimize.zero-vic3l-lr.distributed.control_vector              |NON MODIFIED
-optimize.zero-vic3l-lr.distributed.sim_q                       |NON MODIFIED
+optimize.zero-vic3l-lr.distributed.sim_q                       |MODIFIED
 optimize.zero-vic3l-lr.multi-linear.control_vector             |NON MODIFIED
-optimize.zero-vic3l-lr.multi-linear.sim_q                      |NON MODIFIED
+optimize.zero-vic3l-lr.multi-linear.sim_q                      |MODIFIED
 optimize.zero-vic3l-lr.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-vic3l-lr.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-vic3l-lr.multi-polynomial.sim_q                  |MODIFIED
 optimize.zero-vic3l-lr.uniform.control_vector                  |NON MODIFIED
-optimize.zero-vic3l-lr.uniform.sim_q                           |NON MODIFIED
+optimize.zero-vic3l-lr.uniform.sim_q                           |MODIFIED
 precipitation_indices.d1                                       |NON MODIFIED
 precipitation_indices.d2                                       |NON MODIFIED
 precipitation_indices.hg                                       |NON MODIFIED

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,8 +1,8 @@
-commit ad0fed2194c193dc44e5c795d50b0380a45835de
+commit 050d0c49b02080ec564b83e32cde03372b63bff6
 Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
-Date:   Fri Feb 28 18:14:07 2025 +0100
+Date:   Sat Mar 1 18:48:12 2025 +0100
 
-    MAINT/ENH: add SiLU activation function
+    FIX: decrease initialize weight NN to avoid precision issue with exp function
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,8 +1,24 @@
-commit d5f5608a508550a9f0f125b479a1d72305f27c56
-Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
-Date:   Tue Feb 4 10:38:14 2025 +0100
+commit b57dc197539457979dd5adfda6ec2ca4d929c201
+Author: benRenard <84188144+benRenard@users.noreply.github.com>
+Date:   Tue Feb 25 17:31:32 2025 +0100
 
-    Fix workflow, test_constant
+    DOC: Finished Bayesian tutorial (#383)
+    
+    * Finished Bayesian tutorial
+    
+    * Update bayesian_estimation_approach.rst
+    
+    Updated broken link
+    
+    * Change to code-block style doc + review PR
+    
+    * Fix indent tab in output blocks
+    
+    * Minor fix doc
+    
+    ---------
+    
+    Co-authored-by: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -103,50 +119,50 @@ forward_run.zero-gr4-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr4-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr4-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-gr4-lr.sim_q                                  |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.cost                               |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.jobs                               |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.q_domain                           |NON MODIFIED
+forward_run.zero-gr4_mlp-kw.cost                               |MODIFIED
+forward_run.zero-gr4_mlp-kw.jobs                               |MODIFIED
+forward_run.zero-gr4_mlp-kw.q_domain                           |MODIFIED
 forward_run.zero-gr4_mlp-kw.rr_states.hi                       |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_mlp-kw.sim_q                              |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.cost                             |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.jobs                             |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.q_domain                         |NON MODIFIED
+forward_run.zero-gr4_mlp-kw.rr_states.hp                       |MODIFIED
+forward_run.zero-gr4_mlp-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-gr4_mlp-kw.sim_q                              |MODIFIED
+forward_run.zero-gr4_mlp-lag0.cost                             |MODIFIED
+forward_run.zero-gr4_mlp-lag0.jobs                             |MODIFIED
+forward_run.zero-gr4_mlp-lag0.q_domain                         |MODIFIED
 forward_run.zero-gr4_mlp-lag0.rr_states.hi                     |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-gr4_mlp-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.cost                               |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.jobs                               |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.q_domain                           |NON MODIFIED
+forward_run.zero-gr4_mlp-lag0.rr_states.hp                     |MODIFIED
+forward_run.zero-gr4_mlp-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-gr4_mlp-lag0.sim_q                            |MODIFIED
+forward_run.zero-gr4_mlp-lr.cost                               |MODIFIED
+forward_run.zero-gr4_mlp-lr.jobs                               |MODIFIED
+forward_run.zero-gr4_mlp-lr.q_domain                           |MODIFIED
 forward_run.zero-gr4_mlp-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr4_mlp-lr.sim_q                              |NON MODIFIED
-forward_run.zero-gr4_ode-kw.cost                               |MODIFIED
-forward_run.zero-gr4_ode-kw.jobs                               |MODIFIED
-forward_run.zero-gr4_ode-kw.q_domain                           |MODIFIED
+forward_run.zero-gr4_mlp-lr.rr_states.hp                       |MODIFIED
+forward_run.zero-gr4_mlp-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-gr4_mlp-lr.sim_q                              |MODIFIED
+forward_run.zero-gr4_ode-kw.cost                               |NON MODIFIED
+forward_run.zero-gr4_ode-kw.jobs                               |NON MODIFIED
+forward_run.zero-gr4_ode-kw.q_domain                           |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_ode-kw.rr_states.ht                       |MODIFIED
-forward_run.zero-gr4_ode-kw.sim_q                              |MODIFIED
-forward_run.zero-gr4_ode-lag0.cost                             |MODIFIED
-forward_run.zero-gr4_ode-lag0.jobs                             |MODIFIED
-forward_run.zero-gr4_ode-lag0.q_domain                         |MODIFIED
+forward_run.zero-gr4_ode-kw.rr_states.ht                       |NON MODIFIED
+forward_run.zero-gr4_ode-kw.sim_q                              |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.cost                             |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.jobs                             |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.q_domain                         |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hi                     |NON MODIFIED
 forward_run.zero-gr4_ode-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-gr4_ode-lag0.rr_states.ht                     |MODIFIED
-forward_run.zero-gr4_ode-lag0.sim_q                            |MODIFIED
-forward_run.zero-gr4_ode-lr.cost                               |MODIFIED
-forward_run.zero-gr4_ode-lr.jobs                               |MODIFIED
-forward_run.zero-gr4_ode-lr.q_domain                           |MODIFIED
+forward_run.zero-gr4_ode-lag0.rr_states.ht                     |NON MODIFIED
+forward_run.zero-gr4_ode-lag0.sim_q                            |NON MODIFIED
+forward_run.zero-gr4_ode-lr.cost                               |NON MODIFIED
+forward_run.zero-gr4_ode-lr.jobs                               |NON MODIFIED
+forward_run.zero-gr4_ode-lr.q_domain                           |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr4_ode-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr4_ode-lr.rr_states.ht                       |MODIFIED
-forward_run.zero-gr4_ode-lr.sim_q                              |MODIFIED
+forward_run.zero-gr4_ode-lr.rr_states.ht                       |NON MODIFIED
+forward_run.zero-gr4_ode-lr.sim_q                              |NON MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.cost                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.jobs                           |MODIFIED
 forward_run.zero-gr4_ode_mlp-kw.q_domain                       |MODIFIED
@@ -213,28 +229,28 @@ forward_run.zero-gr5-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr5-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr5-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-gr5-lr.sim_q                                  |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.cost                               |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.jobs                               |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.q_domain                           |NON MODIFIED
+forward_run.zero-gr5_mlp-kw.cost                               |MODIFIED
+forward_run.zero-gr5_mlp-kw.jobs                               |MODIFIED
+forward_run.zero-gr5_mlp-kw.q_domain                           |MODIFIED
 forward_run.zero-gr5_mlp-kw.rr_states.hi                       |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr5_mlp-kw.sim_q                              |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.cost                             |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.jobs                             |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.q_domain                         |NON MODIFIED
+forward_run.zero-gr5_mlp-kw.rr_states.hp                       |MODIFIED
+forward_run.zero-gr5_mlp-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-gr5_mlp-kw.sim_q                              |MODIFIED
+forward_run.zero-gr5_mlp-lag0.cost                             |MODIFIED
+forward_run.zero-gr5_mlp-lag0.jobs                             |MODIFIED
+forward_run.zero-gr5_mlp-lag0.q_domain                         |MODIFIED
 forward_run.zero-gr5_mlp-lag0.rr_states.hi                     |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-gr5_mlp-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.cost                               |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.jobs                               |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.q_domain                           |NON MODIFIED
+forward_run.zero-gr5_mlp-lag0.rr_states.hp                     |MODIFIED
+forward_run.zero-gr5_mlp-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-gr5_mlp-lag0.sim_q                            |MODIFIED
+forward_run.zero-gr5_mlp-lr.cost                               |MODIFIED
+forward_run.zero-gr5_mlp-lr.jobs                               |MODIFIED
+forward_run.zero-gr5_mlp-lr.q_domain                           |MODIFIED
 forward_run.zero-gr5_mlp-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr5_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr5_mlp-lr.sim_q                              |NON MODIFIED
+forward_run.zero-gr5_mlp-lr.rr_states.hp                       |MODIFIED
+forward_run.zero-gr5_mlp-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-gr5_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-gr5_ri-kw.cost                                |NON MODIFIED
 forward_run.zero-gr5_ri-kw.jobs                                |NON MODIFIED
 forward_run.zero-gr5_ri-kw.q_domain                            |NON MODIFIED
@@ -282,31 +298,31 @@ forward_run.zero-gr6-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-gr6-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-gr6-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-gr6-lr.sim_q                                  |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.cost                               |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.jobs                               |NON MODIFIED
+forward_run.zero-gr6_mlp-kw.cost                               |MODIFIED
+forward_run.zero-gr6_mlp-kw.jobs                               |MODIFIED
 forward_run.zero-gr6_mlp-kw.q_domain                           |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.he                       |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.sim_q                              |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.cost                             |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.jobs                             |NON MODIFIED
+forward_run.zero-gr6_mlp-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-gr6_mlp-kw.sim_q                              |MODIFIED
+forward_run.zero-gr6_mlp-lag0.cost                             |MODIFIED
+forward_run.zero-gr6_mlp-lag0.jobs                             |MODIFIED
 forward_run.zero-gr6_mlp-lag0.q_domain                         |NON MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.he                     |NON MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.hi                     |NON MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.cost                               |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.jobs                               |NON MODIFIED
+forward_run.zero-gr6_mlp-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-gr6_mlp-lag0.sim_q                            |MODIFIED
+forward_run.zero-gr6_mlp-lr.cost                               |MODIFIED
+forward_run.zero-gr6_mlp-lr.jobs                               |MODIFIED
 forward_run.zero-gr6_mlp-lr.q_domain                           |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.he                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hlr                      |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.sim_q                              |NON MODIFIED
+forward_run.zero-gr6_mlp-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-gr6_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-grc-kw.cost                                   |NON MODIFIED
 forward_run.zero-grc-kw.jobs                                   |NON MODIFIED
 forward_run.zero-grc-kw.q_domain                               |NON MODIFIED
@@ -332,31 +348,31 @@ forward_run.zero-grc-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-grc-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grc-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-grc-lr.sim_q                                  |NON MODIFIED
-forward_run.zero-grc_mlp-kw.cost                               |NON MODIFIED
-forward_run.zero-grc_mlp-kw.jobs                               |NON MODIFIED
-forward_run.zero-grc_mlp-kw.q_domain                           |NON MODIFIED
+forward_run.zero-grc_mlp-kw.cost                               |MODIFIED
+forward_run.zero-grc_mlp-kw.jobs                               |MODIFIED
+forward_run.zero-grc_mlp-kw.q_domain                           |MODIFIED
 forward_run.zero-grc_mlp-kw.rr_states.hi                       |NON MODIFIED
-forward_run.zero-grc_mlp-kw.rr_states.hl                       |NON MODIFIED
-forward_run.zero-grc_mlp-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-grc_mlp-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-grc_mlp-kw.sim_q                              |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.cost                             |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.jobs                             |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.q_domain                         |NON MODIFIED
+forward_run.zero-grc_mlp-kw.rr_states.hl                       |MODIFIED
+forward_run.zero-grc_mlp-kw.rr_states.hp                       |MODIFIED
+forward_run.zero-grc_mlp-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-grc_mlp-kw.sim_q                              |MODIFIED
+forward_run.zero-grc_mlp-lag0.cost                             |MODIFIED
+forward_run.zero-grc_mlp-lag0.jobs                             |MODIFIED
+forward_run.zero-grc_mlp-lag0.q_domain                         |MODIFIED
 forward_run.zero-grc_mlp-lag0.rr_states.hi                     |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.rr_states.hl                     |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-grc_mlp-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-grc_mlp-lr.cost                               |NON MODIFIED
-forward_run.zero-grc_mlp-lr.jobs                               |NON MODIFIED
-forward_run.zero-grc_mlp-lr.q_domain                           |NON MODIFIED
+forward_run.zero-grc_mlp-lag0.rr_states.hl                     |MODIFIED
+forward_run.zero-grc_mlp-lag0.rr_states.hp                     |MODIFIED
+forward_run.zero-grc_mlp-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-grc_mlp-lag0.sim_q                            |MODIFIED
+forward_run.zero-grc_mlp-lr.cost                               |MODIFIED
+forward_run.zero-grc_mlp-lr.jobs                               |MODIFIED
+forward_run.zero-grc_mlp-lr.q_domain                           |MODIFIED
 forward_run.zero-grc_mlp-lr.rr_states.hi                       |NON MODIFIED
-forward_run.zero-grc_mlp-lr.rr_states.hl                       |NON MODIFIED
+forward_run.zero-grc_mlp-lr.rr_states.hl                       |MODIFIED
 forward_run.zero-grc_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-grc_mlp-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-grc_mlp-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-grc_mlp-lr.sim_q                              |NON MODIFIED
+forward_run.zero-grc_mlp-lr.rr_states.hp                       |MODIFIED
+forward_run.zero-grc_mlp-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-grc_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-grd-kw.cost                                   |NON MODIFIED
 forward_run.zero-grd-kw.jobs                                   |NON MODIFIED
 forward_run.zero-grd-kw.q_domain                               |NON MODIFIED
@@ -376,25 +392,25 @@ forward_run.zero-grd-lr.rr_states.hlr                          |NON MODIFIED
 forward_run.zero-grd-lr.rr_states.hp                           |NON MODIFIED
 forward_run.zero-grd-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-grd-lr.sim_q                                  |NON MODIFIED
-forward_run.zero-grd_mlp-kw.cost                               |NON MODIFIED
-forward_run.zero-grd_mlp-kw.jobs                               |NON MODIFIED
-forward_run.zero-grd_mlp-kw.q_domain                           |NON MODIFIED
-forward_run.zero-grd_mlp-kw.rr_states.hp                       |NON MODIFIED
-forward_run.zero-grd_mlp-kw.rr_states.ht                       |NON MODIFIED
-forward_run.zero-grd_mlp-kw.sim_q                              |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.cost                             |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.jobs                             |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.q_domain                         |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.rr_states.hp                     |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.rr_states.ht                     |NON MODIFIED
-forward_run.zero-grd_mlp-lag0.sim_q                            |NON MODIFIED
-forward_run.zero-grd_mlp-lr.cost                               |NON MODIFIED
-forward_run.zero-grd_mlp-lr.jobs                               |NON MODIFIED
-forward_run.zero-grd_mlp-lr.q_domain                           |NON MODIFIED
+forward_run.zero-grd_mlp-kw.cost                               |MODIFIED
+forward_run.zero-grd_mlp-kw.jobs                               |MODIFIED
+forward_run.zero-grd_mlp-kw.q_domain                           |MODIFIED
+forward_run.zero-grd_mlp-kw.rr_states.hp                       |MODIFIED
+forward_run.zero-grd_mlp-kw.rr_states.ht                       |MODIFIED
+forward_run.zero-grd_mlp-kw.sim_q                              |MODIFIED
+forward_run.zero-grd_mlp-lag0.cost                             |MODIFIED
+forward_run.zero-grd_mlp-lag0.jobs                             |MODIFIED
+forward_run.zero-grd_mlp-lag0.q_domain                         |MODIFIED
+forward_run.zero-grd_mlp-lag0.rr_states.hp                     |MODIFIED
+forward_run.zero-grd_mlp-lag0.rr_states.ht                     |MODIFIED
+forward_run.zero-grd_mlp-lag0.sim_q                            |MODIFIED
+forward_run.zero-grd_mlp-lr.cost                               |MODIFIED
+forward_run.zero-grd_mlp-lr.jobs                               |MODIFIED
+forward_run.zero-grd_mlp-lr.q_domain                           |MODIFIED
 forward_run.zero-grd_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-grd_mlp-lr.rr_states.hp                       |NON MODIFIED
-forward_run.zero-grd_mlp-lr.rr_states.ht                       |NON MODIFIED
-forward_run.zero-grd_mlp-lr.sim_q                              |NON MODIFIED
+forward_run.zero-grd_mlp-lr.rr_states.hp                       |MODIFIED
+forward_run.zero-grd_mlp-lr.rr_states.ht                       |MODIFIED
+forward_run.zero-grd_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-loieau-kw.cost                                |NON MODIFIED
 forward_run.zero-loieau-kw.jobs                                |NON MODIFIED
 forward_run.zero-loieau-kw.q_domain                            |NON MODIFIED
@@ -414,25 +430,25 @@ forward_run.zero-loieau-lr.rr_states.ha                        |NON MODIFIED
 forward_run.zero-loieau-lr.rr_states.hc                        |NON MODIFIED
 forward_run.zero-loieau-lr.rr_states.hlr                       |NON MODIFIED
 forward_run.zero-loieau-lr.sim_q                               |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.cost                            |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.jobs                            |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.q_domain                        |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.rr_states.ha                    |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.rr_states.hc                    |NON MODIFIED
-forward_run.zero-loieau_mlp-kw.sim_q                           |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.cost                          |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.jobs                          |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.q_domain                      |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.rr_states.ha                  |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.rr_states.hc                  |NON MODIFIED
-forward_run.zero-loieau_mlp-lag0.sim_q                         |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.cost                            |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.jobs                            |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.q_domain                        |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.rr_states.ha                    |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.rr_states.hc                    |NON MODIFIED
+forward_run.zero-loieau_mlp-kw.cost                            |MODIFIED
+forward_run.zero-loieau_mlp-kw.jobs                            |MODIFIED
+forward_run.zero-loieau_mlp-kw.q_domain                        |MODIFIED
+forward_run.zero-loieau_mlp-kw.rr_states.ha                    |MODIFIED
+forward_run.zero-loieau_mlp-kw.rr_states.hc                    |MODIFIED
+forward_run.zero-loieau_mlp-kw.sim_q                           |MODIFIED
+forward_run.zero-loieau_mlp-lag0.cost                          |MODIFIED
+forward_run.zero-loieau_mlp-lag0.jobs                          |MODIFIED
+forward_run.zero-loieau_mlp-lag0.q_domain                      |MODIFIED
+forward_run.zero-loieau_mlp-lag0.rr_states.ha                  |MODIFIED
+forward_run.zero-loieau_mlp-lag0.rr_states.hc                  |MODIFIED
+forward_run.zero-loieau_mlp-lag0.sim_q                         |MODIFIED
+forward_run.zero-loieau_mlp-lr.cost                            |MODIFIED
+forward_run.zero-loieau_mlp-lr.jobs                            |MODIFIED
+forward_run.zero-loieau_mlp-lr.q_domain                        |MODIFIED
+forward_run.zero-loieau_mlp-lr.rr_states.ha                    |MODIFIED
+forward_run.zero-loieau_mlp-lr.rr_states.hc                    |MODIFIED
 forward_run.zero-loieau_mlp-lr.rr_states.hlr                   |NON MODIFIED
-forward_run.zero-loieau_mlp-lr.sim_q                           |NON MODIFIED
+forward_run.zero-loieau_mlp-lr.sim_q                           |MODIFIED
 forward_run.zero-vic3l-kw.cost                                 |NON MODIFIED
 forward_run.zero-vic3l-kw.jobs                                 |NON MODIFIED
 forward_run.zero-vic3l-kw.q_domain                             |NON MODIFIED
@@ -543,33 +559,33 @@ internal_fluxes.zero-gr4_mlp-lr.qup                            |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.en                             |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.lexc                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-kw.pn                             |NON MODIFIED
-internal_fluxes.zero-gr4_ode-kw.qim1j                          |MODIFIED
-internal_fluxes.zero-gr4_ode-kw.qt                             |MODIFIED
+internal_fluxes.zero-gr4_ode-kw.qim1j                          |NON MODIFIED
+internal_fluxes.zero-gr4_ode-kw.qt                             |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.en                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.lexc                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lag0.pn                           |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lag0.qt                           |MODIFIED
-internal_fluxes.zero-gr4_ode-lag0.qup                          |MODIFIED
+internal_fluxes.zero-gr4_ode-lag0.qt                           |NON MODIFIED
+internal_fluxes.zero-gr4_ode-lag0.qup                          |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lr.en                             |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lr.lexc                           |NON MODIFIED
 internal_fluxes.zero-gr4_ode-lr.pn                             |NON MODIFIED
-internal_fluxes.zero-gr4_ode-lr.qt                             |MODIFIED
-internal_fluxes.zero-gr4_ode-lr.qup                            |MODIFIED
+internal_fluxes.zero-gr4_ode-lr.qt                             |NON MODIFIED
+internal_fluxes.zero-gr4_ode-lr.qup                            |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.en                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.lexc                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-kw.pn                         |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-kw.qim1j                      |MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-kw.qt                         |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-kw.qim1j                      |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-kw.qt                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.en                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.lexc                     |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lag0.pn                       |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lag0.qt                       |MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lag0.qup                      |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lag0.qt                       |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lag0.qup                      |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.en                         |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.lexc                       |NON MODIFIED
 internal_fluxes.zero-gr4_ode_mlp-lr.pn                         |NON MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lr.qt                         |MODIFIED
-internal_fluxes.zero-gr4_ode_mlp-lr.qup                        |MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lr.qt                         |NON MODIFIED
+internal_fluxes.zero-gr4_ode_mlp-lr.qup                        |NON MODIFIED
 internal_fluxes.zero-gr4_ri-kw.en                              |NON MODIFIED
 internal_fluxes.zero-gr4_ri-kw.es                              |NON MODIFIED
 internal_fluxes.zero-gr4_ri-kw.lexc                            |NON MODIFIED
@@ -1192,66 +1208,66 @@ optimize.zero-gr4-lr.multi-polynomial.control_vector           |NON MODIFIED
 optimize.zero-gr4-lr.multi-polynomial.sim_q                    |NON MODIFIED
 optimize.zero-gr4-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr4-lr.uniform.sim_q                             |NON MODIFIED
-optimize.zero-gr4_mlp-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_mlp-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr4_mlp-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_mlp-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr4_mlp-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_mlp-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-gr4_mlp-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr4_mlp-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr4_mlp-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr4_mlp-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr4_mlp-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr4_mlp-lr.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr4_ode-kw.ann.control_vector                    |MODIFIED
-optimize.zero-gr4_ode-kw.ann.sim_q                             |MODIFIED
-optimize.zero-gr4_ode-kw.distributed.control_vector            |MODIFIED
-optimize.zero-gr4_ode-kw.distributed.sim_q                     |MODIFIED
-optimize.zero-gr4_ode-kw.multi-linear.control_vector           |MODIFIED
-optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-gr4_ode-kw.uniform.control_vector                |MODIFIED
-optimize.zero-gr4_ode-kw.uniform.sim_q                         |MODIFIED
-optimize.zero-gr4_ode-lag0.ann.control_vector                  |MODIFIED
-optimize.zero-gr4_ode-lag0.ann.sim_q                           |MODIFIED
-optimize.zero-gr4_ode-lag0.distributed.control_vector          |MODIFIED
-optimize.zero-gr4_ode-lag0.distributed.sim_q                   |MODIFIED
-optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |MODIFIED
-optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |MODIFIED
-optimize.zero-gr4_ode-lag0.uniform.control_vector              |MODIFIED
-optimize.zero-gr4_ode-lag0.uniform.sim_q                       |MODIFIED
-optimize.zero-gr4_ode-lr.ann.control_vector                    |MODIFIED
-optimize.zero-gr4_ode-lr.ann.sim_q                             |MODIFIED
-optimize.zero-gr4_ode-lr.distributed.control_vector            |MODIFIED
-optimize.zero-gr4_ode-lr.distributed.sim_q                     |MODIFIED
-optimize.zero-gr4_ode-lr.multi-linear.control_vector           |MODIFIED
-optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-gr4_ode-lr.uniform.control_vector                |MODIFIED
-optimize.zero-gr4_ode-lr.uniform.sim_q                         |MODIFIED
+optimize.zero-gr4_mlp-kw.ann.control_vector                    |MODIFIED
+optimize.zero-gr4_mlp-kw.ann.sim_q                             |MODIFIED
+optimize.zero-gr4_mlp-kw.distributed.control_vector            |MODIFIED
+optimize.zero-gr4_mlp-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-gr4_mlp-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr4_mlp-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr4_mlp-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr4_mlp-kw.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr4_mlp-kw.uniform.control_vector                |MODIFIED
+optimize.zero-gr4_mlp-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-gr4_mlp-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-gr4_mlp-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-gr4_mlp-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-gr4_mlp-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-gr4_mlp-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-gr4_mlp-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-gr4_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-gr4_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
+optimize.zero-gr4_mlp-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-gr4_mlp-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-gr4_mlp-lr.ann.control_vector                    |MODIFIED
+optimize.zero-gr4_mlp-lr.ann.sim_q                             |MODIFIED
+optimize.zero-gr4_mlp-lr.distributed.control_vector            |MODIFIED
+optimize.zero-gr4_mlp-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-gr4_mlp-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr4_mlp-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr4_mlp-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr4_mlp-lr.uniform.control_vector                |MODIFIED
+optimize.zero-gr4_mlp-lr.uniform.sim_q                         |MODIFIED
+optimize.zero-gr4_ode-kw.ann.control_vector                    |NON MODIFIED
+optimize.zero-gr4_ode-kw.ann.sim_q                             |NON MODIFIED
+optimize.zero-gr4_ode-kw.distributed.control_vector            |NON MODIFIED
+optimize.zero-gr4_ode-kw.distributed.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-linear.control_vector           |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-kw.uniform.control_vector                |NON MODIFIED
+optimize.zero-gr4_ode-kw.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr4_ode-lag0.ann.control_vector                  |NON MODIFIED
+optimize.zero-gr4_ode-lag0.ann.sim_q                           |NON MODIFIED
+optimize.zero-gr4_ode-lag0.distributed.control_vector          |NON MODIFIED
+optimize.zero-gr4_ode-lag0.distributed.sim_q                   |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr4_ode-lag0.uniform.control_vector              |NON MODIFIED
+optimize.zero-gr4_ode-lag0.uniform.sim_q                       |NON MODIFIED
+optimize.zero-gr4_ode-lr.ann.control_vector                    |NON MODIFIED
+optimize.zero-gr4_ode-lr.ann.sim_q                             |NON MODIFIED
+optimize.zero-gr4_ode-lr.distributed.control_vector            |NON MODIFIED
+optimize.zero-gr4_ode-lr.distributed.sim_q                     |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-linear.control_vector           |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-lr.uniform.control_vector                |NON MODIFIED
+optimize.zero-gr4_ode-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.sim_q                         |MODIFIED
 optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |MODIFIED
@@ -1342,36 +1358,36 @@ optimize.zero-gr5-lr.multi-polynomial.control_vector           |NON MODIFIED
 optimize.zero-gr5-lr.multi-polynomial.sim_q                    |NON MODIFIED
 optimize.zero-gr5-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr5-lr.uniform.sim_q                             |NON MODIFIED
-optimize.zero-gr5_mlp-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr5_mlp-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr5_mlp-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr5_mlp-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr5_mlp-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr5_mlp-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-gr5_mlp-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr5_mlp-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr5_mlp-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr5_mlp-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr5_mlp-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr5_mlp-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr5_mlp-kw.ann.control_vector                    |MODIFIED
+optimize.zero-gr5_mlp-kw.ann.sim_q                             |MODIFIED
+optimize.zero-gr5_mlp-kw.distributed.control_vector            |MODIFIED
+optimize.zero-gr5_mlp-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-gr5_mlp-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr5_mlp-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr5_mlp-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr5_mlp-kw.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr5_mlp-kw.uniform.control_vector                |MODIFIED
+optimize.zero-gr5_mlp-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-gr5_mlp-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-gr5_mlp-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-gr5_mlp-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-gr5_mlp-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-gr5_mlp-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-gr5_mlp-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-gr5_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-gr5_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
+optimize.zero-gr5_mlp-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-gr5_mlp-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-gr5_mlp-lr.ann.control_vector                    |MODIFIED
+optimize.zero-gr5_mlp-lr.ann.sim_q                             |MODIFIED
+optimize.zero-gr5_mlp-lr.distributed.control_vector            |MODIFIED
+optimize.zero-gr5_mlp-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-gr5_mlp-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr5_mlp-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr5_mlp-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr5_mlp-lr.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr5_mlp-lr.uniform.control_vector                |MODIFIED
+optimize.zero-gr5_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-gr5_ri-kw.ann.control_vector                     |NON MODIFIED
 optimize.zero-gr5_ri-kw.ann.sim_q                              |NON MODIFIED
 optimize.zero-gr5_ri-kw.distributed.control_vector             |NON MODIFIED
@@ -1432,36 +1448,36 @@ optimize.zero-gr6-lr.multi-polynomial.control_vector           |NON MODIFIED
 optimize.zero-gr6-lr.multi-polynomial.sim_q                    |NON MODIFIED
 optimize.zero-gr6-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr6-lr.uniform.sim_q                             |NON MODIFIED
-optimize.zero-gr6_mlp-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr6_mlp-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr6_mlp-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr6_mlp-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr6_mlp-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr6_mlp-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr6_mlp-kw.ann.control_vector                    |MODIFIED
+optimize.zero-gr6_mlp-kw.ann.sim_q                             |MODIFIED
+optimize.zero-gr6_mlp-kw.distributed.control_vector            |MODIFIED
+optimize.zero-gr6_mlp-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-gr6_mlp-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr6_mlp-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr6_mlp-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr6_mlp-kw.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr6_mlp-kw.uniform.control_vector                |MODIFIED
+optimize.zero-gr6_mlp-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-gr6_mlp-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-gr6_mlp-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-gr6_mlp-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-gr6_mlp-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-gr6_mlp-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-gr6_mlp-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
 optimize.zero-gr6_mlp-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-gr6_mlp-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-gr6_mlp-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-gr6_mlp-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-gr6_mlp-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-gr6_mlp-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-gr6_mlp-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-gr6_mlp-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-gr6_mlp-lr.ann.control_vector                    |MODIFIED
+optimize.zero-gr6_mlp-lr.ann.sim_q                             |MODIFIED
+optimize.zero-gr6_mlp-lr.distributed.control_vector            |MODIFIED
+optimize.zero-gr6_mlp-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-gr6_mlp-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-gr6_mlp-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-gr6_mlp-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-gr6_mlp-lr.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-gr6_mlp-lr.uniform.control_vector                |MODIFIED
+optimize.zero-gr6_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-grc-kw.ann.control_vector                        |NON MODIFIED
 optimize.zero-grc-kw.ann.sim_q                                 |NON MODIFIED
 optimize.zero-grc-kw.distributed.control_vector                |NON MODIFIED
@@ -1492,36 +1508,36 @@ optimize.zero-grc-lr.multi-polynomial.control_vector           |NON MODIFIED
 optimize.zero-grc-lr.multi-polynomial.sim_q                    |NON MODIFIED
 optimize.zero-grc-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grc-lr.uniform.sim_q                             |NON MODIFIED
-optimize.zero-grc_mlp-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-grc_mlp-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-grc_mlp-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-grc_mlp-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-grc_mlp-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-grc_mlp-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-grc_mlp-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-grc_mlp-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-grc_mlp-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-grc_mlp-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
-optimize.zero-grc_mlp-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-grc_mlp-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-grc_mlp-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-grc_mlp-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-grc_mlp-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-grc_mlp-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
-optimize.zero-grc_mlp-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-grc_mlp-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-grc_mlp-kw.ann.control_vector                    |MODIFIED
+optimize.zero-grc_mlp-kw.ann.sim_q                             |MODIFIED
+optimize.zero-grc_mlp-kw.distributed.control_vector            |MODIFIED
+optimize.zero-grc_mlp-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-grc_mlp-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-grc_mlp-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-grc_mlp-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-grc_mlp-kw.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-grc_mlp-kw.uniform.control_vector                |MODIFIED
+optimize.zero-grc_mlp-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-grc_mlp-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-grc_mlp-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-grc_mlp-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-grc_mlp-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-grc_mlp-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-grc_mlp-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-grc_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-grc_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
+optimize.zero-grc_mlp-lag0.uniform.control_vector              |MODIFIED
+optimize.zero-grc_mlp-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-grc_mlp-lr.ann.control_vector                    |MODIFIED
+optimize.zero-grc_mlp-lr.ann.sim_q                             |MODIFIED
+optimize.zero-grc_mlp-lr.distributed.control_vector            |MODIFIED
+optimize.zero-grc_mlp-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-grc_mlp-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-grc_mlp-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-grc_mlp-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-grc_mlp-lr.multi-polynomial.sim_q                |MODIFIED
+optimize.zero-grc_mlp-lr.uniform.control_vector                |MODIFIED
+optimize.zero-grc_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-grd-kw.ann.control_vector                        |NON MODIFIED
 optimize.zero-grd-kw.ann.sim_q                                 |NON MODIFIED
 optimize.zero-grd-kw.distributed.control_vector                |NON MODIFIED
@@ -1552,36 +1568,36 @@ optimize.zero-grd-lr.multi-polynomial.control_vector           |NON MODIFIED
 optimize.zero-grd-lr.multi-polynomial.sim_q                    |NON MODIFIED
 optimize.zero-grd-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grd-lr.uniform.sim_q                             |NON MODIFIED
-optimize.zero-grd_mlp-kw.ann.control_vector                    |NON MODIFIED
-optimize.zero-grd_mlp-kw.ann.sim_q                             |NON MODIFIED
-optimize.zero-grd_mlp-kw.distributed.control_vector            |NON MODIFIED
-optimize.zero-grd_mlp-kw.distributed.sim_q                     |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grd_mlp-kw.ann.control_vector                    |MODIFIED
+optimize.zero-grd_mlp-kw.ann.sim_q                             |MODIFIED
+optimize.zero-grd_mlp-kw.distributed.control_vector            |MODIFIED
+optimize.zero-grd_mlp-kw.distributed.sim_q                     |MODIFIED
+optimize.zero-grd_mlp-kw.multi-linear.control_vector           |MODIFIED
+optimize.zero-grd_mlp-kw.multi-linear.sim_q                    |MODIFIED
+optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-grd_mlp-kw.uniform.control_vector                |NON MODIFIED
-optimize.zero-grd_mlp-kw.uniform.sim_q                         |NON MODIFIED
-optimize.zero-grd_mlp-lag0.ann.control_vector                  |NON MODIFIED
-optimize.zero-grd_mlp-lag0.ann.sim_q                           |NON MODIFIED
-optimize.zero-grd_mlp-lag0.distributed.control_vector          |NON MODIFIED
-optimize.zero-grd_mlp-lag0.distributed.sim_q                   |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-grd_mlp-kw.uniform.sim_q                         |MODIFIED
+optimize.zero-grd_mlp-lag0.ann.control_vector                  |MODIFIED
+optimize.zero-grd_mlp-lag0.ann.sim_q                           |MODIFIED
+optimize.zero-grd_mlp-lag0.distributed.control_vector          |MODIFIED
+optimize.zero-grd_mlp-lag0.distributed.sim_q                   |MODIFIED
+optimize.zero-grd_mlp-lag0.multi-linear.control_vector         |MODIFIED
+optimize.zero-grd_mlp-lag0.multi-linear.sim_q                  |MODIFIED
+optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
+optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
 optimize.zero-grd_mlp-lag0.uniform.control_vector              |NON MODIFIED
-optimize.zero-grd_mlp-lag0.uniform.sim_q                       |NON MODIFIED
-optimize.zero-grd_mlp-lr.ann.control_vector                    |NON MODIFIED
-optimize.zero-grd_mlp-lr.ann.sim_q                             |NON MODIFIED
-optimize.zero-grd_mlp-lr.distributed.control_vector            |NON MODIFIED
-optimize.zero-grd_mlp-lr.distributed.sim_q                     |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-linear.control_vector           |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grd_mlp-lag0.uniform.sim_q                       |MODIFIED
+optimize.zero-grd_mlp-lr.ann.control_vector                    |MODIFIED
+optimize.zero-grd_mlp-lr.ann.sim_q                             |MODIFIED
+optimize.zero-grd_mlp-lr.distributed.control_vector            |MODIFIED
+optimize.zero-grd_mlp-lr.distributed.sim_q                     |MODIFIED
+optimize.zero-grd_mlp-lr.multi-linear.control_vector           |MODIFIED
+optimize.zero-grd_mlp-lr.multi-linear.sim_q                    |MODIFIED
+optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |MODIFIED
+optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |MODIFIED
 optimize.zero-grd_mlp-lr.uniform.control_vector                |NON MODIFIED
-optimize.zero-grd_mlp-lr.uniform.sim_q                         |NON MODIFIED
+optimize.zero-grd_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-loieau-kw.ann.control_vector                     |NON MODIFIED
 optimize.zero-loieau-kw.ann.sim_q                              |NON MODIFIED
 optimize.zero-loieau-kw.distributed.control_vector             |NON MODIFIED
@@ -1612,36 +1628,36 @@ optimize.zero-loieau-lr.multi-polynomial.control_vector        |NON MODIFIED
 optimize.zero-loieau-lr.multi-polynomial.sim_q                 |NON MODIFIED
 optimize.zero-loieau-lr.uniform.control_vector                 |NON MODIFIED
 optimize.zero-loieau-lr.uniform.sim_q                          |NON MODIFIED
-optimize.zero-loieau_mlp-kw.ann.control_vector                 |NON MODIFIED
-optimize.zero-loieau_mlp-kw.ann.sim_q                          |NON MODIFIED
-optimize.zero-loieau_mlp-kw.distributed.control_vector         |NON MODIFIED
-optimize.zero-loieau_mlp-kw.distributed.sim_q                  |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-linear.control_vector        |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-linear.sim_q                 |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-polynomial.control_vector    |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-polynomial.sim_q             |NON MODIFIED
-optimize.zero-loieau_mlp-kw.uniform.control_vector             |NON MODIFIED
-optimize.zero-loieau_mlp-kw.uniform.sim_q                      |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.ann.control_vector               |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.ann.sim_q                        |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.distributed.control_vector       |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.distributed.sim_q                |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-linear.control_vector      |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-linear.sim_q               |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-polynomial.control_vector  |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-polynomial.sim_q           |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.uniform.control_vector           |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.uniform.sim_q                    |NON MODIFIED
-optimize.zero-loieau_mlp-lr.ann.control_vector                 |NON MODIFIED
-optimize.zero-loieau_mlp-lr.ann.sim_q                          |NON MODIFIED
-optimize.zero-loieau_mlp-lr.distributed.control_vector         |NON MODIFIED
-optimize.zero-loieau_mlp-lr.distributed.sim_q                  |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-linear.control_vector        |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-linear.sim_q                 |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-polynomial.control_vector    |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-polynomial.sim_q             |NON MODIFIED
-optimize.zero-loieau_mlp-lr.uniform.control_vector             |NON MODIFIED
-optimize.zero-loieau_mlp-lr.uniform.sim_q                      |NON MODIFIED
+optimize.zero-loieau_mlp-kw.ann.control_vector                 |MODIFIED
+optimize.zero-loieau_mlp-kw.ann.sim_q                          |MODIFIED
+optimize.zero-loieau_mlp-kw.distributed.control_vector         |MODIFIED
+optimize.zero-loieau_mlp-kw.distributed.sim_q                  |MODIFIED
+optimize.zero-loieau_mlp-kw.multi-linear.control_vector        |MODIFIED
+optimize.zero-loieau_mlp-kw.multi-linear.sim_q                 |MODIFIED
+optimize.zero-loieau_mlp-kw.multi-polynomial.control_vector    |MODIFIED
+optimize.zero-loieau_mlp-kw.multi-polynomial.sim_q             |MODIFIED
+optimize.zero-loieau_mlp-kw.uniform.control_vector             |MODIFIED
+optimize.zero-loieau_mlp-kw.uniform.sim_q                      |MODIFIED
+optimize.zero-loieau_mlp-lag0.ann.control_vector               |MODIFIED
+optimize.zero-loieau_mlp-lag0.ann.sim_q                        |MODIFIED
+optimize.zero-loieau_mlp-lag0.distributed.control_vector       |MODIFIED
+optimize.zero-loieau_mlp-lag0.distributed.sim_q                |MODIFIED
+optimize.zero-loieau_mlp-lag0.multi-linear.control_vector      |MODIFIED
+optimize.zero-loieau_mlp-lag0.multi-linear.sim_q               |MODIFIED
+optimize.zero-loieau_mlp-lag0.multi-polynomial.control_vector  |MODIFIED
+optimize.zero-loieau_mlp-lag0.multi-polynomial.sim_q           |MODIFIED
+optimize.zero-loieau_mlp-lag0.uniform.control_vector           |MODIFIED
+optimize.zero-loieau_mlp-lag0.uniform.sim_q                    |MODIFIED
+optimize.zero-loieau_mlp-lr.ann.control_vector                 |MODIFIED
+optimize.zero-loieau_mlp-lr.ann.sim_q                          |MODIFIED
+optimize.zero-loieau_mlp-lr.distributed.control_vector         |MODIFIED
+optimize.zero-loieau_mlp-lr.distributed.sim_q                  |MODIFIED
+optimize.zero-loieau_mlp-lr.multi-linear.control_vector        |MODIFIED
+optimize.zero-loieau_mlp-lr.multi-linear.sim_q                 |MODIFIED
+optimize.zero-loieau_mlp-lr.multi-polynomial.control_vector    |MODIFIED
+optimize.zero-loieau_mlp-lr.multi-polynomial.sim_q             |MODIFIED
+optimize.zero-loieau_mlp-lr.uniform.control_vector             |MODIFIED
+optimize.zero-loieau_mlp-lr.uniform.sim_q                      |MODIFIED
 optimize.zero-vic3l-kw.ann.control_vector                      |NON MODIFIED
 optimize.zero-vic3l-kw.ann.sim_q                               |NON MODIFIED
 optimize.zero-vic3l-kw.distributed.control_vector              |NON MODIFIED

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,24 +1,8 @@
-commit b57dc197539457979dd5adfda6ec2ca4d929c201
-Author: benRenard <84188144+benRenard@users.noreply.github.com>
-Date:   Tue Feb 25 17:31:32 2025 +0100
+commit ad0fed2194c193dc44e5c795d50b0380a45835de
+Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
+Date:   Fri Feb 28 18:14:07 2025 +0100
 
-    DOC: Finished Bayesian tutorial (#383)
-    
-    * Finished Bayesian tutorial
-    
-    * Update bayesian_estimation_approach.rst
-    
-    Updated broken link
-    
-    * Change to code-block style doc + review PR
-    
-    * Fix indent tab in output blocks
-    
-    * Minor fix doc
-    
-    ---------
-    
-    Co-authored-by: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
+    MAINT/ENH: add SiLU activation function
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -300,27 +284,27 @@ forward_run.zero-gr6-lr.rr_states.ht                           |NON MODIFIED
 forward_run.zero-gr6-lr.sim_q                                  |NON MODIFIED
 forward_run.zero-gr6_mlp-kw.cost                               |MODIFIED
 forward_run.zero-gr6_mlp-kw.jobs                               |MODIFIED
-forward_run.zero-gr6_mlp-kw.q_domain                           |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.rr_states.he                       |NON MODIFIED
+forward_run.zero-gr6_mlp-kw.q_domain                           |MODIFIED
+forward_run.zero-gr6_mlp-kw.rr_states.he                       |MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.hi                       |NON MODIFIED
-forward_run.zero-gr6_mlp-kw.rr_states.hp                       |NON MODIFIED
+forward_run.zero-gr6_mlp-kw.rr_states.hp                       |MODIFIED
 forward_run.zero-gr6_mlp-kw.rr_states.ht                       |MODIFIED
 forward_run.zero-gr6_mlp-kw.sim_q                              |MODIFIED
 forward_run.zero-gr6_mlp-lag0.cost                             |MODIFIED
 forward_run.zero-gr6_mlp-lag0.jobs                             |MODIFIED
-forward_run.zero-gr6_mlp-lag0.q_domain                         |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.rr_states.he                     |NON MODIFIED
+forward_run.zero-gr6_mlp-lag0.q_domain                         |MODIFIED
+forward_run.zero-gr6_mlp-lag0.rr_states.he                     |MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.hi                     |NON MODIFIED
-forward_run.zero-gr6_mlp-lag0.rr_states.hp                     |NON MODIFIED
+forward_run.zero-gr6_mlp-lag0.rr_states.hp                     |MODIFIED
 forward_run.zero-gr6_mlp-lag0.rr_states.ht                     |MODIFIED
 forward_run.zero-gr6_mlp-lag0.sim_q                            |MODIFIED
 forward_run.zero-gr6_mlp-lr.cost                               |MODIFIED
 forward_run.zero-gr6_mlp-lr.jobs                               |MODIFIED
-forward_run.zero-gr6_mlp-lr.q_domain                           |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.rr_states.he                       |NON MODIFIED
+forward_run.zero-gr6_mlp-lr.q_domain                           |MODIFIED
+forward_run.zero-gr6_mlp-lr.rr_states.he                       |MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hi                       |NON MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.hlr                      |NON MODIFIED
-forward_run.zero-gr6_mlp-lr.rr_states.hp                       |NON MODIFIED
+forward_run.zero-gr6_mlp-lr.rr_states.hp                       |MODIFIED
 forward_run.zero-gr6_mlp-lr.rr_states.ht                       |MODIFIED
 forward_run.zero-gr6_mlp-lr.sim_q                              |MODIFIED
 forward_run.zero-grc-kw.cost                                   |NON MODIFIED
@@ -1466,7 +1450,7 @@ optimize.zero-gr6_mlp-lag0.multi-linear.control_vector         |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-linear.sim_q                  |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
-optimize.zero-gr6_mlp-lag0.uniform.control_vector              |NON MODIFIED
+optimize.zero-gr6_mlp-lag0.uniform.control_vector              |MODIFIED
 optimize.zero-gr6_mlp-lag0.uniform.sim_q                       |MODIFIED
 optimize.zero-gr6_mlp-lr.ann.control_vector                    |MODIFIED
 optimize.zero-gr6_mlp-lr.ann.sim_q                             |MODIFIED
@@ -1576,7 +1560,7 @@ optimize.zero-grd_mlp-kw.multi-linear.control_vector           |MODIFIED
 optimize.zero-grd_mlp-kw.multi-linear.sim_q                    |MODIFIED
 optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |MODIFIED
 optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-grd_mlp-kw.uniform.control_vector                |NON MODIFIED
+optimize.zero-grd_mlp-kw.uniform.control_vector                |MODIFIED
 optimize.zero-grd_mlp-kw.uniform.sim_q                         |MODIFIED
 optimize.zero-grd_mlp-lag0.ann.control_vector                  |MODIFIED
 optimize.zero-grd_mlp-lag0.ann.sim_q                           |MODIFIED
@@ -1586,7 +1570,7 @@ optimize.zero-grd_mlp-lag0.multi-linear.control_vector         |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-linear.sim_q                  |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |MODIFIED
 optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |MODIFIED
-optimize.zero-grd_mlp-lag0.uniform.control_vector              |NON MODIFIED
+optimize.zero-grd_mlp-lag0.uniform.control_vector              |MODIFIED
 optimize.zero-grd_mlp-lag0.uniform.sim_q                       |MODIFIED
 optimize.zero-grd_mlp-lr.ann.control_vector                    |MODIFIED
 optimize.zero-grd_mlp-lr.ann.sim_q                             |MODIFIED
@@ -1596,7 +1580,7 @@ optimize.zero-grd_mlp-lr.multi-linear.control_vector           |MODIFIED
 optimize.zero-grd_mlp-lr.multi-linear.sim_q                    |MODIFIED
 optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |MODIFIED
 optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |MODIFIED
-optimize.zero-grd_mlp-lr.uniform.control_vector                |NON MODIFIED
+optimize.zero-grd_mlp-lr.uniform.control_vector                |MODIFIED
 optimize.zero-grd_mlp-lr.uniform.sim_q                         |MODIFIED
 optimize.zero-loieau-kw.ann.control_vector                     |NON MODIFIED
 optimize.zero-loieau-kw.ann.sim_q                              |NON MODIFIED


### PR DESCRIPTION
NaN gradients are produced when using a neural ODE solver on large datasets. The issue appears to stem from the differentiability of the process-parameterization NN (which must be twice differentiable mathematically) and the structure of the Jacobian matrix in the Fortran code.

This PR resolves the issue, tested on ArcMed and Aude catchments, with the following changes:
- The SiLU activation function (which is twice differentiable) replaces ReLU (non-differentiable at 0) in the process-parameterization NN. Since the initial conditions make the output layers very close to zero, using ReLU leads to issues with differentiability at this point;
- SiLU is also added to the list of activation functions available in the Net subpackage;
- Two vectors are used instead of a matrix for computing the Jacobian in the backward routine of the process-parameterization NN.

Baseline:
- The tests for simulated discharges use higher tolerance due to machine precision problems.
- Thus, we check only high flows (that exceed the 0.95-quantile).