### PR TITLE
MAINT: Temporarily drop windows support

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,9 +27,10 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        # Use windows-2019 otherwise there is undefined reference to _setjmpex. This is linked to f90wrap
-        # and f90wrap_abort with FortranDerivedTypeArray
-        - [windows-2019, win, AMD64]
+        # # Use windows-2019 otherwise there is undefined reference to _setjmpex. This is linked to f90wrap
+        # # and f90wrap_abort with FortranDerivedTypeArray
+        # - [windows-2019, win, AMD64]  
+        # Temporarily dropped due to build issues with windows-2022 (windows-2019 is no longer supported)
         - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -16,6 +16,10 @@ versions |min_py_version| to |max_py_version|.
     We strongly recommend using `smash` on **Linux** or **macOS**, particularly if you are using it on a
     large dataset, as Fortran parallel computation is not supported on **Windows**.
 
+.. warning::
+
+    Windows support is temporarily unavailable starting from `smash` v1.1.1 due to wheel build issues.
+
 If you already have Python, you can install `smash` with:
 
 .. code-block:: none


### PR DESCRIPTION
Due to the deprecation of the Windows 2019 Actions runner image (https://github.com/actions/runner-images/issues/12045) and an unresolved issue related to wheel creation on windows-2022 when compiling f90wrap (https://github.com/DassHydro/smash/issues/433), Windows support for smash is temporarily unavailable.