### PR TITLE
MAINT: change the name _bkg in control info to _raw

### DIFF
--- a/doc/source/user_guide/in_depth/bayesian_estimation.rst
+++ b/doc/source/user_guide/in_depth/bayesian_estimation.rst
@@ -96,7 +96,7 @@ The function `smash.optimize_control_info` allows retrieving information on the 
 	... 	model_0, optimize_options=optimize_options_0
 	... )
 	>>> control_names = control_info["name"].tolist()  # names of control values
-	>>> control_values = control_info["x_bkg"].tolist()  # background values before transformation
+	>>> control_values = control_info["x_raw"].tolist()  # raw values before transformation
 	>>> dict(zip(control_names, control_values))
 
 .. code-block:: output
@@ -161,7 +161,7 @@ Then, access to the control values:
 	>>> print(dict(
 	... 	zip(
 	... 		control_info_bayes["name"].tolist(), 
-	... 		control_info_bayes["x_bkg"].tolist()
+	... 		control_info_bayes["x_raw"].tolist()
 	... 	)
 	... ))
 
@@ -208,8 +208,8 @@ Note how the values of ``sg0`` and ``sg1`` are used to compute the standard devi
 	>>> igauge = 0  # index of the calibration gauge
 	>>> obs = model_bayes.response_data.q[igauge]
 	>>> sim = model_bayes.response.q[igauge]
-	>>> sg0 = control_info_bayes['x_bkg'][4]
-	>>> sg1 = control_info_bayes['x_bkg'][5]
+	>>> sg0 = control_info_bayes['x_raw'][4]
+	>>> sg1 = control_info_bayes['x_raw'][5]
 	>>>
 	>>> plot_hydrograph(obs=obs, sim=sim, sg0=sg0, sg1=sg1, xlim=[500, 1440])
 
@@ -265,7 +265,7 @@ Then, access to the control values:
 	>>> print(dict(
 	... 	zip(
 	... 		control_info_bayes_priors["name"].tolist(), 
-	... 		control_info_bayes_priors["x_bkg"].tolist()
+	... 		control_info_bayes_priors["x_raw"].tolist()
 	... 	)
 	... ))
 
@@ -285,8 +285,8 @@ Other parameters compensated by changing values, with no obvious loss of perform
 	>>> igauge = 0  # index of the calibration gauge
 	>>> obs = model_bayes_priors.response_data.q[igauge]
 	>>> sim = model_bayes_priors.response.q[igauge]
-	>>> sg0 = control_info_bayes_priors['x_bkg'][4]
-	>>> sg1 = control_info_bayes_priors['x_bkg'][5]
+	>>> sg0 = control_info_bayes_priors['x_raw'][4]
+	>>> sg1 = control_info_bayes_priors['x_raw'][5]
 	>>>
 	>>> plot_hydrograph(obs=obs, sim=sim, sg0=sg0, sg1=sg1, xlim=[500, 1440])
 
@@ -331,7 +331,7 @@ The values estimated for ``(sg0, sg1)`` implicitly define the weighting of each 
 	>>> print(dict(
 	... 	zip(
 	... 		control_info_bayes_mg["name"].tolist(), 
-	... 		control_info_bayes_mg["x_bkg"].tolist()
+	... 		control_info_bayes_mg["x_raw"].tolist()
 	... 	)
 	... ))
 
@@ -350,8 +350,8 @@ The figure below compares the observed and the simulated discharge time series a
 	>>> igauge = 2  # index of gauge V3517010
 	>>> obs = model_bayes_mg.response_data.q[igauge]
 	>>> sim = model_bayes_mg.response.q[igauge]
-	>>> sg0 = control_info_bayes_mg['x_bkg'][6]
-	>>> sg1 = control_info_bayes_mg['x_bkg'][9]
+	>>> sg0 = control_info_bayes_mg['x_raw'][6]
+	>>> sg1 = control_info_bayes_mg['x_raw'][9]
 	>>>
 	>>> plot_hydrograph(obs=obs, sim=sim, sg0=sg0, sg1=sg1, xlim=[500, 1440])
 
@@ -409,7 +409,7 @@ The parameters of structural errors also changed quite markedly: for instance, a
 	>>> print(dict(
 	... 	zip(
 	... 		control_info_bayes_mg["name"].tolist(), 
-	... 		control_info_bayes_mg["x_bkg"].tolist()
+	... 		control_info_bayes_mg["x_raw"].tolist()
 	... 	)
 	... ))
 
@@ -426,8 +426,8 @@ The parameters of structural errors also changed quite markedly: for instance, a
 	>>> igauge = 2  # index of gauge V3517010
 	>>> obs = model_bayes_mg.response_data.q[igauge]
 	>>> sim = model_bayes_mg.response.q[igauge]
-	>>> sg0 = control_info_bayes_mg['x_bkg'][6]
-	>>> sg1 = control_info_bayes_mg['x_bkg'][9]
+	>>> sg0 = control_info_bayes_mg['x_raw'][6]
+	>>> sg1 = control_info_bayes_mg['x_raw'][9]
 	>>>
 	>>> plot_hydrograph(obs=obs, sim=sim, sg0=sg0, sg1=sg1, xlim=[500, 1440])
 

--- a/doc/source/user_guide/in_depth/retrieving_control_parameters.rst
+++ b/doc/source/user_guide/in_depth/retrieving_control_parameters.rst
@@ -152,7 +152,7 @@ which is spatially uniform.
 
     .. code-block:: python
 
-        >>> control_info["x_bkg"]  # background values before transformation
+        >>> control_info["x_raw"]  # raw values before transformation
 
     .. code-block:: output
         

--- a/smash/core/simulation/_doc.py
+++ b/smash/core/simulation/_doc.py
@@ -62,14 +62,14 @@ control_info : `dict[str, Any]`
         - ``2``: both lower and upper bounds
         - ``3``: only upper bound
 
