### PR TITLE
MAINT/BUG: fix Fortran descriptor derived type still initialized while read_descriptor is set to False

### DIFF
--- a/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
+++ b/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
@@ -60,6 +60,10 @@ The values of these descriptors can be obtained in the ``physio_data`` derived t
 
     (27, 14, 6)
 
+.. note::
+    In this tutorial, we load the setup dictionary using the `smash.factory.load_dataset` function.
+    If you need to define your own setup, ensure that the keys ``read_descriptor``, ``descriptor_name``, and ``descriptor_directory`` are properly set.
+
 Model simulation
 ----------------
 

--- a/smash/core/model/_standardize.py
+++ b/smash/core/model/_standardize.py
@@ -423,8 +423,10 @@ def _standardize_model_setup_descriptor_directory(
     return _standardize_model_setup_directory(read_descriptor, "descriptor_directory", descriptor_directory)
 
 
-def _standardize_model_setup_descriptor_name(descriptor_name: ListLike | None, **kwargs) -> np.ndarray:
-    if descriptor_name is None:
+def _standardize_model_setup_descriptor_name(
+    read_descriptor: bool, descriptor_name: ListLike | None, **kwargs
+) -> np.ndarray:
+    if (not read_descriptor) or (descriptor_name is None):
         descriptor_name = np.empty(shape=0)
     elif isinstance(descriptor_name, (list, tuple, np.ndarray)):
         descriptor_name = np.array(descriptor_name, ndmin=1)
@@ -518,7 +520,7 @@ def _standardize_model_setup_finalize(setup: dict):
     setup["n_layers"] = max(0, np.count_nonzero(setup["neurons"]) - 1)
 
     setup["ntime_step"] = int((setup["end_time"] - setup["start_time"]).total_seconds() / setup["dt"])
-    setup["nd"] = setup["descriptor_name"].size
+    setup["nd"] = setup["descriptor_name"].size if setup["read_descriptor"] else 0
     setup["nrrp"] = len(STRUCTURE_RR_PARAMETERS[setup["structure"]])
     setup["nrrs"] = len(STRUCTURE_RR_STATES[setup["structure"]])
     setup["nsep_mu"] = len(SERR_MU_MAPPING_PARAMETERS[setup["serr_mu_mapping"]])

--- a/smash/core/simulation/_standardize.py
+++ b/smash/core/simulation/_standardize.py
@@ -1143,7 +1143,11 @@ def _standardize_simulation_optimize_options_finalize(
 
     # % Check if decriptors are not found for regionalization mappings
     if model.setup.nd == 0 and mapping in REGIONAL_MAPPING:
-        raise ValueError(f"Physiographic descriptors are required for optimization with {mapping} mapping")
+        raise ValueError(
+            f"Physiographic descriptors are required for optimization with {mapping} mapping. "
+            f"Please check if read_descriptor, descriptor_name and descriptor_directory "
+            f"are properly defined in the model setup."
+        )
 
     descriptor_present = "descriptor" in optimize_options
 


### PR DESCRIPTION
When using regional mappings (ANN, multi-linear, ..), if users set a list of ``descriptor_name`` but forget to set ``read_descriptor`` to True, the descriptor Fortran derived type is still initialized with -99 values, causing NaN gradients during optimization. This PR fix this issue with the following changes:
- Defines ``setup.nd`` (number of descriptors) based on both ``descriptor_name`` and ``read_descriptor``.
- Sets ``descriptor_name`` to an empty array if ``read_descriptor`` is set to False.
- Clarifies the error message in the optimization routine.
- Adds a note to the user guide.

Now, if the parameters related to descriptors in the setup are not properly defined, users will receive a clearer error message when optimizing with regional mappings.