### PR TITLE
MAINT: Windows wheel

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,10 +27,7 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        # # Use windows-2019 otherwise there is undefined reference to _setjmpex. This is linked to f90wrap
-        # # and f90wrap_abort with FortranDerivedTypeArray
-        # - [windows-2019, win, AMD64]  
-        # Temporarily dropped due to build issues with windows-2022 (windows-2019 is no longer supported)
+        - [windows-2022, win, amd64]
         - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        - [windows-2022, win, AMD64]
+        - [windows-latest, win, AMD64]
         - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]
-        - [windows-2022, win, amd64]
+        - [windows-2022, win, AMD64]
         - [macos-13, macosx, x86_64]
         - [macos-14, macosx, arm64]
 

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -15,10 +15,6 @@ It can also be installed directly from its source repository on GitHub.
 
     We strongly recommend using `smash` on **Linux** or **macOS**, especially when working with large datasets, as Fortran parallel computation is not supported on **Windows**.
 
-.. warning::
-
-    Windows support is temporarily unavailable starting from `smash` v1.1.1 due to wheel build issues.
-
 To install the latest released version, run:
 
 .. code-block:: none

--- a/f90wrap/generate_f2py-f90wrap.py
+++ b/f90wrap/generate_f2py-f90wrap.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Note: This file is a wrapper around f90wrap to handle smash specific features and meson build system
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def generate_f2py_f90wrap_files(fortran_files: list[str], module: str, build_dir: str) -> None:
+    cmd_args = [
+        "f2py-f90wrap",
+        "-m",
+        module,
+        "--lower",
+        "--build-dir",
+        build_dir,
+    ]
+
+    cmd_args.extend(fortran_files)
+
+    subprocess.run(cmd_args, check=True)
+
+
+def patch_c_file(module: str, build_dir: str) -> None:
+    # Patch the generated C file to replace setjmpex with setjmp header. This is necessary to build on
+    # Windows 2022 (and later).
+    if sys.platform == "win32":
+        libfile = os.path.join(build_dir, f"{module}module.c")
+        with open(libfile, "r+") as f:
+            buffer = f.read()
+            buffer = re.sub("setjmpex.h", "setjmp.h", buffer, flags=re.DOTALL)
+            f.seek(0)
+            f.write(buffer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "fortran_files",
+        nargs="+",
+        type=str,
+        help="Paths to fortran files in order to generate f2py-f90wrap files",
+    )
+    parser.add_argument(
+        "-m",
+        "--module",
+        default="mod",
+        type=str,
+        help="Name of the module",
+        required=False,
+    )
+    parser.add_argument(
+        "--build-dir",
+        default=".",
+        type=str,
+        help="All f2py-f90wrap generated files are created in this directory",
+        required=False,
+    )
+    args = parser.parse_args()
+
+    generate_f2py_f90wrap_files(args.fortran_files, args.module, args.build_dir)
+
+    patch_c_file(args.module, args.build_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/smash/fcore/meson.build
+++ b/smash/fcore/meson.build
@@ -126,7 +126,12 @@ foreach i : range(f90wrap_f90_output.length())
     f90wrap_f90_sources += f90wrap_sources[i]
 endforeach
 
-f2py_f90wrap = ['f2py-f90wrap', '@INPUT@', '--build-dir', '@OUTDIR@', '--lower']
+f2py_f90wrap = [
+    py,
+    files('../../f90wrap/generate_f2py-f90wrap.py'),
+    '@INPUT@',
+    '--build-dir', '@OUTDIR@',
+]
 
 f2py_f90wrap_sources = custom_target(
     input: f90wrap_f90_sources,


### PR DESCRIPTION
Update of Windows wheel building on GitHub actions:
- Switch to Windows 2022 runner
- Patch f2py C file to handle _setjmpex linking error (use setjmp.h instead of setjmpex.h) 