-    - x_bkg : `numpy.ndarray`
-        An array of shape *(n,)* containing the background values of the control vector.
+    - x_raw : `numpy.ndarray`
+        An array of shape *(n,)* containing the raw (non-transformed) values of the control vector.
 
-    - l_bkg : `numpy.ndarray`
-        An array of shape *(n,)* containing the background lower bounds of the control vector.
+    - l_raw : `numpy.ndarray`
+        An array of shape *(n,)* containing the raw (non-transformed) lower bounds of the control vector.
 
-    - u_bkg : `numpy.ndarray`
-        An array of shape *(n,)* containing the background upper bounds of the control vector.
+    - u_raw : `numpy.ndarray`
+        An array of shape *(n,)* containing the raw (non-transformed) upper bounds of the control vector.
 """
 
 MAPPING_OPTIMIZER_BASE_DOC = {
@@ -1287,21 +1287,21 @@ Default optimize control vector information
 >>> control_info
 {
     'l': array([-13.815511 , -13.815511 ,  -4.6052704, -13.815511 ], dtype=float32),
-    'l_bkg': array([ 1.e-06,  1.e-06, -5.e+01,  1.e-06], dtype=float32),
+    'l_raw': array([ 1.e-06,  1.e-06, -5.e+01,  1.e-06], dtype=float32),
     'n': 4,
     'name': array(['cp-0', 'ct-0', 'kexc-0', 'llr-0'], dtype='<U128'),
     'nbd': array([2, 2, 2, 2], dtype=int32),
     'nbk': array([4, 0, 0, 0, 0, 0]),
     'u': array([6.9077554, 6.9077554, 4.6052704, 6.9077554], dtype=float32),
-    'u_bkg': array([1000., 1000.,   50., 1000.], dtype=float32),
+    'u_raw': array([1000., 1000.,   50., 1000.], dtype=float32),
     'x': array([5.2983174, 6.214608 , 0.       , 1.609438 ], dtype=float32),
-    'x_bkg': array([200., 500.,   0.,   5.], dtype=float32),
+    'x_raw': array([200., 500.,   0.,   5.], dtype=float32),
 }
 
 This gives a direct indication of what the optimizer takes as input, depending on the optimization
 configuration set up. 4 rainfall-runoff parameters are uniformly optimized (``'cp-0'``, ``'ct-0'``,
 ``'kexc-0'`` and ``'llr-0'``). Each parameter has a lower and upper bound (``2`` in ``nbd``) and a
-transformation was applied to the control (``x`` relative to ``x_bkg``).
+transformation was applied to the control (``x`` relative to ``x_raw``).
 
 With a customize optimize configuration. Here, choosing a ``multi-linear`` mapping and optimizing only ``cp``
 and ``kexc`` with different descriptors
@@ -1317,15 +1317,15 @@ and ``kexc`` with different descriptors
 >>> control_info
 {
     'l': array([-inf, -inf, -inf, -inf, -inf], dtype=float32),
-    'l_bkg': array([-inf, -inf, -inf, -inf, -inf], dtype=float32),
+    'l_raw': array([-inf, -inf, -inf, -inf, -inf], dtype=float32),
     'n': 5,
     'name': array(['cp-0', 'cp-slope-a', 'cp-dd-a', 'kexc-0', 'kexc-dd-a'], dtype='<U128'),
     'nbd': array([0, 0, 0, 0, 0], dtype=int32),
     'nbk': array([5, 0, 0, 0, 0, 0]),
     'u': array([inf, inf, inf, inf, inf], dtype=float32),
-    'u_bkg': array([inf, inf, inf, inf, inf], dtype=float32),
+    'u_raw': array([inf, inf, inf, inf, inf], dtype=float32),
     'x': array([-1.3862944,  0.       ,  0.       ,  0.       ,  0.       ], dtype=float32),
-    'x_bkg': array([-1.3862944,  0.       ,  0.       ,  0.       ,  0.       ], dtype=float32),
+    'x_raw': array([-1.3862944,  0.       ,  0.       ,  0.       ,  0.       ], dtype=float32),
 }
 
 5 parameters are optimized which are the intercepts (``'cp-0'`` and  ``'kexc-0'``) and the coefficients
@@ -1404,23 +1404,23 @@ Default optimize control vector information
 {
     'l': array([-1.3815511e+01, -1.3815511e+01, -4.6052704e+00, -1.3815511e+01, 1.0000000e-06, 1.0000000e-06],
          dtype=float32),
-    'l_bkg': array([ 1.e-06,  1.e-06, -5.e+01,  1.e-06,  1.e-06,  1.e-06], dtype=float32),
+    'l_raw': array([ 1.e-06,  1.e-06, -5.e+01,  1.e-06,  1.e-06,  1.e-06], dtype=float32),
     'n': 6,
     'name': array(['cp-0', 'ct-0', 'kexc-0', 'llr-0', 'sg0-V3524010', 'sg1-V3524010'], dtype='<U128'),
     'nbd': array([2, 2, 2, 2, 2, 2], dtype=int32),
     'nbk': array([4, 0, 0, 2]),
     'u': array([   6.9077554,    6.9077554,    4.6052704,    6.9077554, 1000.       ,   10.       ],
          dtype=float32),
-    'u_bkg': array([1000., 1000.,   50., 1000., 1000.,   10.], dtype=float32),
+    'u_raw': array([1000., 1000.,   50., 1000., 1000.,   10.], dtype=float32),
     'x': array([5.2983174, 6.214608 , 0.       , 1.609438 , 1.       , 0.2      ], dtype=float32),
-    'x_bkg': array([2.e+02, 5.e+02, 0.e+00, 5.e+00, 1.e+00, 2.e-01], dtype=float32),
+    'x_raw': array([2.e+02, 5.e+02, 0.e+00, 5.e+00, 1.e+00, 2.e-01], dtype=float32),
 }
 
 This gives a direct indication of what the optimizer takes as input, depending on the optimization
 configuration set up. 4 rainfall-runoff parameters are uniformly optimized (``'cp-0'``, ``'ct-0'``,
 ``'kexc-0'`` and ``'llr-0'``) and 2 structural error sigma parameters at gauge ``'V3524010'``
 (``'sg0-V3524010'``, ``'sg1-V3524010'``). Each parameter has a lower and upper bound (``2`` in ``nbd``)
-and a transformation was applied to the control (``x`` relative to ``x_bkg``).
+and a transformation was applied to the control (``x`` relative to ``x_raw``).
 
 With a customize optimize configuration. Here, choosing a ``multi-linear`` mapping and
 optimizing only 2 rainfall-runoff parameters ``cp``, ``kexc`` with different descriptors and 2 structural
@@ -1437,17 +1437,17 @@ error sigma parameters ``sg0`` and ``sg1``.
 >>> control_info
 {
     'l': array([-inf, -inf, -inf, -inf, -inf,   0.,   0.], dtype=float32),
-    'l_bkg': array([  -inf,   -inf,   -inf,   -inf,   -inf, 1.e-06, 1.e-06], dtype=float32),
+    'l_raw': array([  -inf,   -inf,   -inf,   -inf,   -inf, 1.e-06, 1.e-06], dtype=float32),
     'n': 7,
     'name': array(['cp-0', 'cp-slope-a', 'cp-dd-a', 'kexc-0', 'kexc-dd-a', 'sg0-V3524010', 'sg1-V3524010'],
             dtype='<U128'),
     'nbd': array([0, 0, 0, 0, 0, 2, 2], dtype=int32),
     'nbk': array([5, 0, 0, 2]),
     'u': array([inf, inf, inf, inf, inf,  1.,  1.], dtype=float32),
-    'u_bkg': array([  inf,   inf,   inf,   inf,   inf, 1000.,   10.], dtype=float32),
+    'u_raw': array([  inf,   inf,   inf,   inf,   inf, 1000.,   10.], dtype=float32),
     'x': array([-1.3862944e+00,  0.0000000e+00,  0.0000000e+00,  0.0000000e+00, 0.0000000e+00,  9.9999900e-04,
          1.9999903e-02], dtype=float32),
-    'x_bkg': array([-1.3862944,  0.       ,  0.       ,  0.       ,  0.       , 1.       ,  0.2      ],
+    'x_raw': array([-1.3862944,  0.       ,  0.       ,  0.       ,  0.       , 1.       ,  0.2      ],
              dtype=float32),
 }
 

--- a/smash/core/simulation/optimize/_tools.py
+++ b/smash/core/simulation/optimize/_tools.py
@@ -60,7 +60,7 @@ def _get_control_info(
             value = value.copy()
         ret[attr] = value
 
-    for key in ["l", "u", "l_bkg", "u_bkg"]:
+    for key in ["l", "u", "l_raw", "u_raw"]:
         # Handle unbounded and semi-unbounded parameters
         if key.startswith("l"):
             ret[key] = np.where(np.isin(ret["nbd"], [0, 3]), -np.inf, ret[key])
@@ -106,7 +106,7 @@ def _merge_net_control(ret: dict, optimize_options: dict):
 
         ret["nbd"] = np.append(ret["nbd"], np.zeros(x_net_size))
 
-        for key in ["l", "u", "l_bkg", "u_bkg"]:
+        for key in ["l", "u", "l_raw", "u_raw"]:
             if key.startswith("l"):
                 value = -np.inf
             elif key.startswith("u"):
@@ -130,7 +130,7 @@ def _merge_net_control(ret: dict, optimize_options: dict):
 
         ret["x"] = np.append(ret["x"], x)
 
-        ret["x_bkg"] = np.append(ret["x_bkg"], x)  # no transformation applied to x
+        ret["x_raw"] = np.append(ret["x_raw"], x)  # no transformation applied to x
 
 
 def _net2vect(net: Net) -> np.ndarray:

--- a/smash/fcore/cost/md_regularization.f90
+++ b/smash/fcore/cost/md_regularization.f90
@@ -31,7 +31,7 @@ contains
         real(sp), dimension(parameters%control%n) :: dbkg
 
         ! Tapenade needs to know the size somehow
-        dbkg = parameters%control%x - parameters%control%x_bkg
+        dbkg = parameters%control%x - parameters%control%x_raw
 
         res = sum(dbkg*dbkg)
 
@@ -94,9 +94,9 @@ contains
 
         ! This allows to retrieve a parameters structure with background values
         parameters_bkg = parameters
-        parameters_bkg%control%x = parameters%control%x_bkg
-        parameters_bkg%control%l = parameters%control%l_bkg
-        parameters_bkg%control%u = parameters%control%u_bkg
+        parameters_bkg%control%x = parameters%control%x_raw
+        parameters_bkg%control%l = parameters%control%l_raw
+        parameters_bkg%control%u = parameters%control%u_raw
 
         call control_tfm(parameters_bkg, options)
         call control_to_parameters(setup, mesh, input_data, parameters_bkg, options)

--- a/smash/fcore/derived_type/mwd_control.f90
+++ b/smash/fcore/derived_type/mwd_control.f90
@@ -12,9 +12,9 @@
 !%          ``x``                      Control vector
 !%          ``l``                      Control vector lower bound
 !%          ``u``                      Control vector upper bound
-!%          ``x_bkg``                  Control vector background
-!%          ``l_bkg``                  Control vector lower bound background
-!%          ``u_bkg``                  Control vector upper bound background
+!%          ``x_raw``                  Control vector raw
+!%          ``l_raw``                  Control vector lower bound raw
+!%          ``u_raw``                  Control vector upper bound raw
 !%          ``nbd``                    Control vector kind of bound
 !%
 !§      Subroutine
@@ -38,9 +38,9 @@ module mwd_control
         real(sp), dimension(:), allocatable :: l
         real(sp), dimension(:), allocatable :: u
 
-        real(sp), dimension(:), allocatable :: x_bkg
-        real(sp), dimension(:), allocatable :: l_bkg
-        real(sp), dimension(:), allocatable :: u_bkg
+        real(sp), dimension(:), allocatable :: x_raw
+        real(sp), dimension(:), allocatable :: l_raw
+        real(sp), dimension(:), allocatable :: u_raw
 
         integer, dimension(:), allocatable :: nbd
         character(lchar), dimension(:), allocatable :: name !$F90W char-array
@@ -70,14 +70,14 @@ contains
         allocate (this%u(this%n))
         this%u = -99._sp
 
-        allocate (this%x_bkg(this%n))
-        this%x_bkg = 0._sp
+        allocate (this%x_raw(this%n))
+        this%x_raw = 0._sp
 
-        allocate (this%l_bkg(this%n))
-        this%l_bkg = -99._sp
+        allocate (this%l_raw(this%n))
+        this%l_raw = -99._sp
 
-        allocate (this%u_bkg(this%n))
-        this%u_bkg = -99._sp
+        allocate (this%u_raw(this%n))
+        this%u_raw = -99._sp
 
         allocate (this%nbd(this%n))
         this%nbd = -99
@@ -101,11 +101,11 @@ contains
 
             deallocate (this%u)
 
-            deallocate (this%x_bkg)
+            deallocate (this%x_raw)
 
-            deallocate (this%l_bkg)
+            deallocate (this%l_raw)
 
-            deallocate (this%u_bkg)
+            deallocate (this%u_raw)
 
             deallocate (this%nbd)
 

--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -2205,9 +2205,9 @@ END MODULE MWD_OUTPUT_DIFF
 !%          ``x``                      Control vector
 !%          ``l``                      Control vector lower bound
 !%          ``u``                      Control vector upper bound
-!%          ``x_bkg``                  Control vector background
-!%          ``l_bkg``                  Control vector lower bound background
-!%          ``u_bkg``                  Control vector upper bound background
+!%          ``x_raw``                  Control vector raw
+!%          ``l_raw``                  Control vector lower bound raw
+!%          ``u_raw``                  Control vector upper bound raw
 !%          ``nbd``                    Control vector kind of bound
 !%
 !§      Subroutine
@@ -2227,9 +2227,9 @@ MODULE MWD_CONTROL_DIFF
       REAL(sp), DIMENSION(:), ALLOCATABLE :: x
       REAL(sp), DIMENSION(:), ALLOCATABLE :: l
       REAL(sp), DIMENSION(:), ALLOCATABLE :: u
-      REAL(sp), DIMENSION(:), ALLOCATABLE :: x_bkg
-      REAL(sp), DIMENSION(:), ALLOCATABLE :: l_bkg
-      REAL(sp), DIMENSION(:), ALLOCATABLE :: u_bkg
+      REAL(sp), DIMENSION(:), ALLOCATABLE :: x_raw
+      REAL(sp), DIMENSION(:), ALLOCATABLE :: l_raw
+      REAL(sp), DIMENSION(:), ALLOCATABLE :: u_raw
       INTEGER, DIMENSION(:), ALLOCATABLE :: nbd
       CHARACTER(len=lchar), DIMENSION(:), ALLOCATABLE :: name
   END TYPE CONTROLDT
@@ -2237,8 +2237,8 @@ MODULE MWD_CONTROL_DIFF
       REAL(sp), DIMENSION(:), ALLOCATABLE :: x
       REAL(sp), DIMENSION(:), ALLOCATABLE :: l
       REAL(sp), DIMENSION(:), ALLOCATABLE :: u
-      REAL(sp), DIMENSION(:), ALLOCATABLE :: l_bkg
-      REAL(sp), DIMENSION(:), ALLOCATABLE :: u_bkg
+      REAL(sp), DIMENSION(:), ALLOCATABLE :: l_raw
+      REAL(sp), DIMENSION(:), ALLOCATABLE :: u_raw
       INTEGER, DIMENSION(:), ALLOCATABLE :: nbd
   END TYPE CONTROLDT_DIFF
 
@@ -2258,12 +2258,12 @@ CONTAINS
     this%l = -99._sp
     ALLOCATE(this%u(this%n))
     this%u = -99._sp
-    ALLOCATE(this%x_bkg(this%n))
-    this%x_bkg = 0._sp
-    ALLOCATE(this%l_bkg(this%n))
-    this%l_bkg = -99._sp
-    ALLOCATE(this%u_bkg(this%n))
-    this%u_bkg = -99._sp
+    ALLOCATE(this%x_raw(this%n))
+    this%x_raw = 0._sp
+    ALLOCATE(this%l_raw(this%n))
+    this%l_raw = -99._sp
+    ALLOCATE(this%u_raw(this%n))
+    this%u_raw = -99._sp
     ALLOCATE(this%nbd(this%n))
     this%nbd = -99
     ALLOCATE(this%name(this%n))
@@ -2278,9 +2278,9 @@ CONTAINS
       DEALLOCATE(this%x)
       DEALLOCATE(this%l)
       DEALLOCATE(this%u)
-      DEALLOCATE(this%x_bkg)
-      DEALLOCATE(this%l_bkg)
-      DEALLOCATE(this%u_bkg)
+      DEALLOCATE(this%x_raw)
+      DEALLOCATE(this%l_raw)
+      DEALLOCATE(this%u_raw)
       DEALLOCATE(this%nbd)
       DEALLOCATE(this%name)
     END IF
@@ -5779,8 +5779,8 @@ CONTAINS
 !  Differentiation of sbs_control_tfm in forward (tangent) mode (with options fixinterface noISIZE context):
 !   variations   of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE SBS_CONTROL_TFM_D(parameters, parameters_d)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -5796,12 +5796,12 @@ CONTAINS
 ! Only apply sbs transformation on RR parameters and RR initial states
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (nbd_mask(i)) THEN
-        IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+        IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
           parameters_d%control%x(i) = parameters_d%control%x(i)/SQRT(1.0&
 &           +parameters%control%x(i)**2)
           parameters%control%x(i) = ASINH(parameters%control%x(i))
-        ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters&
-&           %control%u_bkg(i) .LE. 1._sp) THEN
+        ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters&
+&           %control%u_raw(i) .LE. 1._sp) THEN
           temp = parameters%control%x(i)/(-parameters%control%x(i)+1._sp&
 &           )
           parameters_d%control%x(i) = (temp+1.0)*parameters_d%control%x(&
@@ -5819,8 +5819,8 @@ CONTAINS
 !  Differentiation of sbs_control_tfm in reverse (adjoint) mode (with options fixinterface noISIZE context):
 !   gradient     of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE SBS_CONTROL_TFM_B(parameters, parameters_b)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -5840,12 +5840,12 @@ CONTAINS
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (.NOT.nbd_mask(i)) THEN
         CALL PUSHCONTROL2B(0)
-      ELSE IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+      ELSE IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
         CALL PUSHREAL4(parameters%control%x(i))
         parameters%control%x(i) = ASINH(parameters%control%x(i))
         CALL PUSHCONTROL2B(3)
-      ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters%&
-&         control%u_bkg(i) .LE. 1._sp) THEN
+      ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters%&
+&         control%u_raw(i) .LE. 1._sp) THEN
         CALL PUSHREAL4(parameters%control%x(i))
         parameters%control%x(i) = LOG(parameters%control%x(i)/(1._sp-&
 &         parameters%control%x(i)))
@@ -5892,22 +5892,22 @@ CONTAINS
 ! Only apply sbs transformation on RR parameters and RR initial states
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (nbd_mask(i)) THEN
-        IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+        IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
           parameters%control%x(i) = ASINH(parameters%control%x(i))
-          parameters%control%l(i) = ASINH(parameters%control%l_bkg(i))
-          parameters%control%u(i) = ASINH(parameters%control%u_bkg(i))
-        ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters&
-&           %control%u_bkg(i) .LE. 1._sp) THEN
+          parameters%control%l(i) = ASINH(parameters%control%l_raw(i))
+          parameters%control%u(i) = ASINH(parameters%control%u_raw(i))
+        ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters&
+&           %control%u_raw(i) .LE. 1._sp) THEN
           parameters%control%x(i) = LOG(parameters%control%x(i)/(1._sp-&
 &           parameters%control%x(i)))
-          parameters%control%l(i) = LOG(parameters%control%l_bkg(i)/(&
-&           1._sp-parameters%control%l_bkg(i)))
-          parameters%control%u(i) = LOG(parameters%control%u_bkg(i)/(&
-&           1._sp-parameters%control%u_bkg(i)))
+          parameters%control%l(i) = LOG(parameters%control%l_raw(i)/(&
+&           1._sp-parameters%control%l_raw(i)))
+          parameters%control%u(i) = LOG(parameters%control%u_raw(i)/(&
+&           1._sp-parameters%control%u_raw(i)))
         ELSE
           parameters%control%x(i) = LOG(parameters%control%x(i))
-          parameters%control%l(i) = LOG(parameters%control%l_bkg(i))
-          parameters%control%u(i) = LOG(parameters%control%u_bkg(i))
+          parameters%control%l(i) = LOG(parameters%control%l_raw(i))
+          parameters%control%u(i) = LOG(parameters%control%u_raw(i))
         END IF
       END IF
     END DO
@@ -5916,8 +5916,8 @@ CONTAINS
 !  Differentiation of sbs_inv_control_tfm in forward (tangent) mode (with options fixinterface noISIZE context):
 !   variations   of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE SBS_INV_CONTROL_TFM_D(parameters, parameters_d)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -5934,12 +5934,12 @@ CONTAINS
 ! Only apply sbs inv transformation on RR parameters et RR initial states
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (nbd_mask(i)) THEN
-        IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+        IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
           parameters_d%control%x(i) = COSH(parameters%control%x(i))*&
 &           parameters_d%control%x(i)
           parameters%control%x(i) = SINH(parameters%control%x(i))
-        ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters&
-&           %control%u_bkg(i) .LE. 1._sp) THEN
+        ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters&
+&           %control%u_raw(i) .LE. 1._sp) THEN
           temp = EXP(parameters%control%x(i)) + 1._sp
           temp0 = EXP(parameters%control%x(i))/temp
           parameters_d%control%x(i) = (EXP(parameters%control%x(i))-&
@@ -5958,8 +5958,8 @@ CONTAINS
 !  Differentiation of sbs_inv_control_tfm in reverse (adjoint) mode (with options fixinterface noISIZE context):
 !   gradient     of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE SBS_INV_CONTROL_TFM_B(parameters, parameters_b)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -5978,12 +5978,12 @@ CONTAINS
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (.NOT.nbd_mask(i)) THEN
         CALL PUSHCONTROL2B(0)
-      ELSE IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+      ELSE IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
         CALL PUSHREAL4(parameters%control%x(i))
         parameters%control%x(i) = SINH(parameters%control%x(i))
         CALL PUSHCONTROL2B(3)
-      ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters%&
-&         control%u_bkg(i) .LE. 1._sp) THEN
+      ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters%&
+&         control%u_raw(i) .LE. 1._sp) THEN
         CALL PUSHREAL4(parameters%control%x(i))
         parameters%control%x(i) = EXP(parameters%control%x(i))/(1._sp+&
 &         EXP(parameters%control%x(i)))
@@ -6031,10 +6031,10 @@ CONTAINS
 ! Only apply sbs inv transformation on RR parameters et RR initial states
     DO i=1,SUM(parameters%control%nbk(1:2))
       IF (nbd_mask(i)) THEN
-        IF (parameters%control%l_bkg(i) .LT. 0._sp) THEN
+        IF (parameters%control%l_raw(i) .LT. 0._sp) THEN
           parameters%control%x(i) = SINH(parameters%control%x(i))
-        ELSE IF (parameters%control%l_bkg(i) .GE. 0._sp .AND. parameters&
-&           %control%u_bkg(i) .LE. 1._sp) THEN
+        ELSE IF (parameters%control%l_raw(i) .GE. 0._sp .AND. parameters&
+&           %control%u_raw(i) .LE. 1._sp) THEN
           parameters%control%x(i) = EXP(parameters%control%x(i))/(1._sp+&
 &           EXP(parameters%control%x(i)))
         ELSE
@@ -6042,8 +6042,8 @@ CONTAINS
         END IF
       END IF
     END DO
-    parameters%control%l = parameters%control%l_bkg
-    parameters%control%u = parameters%control%u_bkg
+    parameters%control%l = parameters%control%l_raw
+    parameters%control%u = parameters%control%u_raw
   END SUBROUTINE SBS_INV_CONTROL_TFM
 
 !  Differentiation of normalize_control_tfm in forward (tangent) mode (with options fixinterface noISIZE context):
@@ -6059,9 +6059,9 @@ CONTAINS
     nbd_mask = parameters%control%nbd(:) .EQ. 2
     WHERE (nbd_mask) 
       parameters_d%control%x = parameters_d%control%x/(parameters%&
-&       control%u_bkg-parameters%control%l_bkg)
+&       control%u_raw-parameters%control%l_raw)
       parameters%control%x = (parameters%control%x-parameters%control%&
-&       l_bkg)/(parameters%control%u_bkg-parameters%control%l_bkg)
+&       l_raw)/(parameters%control%u_raw-parameters%control%l_raw)
     END WHERE
   END SUBROUTINE NORMALIZE_CONTROL_TFM_D
 
@@ -6077,7 +6077,7 @@ CONTAINS
 !% Need lower and upper bound to normalize
     nbd_mask = parameters%control%nbd(:) .EQ. 2
     WHERE (nbd_mask) parameters_b%control%x = parameters_b%control%x/(&
-&       parameters%control%u_bkg-parameters%control%l_bkg)
+&       parameters%control%u_raw-parameters%control%l_raw)
   END SUBROUTINE NORMALIZE_CONTROL_TFM_B
 
   SUBROUTINE NORMALIZE_CONTROL_TFM(parameters)
@@ -6088,7 +6088,7 @@ CONTAINS
     nbd_mask = parameters%control%nbd(:) .EQ. 2
     WHERE (nbd_mask) 
       parameters%control%x = (parameters%control%x-parameters%control%&
-&       l_bkg)/(parameters%control%u_bkg-parameters%control%l_bkg)
+&       l_raw)/(parameters%control%u_raw-parameters%control%l_raw)
       parameters%control%l = 0._sp
       parameters%control%u = 1._sp
     END WHERE
@@ -6097,8 +6097,8 @@ CONTAINS
 !  Differentiation of normalize_inv_control_tfm in forward (tangent) mode (with options fixinterface noISIZE context):
 !   variations   of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE NORMALIZE_INV_CONTROL_TFM_D(parameters, parameters_d)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6107,18 +6107,18 @@ CONTAINS
 !% Need lower and upper bound to denormalize
     nbd_mask = parameters%control%nbd(:) .EQ. 2
     WHERE (nbd_mask) 
-      parameters_d%control%x = (parameters%control%u_bkg-parameters%&
-&       control%l_bkg)*parameters_d%control%x
+      parameters_d%control%x = (parameters%control%u_raw-parameters%&
+&       control%l_raw)*parameters_d%control%x
       parameters%control%x = parameters%control%x*(parameters%control%&
-&       u_bkg-parameters%control%l_bkg) + parameters%control%l_bkg
+&       u_raw-parameters%control%l_raw) + parameters%control%l_raw
     END WHERE
   END SUBROUTINE NORMALIZE_INV_CONTROL_TFM_D
 
 !  Differentiation of normalize_inv_control_tfm in reverse (adjoint) mode (with options fixinterface noISIZE context):
 !   gradient     of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
-!   Plus diff mem management of: parameters.control.x:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!   Plus diff mem management of: parameters.control.x:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE NORMALIZE_INV_CONTROL_TFM_B(parameters, parameters_b)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6126,8 +6126,8 @@ CONTAINS
     LOGICAL, DIMENSION(parameters%control%n) :: nbd_mask
 !% Need lower and upper bound to denormalize
     nbd_mask = parameters%control%nbd(:) .EQ. 2
-    WHERE (nbd_mask) parameters_b%control%x = (parameters%control%u_bkg-&
-&       parameters%control%l_bkg)*parameters_b%control%x
+    WHERE (nbd_mask) parameters_b%control%x = (parameters%control%u_raw-&
+&       parameters%control%l_raw)*parameters_b%control%x
   END SUBROUTINE NORMALIZE_INV_CONTROL_TFM_B
 
   SUBROUTINE NORMALIZE_INV_CONTROL_TFM(parameters)
@@ -6138,9 +6138,9 @@ CONTAINS
     nbd_mask = parameters%control%nbd(:) .EQ. 2
     WHERE (nbd_mask) 
       parameters%control%x = parameters%control%x*(parameters%control%&
-&       u_bkg-parameters%control%l_bkg) + parameters%control%l_bkg
-      parameters%control%l = parameters%control%l_bkg
-      parameters%control%u = parameters%control%u_bkg
+&       u_raw-parameters%control%l_raw) + parameters%control%l_raw
+      parameters%control%l = parameters%control%l_raw
+      parameters%control%u = parameters%control%u_raw
     END WHERE
   END SUBROUTINE NORMALIZE_INV_CONTROL_TFM
 
@@ -6148,8 +6148,8 @@ CONTAINS
 !   variations   of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE CONTROL_TFM_D(parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6167,8 +6167,8 @@ CONTAINS
 !   gradient     of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE CONTROL_TFM_B(parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6208,8 +6208,8 @@ CONTAINS
 !   variations   of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE INV_CONTROL_TFM_D(parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6227,8 +6227,8 @@ CONTAINS
 !   gradient     of useful results: *(parameters.control.x)
 !   with respect to varying inputs: *(parameters.control.x)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in
   SUBROUTINE INV_CONTROL_TFM_B(parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(PARAMETERSDT), INTENT(INOUT) :: parameters
@@ -6902,10 +6902,10 @@ CONTAINS
     CALL SERR_SIGMA_PARAMETERS_FILL_CONTROL(setup, mesh, parameters, &
 &                                     options)
     CALL NN_PARAMETERS_FILL_CONTROL(setup, options, parameters)
-! Store background
-    parameters%control%x_bkg = parameters%control%x
-    parameters%control%l_bkg = parameters%control%l
-    parameters%control%u_bkg = parameters%control%u
+! Store raw control values
+    parameters%control%x_raw = parameters%control%x
+    parameters%control%l_raw = parameters%control%l
+    parameters%control%u_raw = parameters%control%u
   END SUBROUTINE FILL_CONTROL
 
 !  Differentiation of uniform_rr_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE context)
@@ -8874,8 +8874,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -8917,8 +8917,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -9054,7 +9054,7 @@ CONTAINS
     INTRINSIC SUM
 ! Tapenade needs to know the size somehow
     dbkg_d = parameters_d%control%x
-    dbkg = parameters%control%x - parameters%control%x_bkg
+    dbkg = parameters%control%x - parameters%control%x_raw
     res_d = SUM(2*dbkg*dbkg_d)
     res = SUM(dbkg*dbkg)
   END FUNCTION PRIOR_REGULARIZATION_D
@@ -9073,8 +9073,8 @@ CONTAINS
     REAL(sp), DIMENSION(parameters%control%n) :: dbkg_b
     INTRINSIC SUM
 ! Tapenade needs to know the size somehow
-    dbkg = parameters%control%x - parameters%control%x_bkg
-    dbkg = parameters%control%x - parameters%control%x_bkg
+    dbkg = parameters%control%x - parameters%control%x_raw
+    dbkg = parameters%control%x - parameters%control%x_raw
     dbkg_b = 0.0_4
     dbkg_b = 2*dbkg*res_b
     parameters_b%control%x = parameters_b%control%x + dbkg_b
@@ -9087,7 +9087,7 @@ CONTAINS
     REAL(sp), DIMENSION(parameters%control%n) :: dbkg
     INTRINSIC SUM
 ! Tapenade needs to know the size somehow
-    dbkg = parameters%control%x - parameters%control%x_bkg
+    dbkg = parameters%control%x - parameters%control%x_raw
     res = SUM(dbkg*dbkg)
   END FUNCTION PRIOR_REGULARIZATION
 
@@ -9310,8 +9310,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -9341,7 +9341,7 @@ CONTAINS
     parameters_bkg_d = parameters_d
     parameters_bkg = parameters
     parameters_bkg_d%control%x = 0.0_4
-    parameters_bkg%control%x = parameters%control%x_bkg
+    parameters_bkg%control%x = parameters%control%x_raw
     CALL CONTROL_TFM_D(parameters_bkg, parameters_bkg_d, options)
     CALL CONTROL_TO_PARAMETERS_D(setup, mesh, input_data, parameters_bkg&
 &                          , parameters_bkg_d, options)
@@ -9390,8 +9390,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -9426,7 +9426,7 @@ CONTAINS
     parameters_bkg = parameters
     CALL PUSHREAL4ARRAY(parameters_bkg%control%x, SIZE(parameters_bkg%&
 &                 control%x, 1))
-    parameters_bkg%control%x = parameters%control%x_bkg
+    parameters_bkg%control%x = parameters%control%x_raw
     CALL PUSHREAL4ARRAY(parameters_bkg%control%x, SIZE(parameters_bkg%&
 &                 control%x, 1))
     CALL CONTROL_TFM(parameters_bkg, options)
@@ -9600,9 +9600,9 @@ CONTAINS
     res = 0._sp
 ! This allows to retrieve a parameters structure with background values
     parameters_bkg = parameters
-    parameters_bkg%control%x = parameters%control%x_bkg
-    parameters_bkg%control%l = parameters%control%l_bkg
-    parameters_bkg%control%u = parameters%control%u_bkg
+    parameters_bkg%control%x = parameters%control%x_raw
+    parameters_bkg%control%l = parameters%control%l_raw
+    parameters_bkg%control%u = parameters%control%u_raw
     CALL CONTROL_TFM(parameters_bkg, options)
     CALL CONTROL_TO_PARAMETERS(setup, mesh, input_data, parameters_bkg, &
 &                        options)
@@ -11569,8 +11569,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -11627,8 +11627,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -11849,8 +11849,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values) *(output.response.q)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -11886,8 +11886,8 @@ CONTAINS
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !                *(parameters.rr_initial_states.values) *(output.response.q)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -11998,8 +11998,8 @@ CONTAINS
 !                *(parameters.rr_initial_states.values) *(parameters.serr_mu_parameters.values)
 !                *(parameters.serr_sigma_parameters.values) *(output.response.q)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -12036,8 +12036,8 @@ CONTAINS
 !                *(parameters.rr_initial_states.values) *(parameters.serr_mu_parameters.values)
 !                *(parameters.serr_sigma_parameters.values) *(output.response.q)
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -29277,8 +29277,8 @@ END MODULE MD_SIMULATION_DIFF
 !                *(parameters.nn_parameters.weight_3):(loc) *(parameters.nn_parameters.bias_3):(loc)
 !                *(output.response.q):(loc) output.cost:out
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in
@@ -29345,8 +29345,8 @@ END SUBROUTINE BASE_FORWARD_RUN_D
 !                *(parameters.nn_parameters.weight_3):(loc) *(parameters.nn_parameters.bias_3):(loc)
 !                *(output.response.q):(loc) output.cost:in-killed
 !   Plus diff mem management of: parameters.control.x:in parameters.control.l:in
-!                parameters.control.u:in parameters.control.l_bkg:in
-!                parameters.control.u_bkg:in parameters.rr_parameters.values:in
+!                parameters.control.u:in parameters.control.l_raw:in
+!                parameters.control.u_raw:in parameters.rr_parameters.values:in
 !                parameters.rr_initial_states.values:in parameters.serr_mu_parameters.values:in
 !                parameters.serr_sigma_parameters.values:in parameters.nn_parameters.weight_1:in
 !                parameters.nn_parameters.bias_1:in parameters.nn_parameters.weight_2:in

--- a/smash/fcore/routine/mwd_parameters_manipulation.f90
+++ b/smash/fcore/routine/mwd_parameters_manipulation.f90
@@ -436,23 +436,23 @@ contains
 
             if (.not. nbd_mask(i)) cycle
 
-            if (parameters%control%l_bkg(i) .lt. 0._sp) then
+            if (parameters%control%l_raw(i) .lt. 0._sp) then
 
                 parameters%control%x(i) = asinh(parameters%control%x(i))
-                parameters%control%l(i) = asinh(parameters%control%l_bkg(i))
-                parameters%control%u(i) = asinh(parameters%control%u_bkg(i))
+                parameters%control%l(i) = asinh(parameters%control%l_raw(i))
+                parameters%control%u(i) = asinh(parameters%control%u_raw(i))
 
-            else if (parameters%control%l_bkg(i) .ge. 0._sp .and. parameters%control%u_bkg(i) .le. 1._sp) then
+            else if (parameters%control%l_raw(i) .ge. 0._sp .and. parameters%control%u_raw(i) .le. 1._sp) then
 
                 parameters%control%x(i) = log(parameters%control%x(i)/(1._sp - parameters%control%x(i)))
-                parameters%control%l(i) = log(parameters%control%l_bkg(i)/(1._sp - parameters%control%l_bkg(i)))
-                parameters%control%u(i) = log(parameters%control%u_bkg(i)/(1._sp - parameters%control%u_bkg(i)))
+                parameters%control%l(i) = log(parameters%control%l_raw(i)/(1._sp - parameters%control%l_raw(i)))
+                parameters%control%u(i) = log(parameters%control%u_raw(i)/(1._sp - parameters%control%u_raw(i)))
 
             else
 
                 parameters%control%x(i) = log(parameters%control%x(i))
-                parameters%control%l(i) = log(parameters%control%l_bkg(i))
-                parameters%control%u(i) = log(parameters%control%u_bkg(i))
+                parameters%control%l(i) = log(parameters%control%l_raw(i))
+                parameters%control%u(i) = log(parameters%control%u_raw(i))
 
             end if
 
@@ -477,11 +477,11 @@ contains
 
             if (.not. nbd_mask(i)) cycle
 
-            if (parameters%control%l_bkg(i) .lt. 0._sp) then
+            if (parameters%control%l_raw(i) .lt. 0._sp) then
 
                 parameters%control%x(i) = sinh(parameters%control%x(i))
 
-            else if (parameters%control%l_bkg(i) .ge. 0._sp .and. parameters%control%u_bkg(i) .le. 1._sp) then
+            else if (parameters%control%l_raw(i) .ge. 0._sp .and. parameters%control%u_raw(i) .le. 1._sp) then
 
                 parameters%control%x(i) = exp(parameters%control%x(i))/(1._sp + exp(parameters%control%x(i)))
 
@@ -493,8 +493,8 @@ contains
 
         end do
 
-        parameters%control%l = parameters%control%l_bkg
-        parameters%control%u = parameters%control%u_bkg
+        parameters%control%l = parameters%control%l_raw
+        parameters%control%u = parameters%control%u_raw
 
     end subroutine sbs_inv_control_tfm
 
@@ -511,8 +511,8 @@ contains
 
         where (nbd_mask)
 
-            parameters%control%x = (parameters%control%x - parameters%control%l_bkg)/ &
-                                   (parameters%control%u_bkg - parameters%control%l_bkg)
+            parameters%control%x = (parameters%control%x - parameters%control%l_raw)/ &
+                                   (parameters%control%u_raw - parameters%control%l_raw)
             parameters%control%l = 0._sp
             parameters%control%u = 1._sp
 
@@ -534,9 +534,9 @@ contains
         where (nbd_mask)
 
             parameters%control%x = parameters%control%x* &
-            & (parameters%control%u_bkg - parameters%control%l_bkg) + parameters%control%l_bkg
-            parameters%control%l = parameters%control%l_bkg
-            parameters%control%u = parameters%control%u_bkg
+            & (parameters%control%u_raw - parameters%control%l_raw) + parameters%control%l_raw
+            parameters%control%l = parameters%control%l_raw
+            parameters%control%u = parameters%control%u_raw
 
         end where
 
@@ -1381,10 +1381,10 @@ contains
 
         call nn_parameters_fill_control(setup, options, parameters)
 
-        ! Store background
-        parameters%control%x_bkg = parameters%control%x
-        parameters%control%l_bkg = parameters%control%l
-        parameters%control%u_bkg = parameters%control%u
+        ! Store raw control values
+        parameters%control%x_raw = parameters%control%x
+        parameters%control%l_raw = parameters%control%l
+        parameters%control%u_raw = parameters%control%u
 
     end subroutine fill_control
 


### PR DESCRIPTION
The name _bkg (background) applied for control values/upper/lower bounds is changed to _raw for clarification.