### PR TITLE
MAINT: changing mapping name multi-polynomial to multi-power

### DIFF
--- a/doc/source/math_num_documentation/mapping.rst
+++ b/doc/source/math_num_documentation/mapping.rst
@@ -200,8 +200,8 @@ with :math:`l_i` and :math:`u_i` the bound constraint on the :math:`i^{th}` conc
 :math:`l_i < \theta_i(x) < u_i, i\in[1..N_{\theta}]` and for conceptual states :math:`l_i < h_{0_s} < u_i,\; i=N_{\theta}+s, \; s\in [1..N_h]`.
 
 
-Multi-Polynomial
-----------------
+Multi-Power
+-----------
 
 This mapping is analoguous to the multi-linear mapping but with optimizable exponents applied to each physical descriptor.
 

--- a/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
+++ b/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
@@ -67,14 +67,14 @@ The values of these descriptors can be obtained in the ``physio_data`` derived t
 Model simulation
 ----------------
 
-Multiple linear/polynomial mapping
-**********************************
+Multiple linear/power mapping
+*****************************
 
 Two classical approaches are commonly used for regionalization to map descriptors to parameters:
 
-- ``multi-linear``: a linear mapping where the optimizable parameters are the coefficients.
+- ``multi-linear``: a multiple linear mapping where the optimizable parameters are the coefficients.
 
-- ``multi-polynomial``: a polynomial mapping where the optimizable parameters include both the coefficients and the degree.
+- ``multi-power``: a multiple power mapping where the optimizable parameters include both the coefficients and the degree.
 
 In this example, we use the multi-linear mapping. Before optimizing the model, it is recommended to provide a first guess for the control vector  
 (see explanation on :ref:`first guess selection <math_num_documentation.mapping.spatially_uniform.first_guess>` for details).

--- a/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
+++ b/doc/source/user_guide/classical_uses/regionalization_spatial_validation.rst
@@ -74,7 +74,7 @@ Two classical approaches are commonly used for regionalization to map descriptor
 
 - ``multi-linear``: a multiple linear mapping where the optimizable parameters are the coefficients.
 
-- ``multi-power``: a multiple power mapping where the optimizable parameters include both the coefficients and the degree.
+- ``multi-power``: a multiple power mapping where the optimizable parameters include both the coefficients and the exponents.
 
 In this example, we use the multi-linear mapping. Before optimizing the model, it is recommended to provide a first guess for the control vector  
 (see explanation on :ref:`first guess selection <math_num_documentation.mapping.spatially_uniform.first_guess>` for details).

--- a/doc/source/user_guide/in_depth/bayesian_estimation.rst
+++ b/doc/source/user_guide/in_depth/bayesian_estimation.rst
@@ -129,7 +129,7 @@ Bayesian estimation works in a very similar way, with two notable differences:
 
 For simplicity, we will use the default optimization options as above for the rest of the tutorial, so there is no need to define ``optimize_options`` in `smash.bayesian_optimize`.
 Additionally, we will use the simplest mapping, which is uniform mapping.
-However, this Bayesian approach can also be applied to more complex mappings such as distributed mapping or multiple polynomial mappings.
+However, this Bayesian approach can also be applied to more complex mappings such as distributed mapping or multiple linear/power mappings.
 
 .. warning::
 	The Bayesian estimation approach is currently not supported for neural network-based mappings (``mapping='ann'``).

--- a/doc/source/user_guide/in_depth/retrieving_control_parameters.rst
+++ b/doc/source/user_guide/in_depth/retrieving_control_parameters.rst
@@ -200,7 +200,7 @@ Finally, we can continue the calibration using the starting point defined by the
 As observed, the optimization process resumes from the previously interrupted point, with the initial cost value being the same as the one at iteration 5 from the previous calibration.
 
 .. warning::
-    Due to technical limitations, the continuous calibration process currently does not work with ``mapping='multi-linear'`` or ``mapping='multi-polynomial'``.
+    Due to technical limitations, the continuous calibration process currently does not work with ``mapping='multi-linear'`` or ``mapping='multi-power'``.
     However, you can still set the control values to the model to retrieve the model parameters and then perform a forward run to update the hydrological responses and final states.
 
     .. code-block:: python
@@ -225,7 +225,7 @@ As observed, the optimization process resumes from the previously interrupted po
         </> Forward Run
             Cost value (1-NSE) = 0.30294644832611084
 
-    Continuous calibration currently does not work with multiple polynomial mappings.
+    Continuous calibration currently does not work with multiple linear and multiple power mappings.
     However, for multiple linear mapping, an alternative solution to continue the calibration process from an obtained control vector is to create a neural network without hidden layers (equivalent to multiple linear regression) and set the obtained control vector as the initial weights of the neural network. 
     You can then continue to calibrate the model with ``mapping='ann'``.
 

--- a/smash/_constant.py
+++ b/smash/_constant.py
@@ -834,7 +834,7 @@ PROBLEM_KEYS = ["num_vars", "names", "bounds"]
 ### SIMULATION ###
 ##################
 
-REGIONAL_MAPPING = ["multi-linear", "multi-polynomial", "ann"]
+REGIONAL_MAPPING = ["multi-linear", "multi-power", "ann"]
 
 MAPPING = ["uniform", "distributed"] + REGIONAL_MAPPING
 
@@ -853,7 +853,7 @@ MAPPING_OPTIMIZER = dict(
             OPTIMIZER,  # for uniform mapping (all optimizers are possible, default is sbs)
             *(
                 [GRADIENT_BASED_OPTIMIZER] * 3
-            ),  # for distributed, multi-linear, multi-polynomial mappings (default is lbfgsb)
+            ),  # for distributed, multi-linear, multi-power mappings (default is lbfgsb)
             ADAPTIVE_OPTIMIZER,  # for ann mapping (default is adam)
         ],
     )
@@ -956,7 +956,7 @@ SIMULATION_OPTIMIZE_OPTIONS_KEYS = {
         "descriptor",
         "termination_crit",
     ],
-    ("multi-polynomial", "lbfgsb"): [
+    ("multi-power", "lbfgsb"): [
         "parameters",
         "bounds",
         "control_tfm",
@@ -965,7 +965,7 @@ SIMULATION_OPTIMIZE_OPTIONS_KEYS = {
     ],
     **dict(
         zip(
-            itertools.product(["multi-linear", "multi-polynomial"], ADAPTIVE_OPTIMIZER),
+            itertools.product(["multi-linear", "multi-power"], ADAPTIVE_OPTIMIZER),
             2
             * len(ADAPTIVE_OPTIMIZER)
             * [
@@ -979,7 +979,7 @@ SIMULATION_OPTIMIZE_OPTIONS_KEYS = {
                 ]
             ],
         )
-    ),  # product between 2 mappings (multi-linear, multi-polynomial) and all adaptive optimizers
+    ),  # product between 2 mappings (multi-linear, multi-power) and all adaptive optimizers
     **dict(
         zip(
             [("ann", optimizer) for optimizer in ADAPTIVE_OPTIMIZER],

--- a/smash/core/simulation/_doc.py
+++ b/smash/core/simulation/_doc.py
@@ -83,7 +83,7 @@ MAPPING_OPTIMIZER_BASE_DOC = {
         - ``'uniform'``
         - ``'distributed'``
         - ``'multi-linear'``
-        - ``'multi-polynomial'``
+        - ``'multi-power'``
         %(mapping_ann)s
 
         .. hint::
@@ -110,7 +110,7 @@ MAPPING_OPTIMIZER_BASE_DOC = {
             If not given, a default optimizer will be set as follows:
 
             - ``'sbs'`` for **mapping** = ``'uniform'``
-            - ``'lbfgsb'`` for **mapping** = ``'distributed'``, ``'multi-linear'``, ``'multi-polynomial'``
+            - ``'lbfgsb'`` for **mapping** = ``'distributed'``, ``'multi-linear'``, ``'multi-power'``
             %(default_optimizer_for_ann_mapping)s
 
         .. hint::
@@ -205,7 +205,7 @@ OPTIMIZE_OPTIONS_BASE_DOC = {
 
         .. note::
             If not given, all descriptors will be used for each parameter.
-            This option is only be used when **mapping** is ``'multi-linear'`` or ``'multi-polynomial'``.
+            This option is only be used when **mapping** is ``'multi-linear'`` or ``'multi-power'``.
             In case of ``'ann'``, all descriptors will be used.
         """,
     ),
@@ -1263,12 +1263,12 @@ optimize_options : `dict[str, Any]` or None, default None
     - name : `numpy.ndarray`
         An array of shape *(n,)* containing the names of the control vector. The naming convention is:
 
-        - ``<key>-0``: Spatially uniform parameter or multi-linear/polynomial intercept where ``<key>`` is the
+        - ``<key>-0``: Spatially uniform parameter or multi-linear/power intercept where ``<key>`` is the
           name of any rainfall-runoff parameters or initial_states (``'cp-0'``, ``'llr-0'``, ``'ht-0'``, etc).
         - ``<key>-<row>-<col>``: Spatially distributed parameter where ``<key>`` is the name of any
           rainfall-runoff parameters or initial_states and ``<row>``, ``<col>``, the corresponding position in
           the spatial domain (``'cp-1-1'``, ``'llr-20-2'``, ``'ht-3-12'``, etc). It's one based indexing.
-        - ``<key>-<desc>-<kind>``: Multi-linear/polynomial descriptor linked parameter where ``<key>`` is the
+        - ``<key>-<desc>-<kind>``: Multi-linear/power descriptor linked parameter where ``<key>`` is the
           name of any rainfall-runoff parameters or initial_states, ``<desc>`` the corresponding descriptor
           and ``<kind>``, the kind of parameter (coefficient or exposant) (``'cp-slope-a'``,
           ``'llr-slope-b'``, ``'ht-dd-a'``).
@@ -1380,12 +1380,12 @@ cost_options : `dict[str, Any]` or None, default None
     - name : `numpy.ndarray`
         An array of shape *(n,)* containing the names of the control vector. The naming convention is:
 
-        - ``<key>-0``: Spatially uniform parameter or multi-linear/polynomial intercept where ``<key>`` is the
+        - ``<key>-0``: Spatially uniform parameter or multi-linear/power intercept where ``<key>`` is the
           name of any rainfall-runoff parameters or initial_states (``'cp-0'``, ``'llr-0'``, ``'ht-0'``, etc).
         - ``<key>-<row>-<col>``: Spatially distributed parameter where ``<key>`` is the name of any
           rainfall-runoff parameters or initial_states and ``<row>``, ``<col>``, the corresponding position in
           the spatial domain (``'cp-1-1'``, ``'llr-20-2'``, ``'ht-3-12'``, etc). It's one based indexing.
-        - ``<key>-<desc>-<kind>``: Multi-linear/polynomial descriptor linked parameter where ``<key>`` is the
+        - ``<key>-<desc>-<kind>``: Multi-linear/power descriptor linked parameter where ``<key>`` is the
           name of any rainfall-runoff parameters or initial_states, ``<desc>`` the corresponding descriptor
           and ``<kind>``, the kind of parameter (coefficient or exposant) (``'cp-slope-a'``,
           ``'llr-slope-b'``, ``'ht-dd-a'``).

--- a/smash/fcore/forward/forward_db.f90
+++ b/smash/fcore/forward/forward_db.f90
@@ -5443,8 +5443,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_get_control_size
 !%      - multi_linear_rr_parameters_get_control_size
 !%      - multi_linear_rr_initial_states_get_control_size
-!%      - multi_polynomial_rr_parameters_get_control_size
-!%      - multi_polynomial_rr_initial_states_get_control_size
+!%      - multi_power_rr_parameters_get_control_size
+!%      - multi_power_rr_initial_states_get_control_size
 !%      - serr_mu_parameters_get_control_size
 !%      - nn_parameters_get_control_size
 !%      - get_control_sizes
@@ -5454,8 +5454,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_fill_control
 !%      - multi_linear_rr_parameters_fill_control
 !%      - multi_linear_rr_initial_states_fill_control
-!%      - multi_polynomial_rr_parameters_fill_control
-!%      - multi_polynomial_rr_initial_states_fill_control
+!%      - multi_power_rr_parameters_fill_control
+!%      - multi_power_rr_initial_states_fill_control
 !%      - serr_mu_parameters_fill_control
 !%      - serr_sigma_parameters_fill_control
 !%      - nn_parameters_fill_control
@@ -5466,8 +5466,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_fill_parameters
 !%      - multi_linear_rr_parameters_fill_parameters
 !%      - multi_linear_rr_initial_states_fill_parameters
-!%      - multi_polynomial_rr_parameters_fill_parameters
-!%      - multi_polynomial_rr_initial_states_fill_parameters
+!%      - multi_power_rr_parameters_fill_parameters
+!%      - multi_power_rr_initial_states_fill_parameters
 !%      - serr_mu_parameters_fill_parameters
 !%      - serr_sigma_parameters_fill_parameters
 !%      - nn_parameters_fill_parameters
@@ -6326,8 +6326,8 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_GET_CONTROL_SIZE
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE(setup, &
-&   options, n)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE(setup, options, &
+&   n)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(OPTIONSDT), INTENT(IN) :: options
@@ -6339,9 +6339,9 @@ CONTAINS
       IF (options%optimize%rr_parameters(i) .NE. 0) n = n + 1 + 2*SUM(&
 &         options%optimize%rr_parameters_descriptor(:, i))
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
 &   options, n)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
@@ -6354,7 +6354,7 @@ CONTAINS
       IF (options%optimize%rr_initial_states(i) .NE. 0) n = n + 1 + 2*&
 &         SUM(options%optimize%rr_initial_states_descriptor(:, i))
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE
 
   SUBROUTINE SERR_MU_PARAMETERS_GET_CONTROL_SIZE(options, n)
     IMPLICIT NONE
@@ -6408,12 +6408,11 @@ CONTAINS
 &                                                nbk(1))
       CALL MULTI_LINEAR_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
 &                                                    options, nbk(2))
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE(setup, &
-&                                                    options, nbk(1))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
-&                                                        options, nbk(2)&
-&                                                       )
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE(setup, options, &
+&                                               nbk(1))
+      CALL MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, options&
+&                                                   , nbk(2))
     CASE ('ann') 
       nbk(1) = 0
       nbk(2) = 0
@@ -6633,7 +6632,7 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_FILL_CONTROL
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
 &   parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
@@ -6677,10 +6676,10 @@ CONTAINS
         END DO
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_CONTROL
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh&
-&   , parameters, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
+&   parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -6725,7 +6724,7 @@ CONTAINS
         END DO
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL
 
   SUBROUTINE SERR_MU_PARAMETERS_FILL_CONTROL(setup, mesh, parameters, &
 &   options)
@@ -6889,12 +6888,11 @@ CONTAINS
 &                                            parameters, options)
       CALL MULTI_LINEAR_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
 &                                                parameters, options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
-&                                                parameters, options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
-&                                                    parameters, options&
-&                                                   )
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
+&                                           parameters, options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
+&                                               parameters, options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_CONTROL(setup, mesh, parameters, &
@@ -7652,13 +7650,13 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_FILL_PARAMETERS
 
-!  Differentiation of multi_polynomial_rr_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE
-! context):
+!  Differentiation of multi_power_rr_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE cont
+!ext):
 !   variations   of useful results: *(parameters.rr_parameters.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_parameters.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D(setup, &
-&   mesh, input_data, parameters, parameters_d, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, &
+&   input_data, parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7706,15 +7704,15 @@ CONTAINS
 &                          rr_parameters%values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D
 
-!  Differentiation of multi_polynomial_rr_parameters_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE
-! context):
+!  Differentiation of multi_power_rr_parameters_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE cont
+!ext):
 !   gradient     of useful results: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_parameters.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B(setup, &
-&   mesh, input_data, parameters, parameters_b, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh, &
+&   input_data, parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7798,10 +7796,10 @@ CONTAINS
         CALL POPINTEGER4(j)
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh&
-&   , input_data, parameters, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&   input_data, parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7835,15 +7833,15 @@ CONTAINS
 &                        values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS
 
-!  Differentiation of multi_polynomial_rr_initial_states_fill_parameters in forward (tangent) mode (with options fixinterface noI
-!SIZE context):
+!  Differentiation of multi_power_rr_initial_states_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE 
+!context):
 !   variations   of useful results: *(parameters.rr_initial_states.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_initial_states.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup&
-&   , mesh, input_data, parameters, parameters_d, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, mesh&
+&   , input_data, parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7892,15 +7890,15 @@ CONTAINS
 &                          ))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D
 
-!  Differentiation of multi_polynomial_rr_initial_states_fill_parameters in reverse (adjoint) mode (with options fixinterface noI
-!SIZE context):
+!  Differentiation of multi_power_rr_initial_states_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE 
+!context):
 !   gradient     of useful results: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_initial_states.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup&
-&   , mesh, input_data, parameters, parameters_b, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, mesh&
+&   , input_data, parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7985,10 +7983,10 @@ CONTAINS
         CALL POPINTEGER4(j)
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&   mesh, input_data, parameters, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&   input_data, parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -8022,7 +8020,7 @@ CONTAINS
 &                        values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS
 
 !  Differentiation of serr_mu_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE context):
 !   variations   of useful results: *(parameters.serr_mu_parameters.values)
@@ -8575,18 +8573,16 @@ CONTAINS
 &                                                     parameters, &
 &                                                     parameters_d, &
 &                                                     options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh&
-&                                                     , input_data, &
-&                                                     parameters, &
-&                                                     parameters_d, &
-&                                                     options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, &
-&                                                         mesh, &
-&                                                         input_data, &
-&                                                         parameters, &
-&                                                         parameters_d, &
-&                                                         options)
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, &
+&                                                input_data, parameters&
+&                                                , parameters_d, options&
+&                                               )
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, mesh, &
+&                                                    input_data, &
+&                                                    parameters, &
+&                                                    parameters_d, &
+&                                                    options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, parameters, &
@@ -8667,22 +8663,21 @@ CONTAINS
 &                                                   input_data, &
 &                                                   parameters, options)
       CALL PUSHCONTROL3B(3)
-    CASE ('multi-polynomial') 
+    CASE ('multi-power') 
       CALL PUSHREAL4ARRAY(parameters%rr_parameters%values, SIZE(&
 &                   parameters%rr_parameters%values, 1)*SIZE(parameters%&
 &                   rr_parameters%values, 2)*SIZE(parameters%&
 &                   rr_parameters%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
-&                                                   input_data, &
-&                                                   parameters, options)
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&                                              input_data, parameters, &
+&                                              options)
       CALL PUSHREAL4ARRAY(parameters%rr_initial_states%values, SIZE(&
 &                   parameters%rr_initial_states%values, 1)*SIZE(&
 &                   parameters%rr_initial_states%values, 2)*SIZE(&
 &                   parameters%rr_initial_states%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&                                                       mesh, input_data&
-&                                                       , parameters, &
-&                                                       options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&                                                  input_data, &
+&                                                  parameters, options)
       CALL PUSHCONTROL3B(4)
     CASE DEFAULT
       CALL PUSHCONTROL3B(0)
@@ -8787,21 +8782,19 @@ CONTAINS
 &                  parameters%rr_initial_states%values, 1)*SIZE(&
 &                  parameters%rr_initial_states%values, 2)*SIZE(&
 &                  parameters%rr_initial_states%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, &
-&                                                         mesh, &
-&                                                         input_data, &
-&                                                         parameters, &
-&                                                         parameters_b, &
-&                                                         options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, mesh, &
+&                                                    input_data, &
+&                                                    parameters, &
+&                                                    parameters_b, &
+&                                                    options)
       CALL POPREAL4ARRAY(parameters%rr_parameters%values, SIZE(&
 &                  parameters%rr_parameters%values, 1)*SIZE(parameters%&
 &                  rr_parameters%values, 2)*SIZE(parameters%&
 &                  rr_parameters%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh&
-&                                                     , input_data, &
-&                                                     parameters, &
-&                                                     parameters_b, &
-&                                                     options)
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh, &
+&                                                input_data, parameters&
+&                                                , parameters_b, options&
+&                                               )
     END IF
   END SUBROUTINE FILL_PARAMETERS_B
 
@@ -8831,14 +8824,13 @@ CONTAINS
       CALL MULTI_LINEAR_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
 &                                                   input_data, &
 &                                                   parameters, options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
-&                                                   input_data, &
-&                                                   parameters, options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&                                                       mesh, input_data&
-&                                                       , parameters, &
-&                                                       options)
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&                                              input_data, parameters, &
+&                                              options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&                                                  input_data, &
+&                                                  parameters, options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_PARAMETERS(setup, mesh, parameters, &

--- a/smash/fcore/forward/forward_openmp_db.f90
+++ b/smash/fcore/forward/forward_openmp_db.f90
@@ -5443,8 +5443,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_get_control_size
 !%      - multi_linear_rr_parameters_get_control_size
 !%      - multi_linear_rr_initial_states_get_control_size
-!%      - multi_polynomial_rr_parameters_get_control_size
-!%      - multi_polynomial_rr_initial_states_get_control_size
+!%      - multi_power_rr_parameters_get_control_size
+!%      - multi_power_rr_initial_states_get_control_size
 !%      - serr_mu_parameters_get_control_size
 !%      - nn_parameters_get_control_size
 !%      - get_control_sizes
@@ -5454,8 +5454,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_fill_control
 !%      - multi_linear_rr_parameters_fill_control
 !%      - multi_linear_rr_initial_states_fill_control
-!%      - multi_polynomial_rr_parameters_fill_control
-!%      - multi_polynomial_rr_initial_states_fill_control
+!%      - multi_power_rr_parameters_fill_control
+!%      - multi_power_rr_initial_states_fill_control
 !%      - serr_mu_parameters_fill_control
 !%      - serr_sigma_parameters_fill_control
 !%      - nn_parameters_fill_control
@@ -5466,8 +5466,8 @@ END MODULE MWD_SIGNATURES_DIFF
 !%      - distributed_rr_initial_states_fill_parameters
 !%      - multi_linear_rr_parameters_fill_parameters
 !%      - multi_linear_rr_initial_states_fill_parameters
-!%      - multi_polynomial_rr_parameters_fill_parameters
-!%      - multi_polynomial_rr_initial_states_fill_parameters
+!%      - multi_power_rr_parameters_fill_parameters
+!%      - multi_power_rr_initial_states_fill_parameters
 !%      - serr_mu_parameters_fill_parameters
 !%      - serr_sigma_parameters_fill_parameters
 !%      - nn_parameters_fill_parameters
@@ -6326,8 +6326,8 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_GET_CONTROL_SIZE
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE(setup, &
-&   options, n)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE(setup, options, &
+&   n)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(OPTIONSDT), INTENT(IN) :: options
@@ -6339,9 +6339,9 @@ CONTAINS
       IF (options%optimize%rr_parameters(i) .NE. 0) n = n + 1 + 2*SUM(&
 &         options%optimize%rr_parameters_descriptor(:, i))
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
 &   options, n)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
@@ -6354,7 +6354,7 @@ CONTAINS
       IF (options%optimize%rr_initial_states(i) .NE. 0) n = n + 1 + 2*&
 &         SUM(options%optimize%rr_initial_states_descriptor(:, i))
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE
 
   SUBROUTINE SERR_MU_PARAMETERS_GET_CONTROL_SIZE(options, n)
     IMPLICIT NONE
@@ -6408,12 +6408,11 @@ CONTAINS
 &                                                nbk(1))
       CALL MULTI_LINEAR_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
 &                                                    options, nbk(2))
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_GET_CONTROL_SIZE(setup, &
-&                                                    options, nbk(1))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, &
-&                                                        options, nbk(2)&
-&                                                       )
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_GET_CONTROL_SIZE(setup, options, &
+&                                               nbk(1))
+      CALL MULTI_POWER_RR_INITIAL_STATES_GET_CONTROL_SIZE(setup, options&
+&                                                   , nbk(2))
     CASE ('ann') 
       nbk(1) = 0
       nbk(2) = 0
@@ -6633,7 +6632,7 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_FILL_CONTROL
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
 &   parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
@@ -6677,10 +6676,10 @@ CONTAINS
         END DO
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_CONTROL
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh&
-&   , parameters, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
+&   parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -6725,7 +6724,7 @@ CONTAINS
         END DO
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL
 
   SUBROUTINE SERR_MU_PARAMETERS_FILL_CONTROL(setup, mesh, parameters, &
 &   options)
@@ -6889,12 +6888,11 @@ CONTAINS
 &                                            parameters, options)
       CALL MULTI_LINEAR_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
 &                                                parameters, options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
-&                                                parameters, options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
-&                                                    parameters, options&
-&                                                   )
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_CONTROL(setup, mesh, &
+&                                           parameters, options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_CONTROL(setup, mesh, &
+&                                               parameters, options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_CONTROL(setup, mesh, parameters, &
@@ -7652,13 +7650,13 @@ CONTAINS
     END DO
   END SUBROUTINE MULTI_LINEAR_RR_INITIAL_STATES_FILL_PARAMETERS
 
-!  Differentiation of multi_polynomial_rr_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE
-! context OpenMP):
+!  Differentiation of multi_power_rr_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE cont
+!ext OpenMP):
 !   variations   of useful results: *(parameters.rr_parameters.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_parameters.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D(setup, &
-&   mesh, input_data, parameters, parameters_d, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, &
+&   input_data, parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7706,15 +7704,15 @@ CONTAINS
 &                          rr_parameters%values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D
 
-!  Differentiation of multi_polynomial_rr_parameters_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE
-! context OpenMP):
+!  Differentiation of multi_power_rr_parameters_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE cont
+!ext OpenMP):
 !   gradient     of useful results: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_parameters.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_parameters.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B(setup, &
-&   mesh, input_data, parameters, parameters_b, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh, &
+&   input_data, parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7798,10 +7796,10 @@ CONTAINS
         CALL POPINTEGER4(j)
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh&
-&   , input_data, parameters, options)
+  SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&   input_data, parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7835,15 +7833,15 @@ CONTAINS
 &                        values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS
+  END SUBROUTINE MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS
 
-!  Differentiation of multi_polynomial_rr_initial_states_fill_parameters in forward (tangent) mode (with options fixinterface noI
-!SIZE context OpenMP):
+!  Differentiation of multi_power_rr_initial_states_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE 
+!context OpenMP):
 !   variations   of useful results: *(parameters.rr_initial_states.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_initial_states.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup&
-&   , mesh, input_data, parameters, parameters_d, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, mesh&
+&   , input_data, parameters, parameters_d, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7892,15 +7890,15 @@ CONTAINS
 &                          ))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D
 
-!  Differentiation of multi_polynomial_rr_initial_states_fill_parameters in reverse (adjoint) mode (with options fixinterface noI
-!SIZE context OpenMP):
+!  Differentiation of multi_power_rr_initial_states_fill_parameters in reverse (adjoint) mode (with options fixinterface noISIZE 
+!context OpenMP):
 !   gradient     of useful results: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   with respect to varying inputs: *(parameters.control.x) *(parameters.rr_initial_states.values)
 !   Plus diff mem management of: parameters.control.x:in parameters.rr_initial_states.values:in
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup&
-&   , mesh, input_data, parameters, parameters_b, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, mesh&
+&   , input_data, parameters, parameters_b, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -7985,10 +7983,10 @@ CONTAINS
         CALL POPINTEGER4(j)
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B
 
-  SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&   mesh, input_data, parameters, options)
+  SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&   input_data, parameters, options)
     IMPLICIT NONE
     TYPE(SETUPDT), INTENT(IN) :: setup
     TYPE(MESHDT), INTENT(IN) :: mesh
@@ -8022,7 +8020,7 @@ CONTAINS
 &                        values(:, :, i))
       END IF
     END DO
-  END SUBROUTINE MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS
+  END SUBROUTINE MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS
 
 !  Differentiation of serr_mu_parameters_fill_parameters in forward (tangent) mode (with options fixinterface noISIZE context Ope
 !nMP):
@@ -8577,18 +8575,16 @@ CONTAINS
 &                                                     parameters, &
 &                                                     parameters_d, &
 &                                                     options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh&
-&                                                     , input_data, &
-&                                                     parameters, &
-&                                                     parameters_d, &
-&                                                     options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, &
-&                                                         mesh, &
-&                                                         input_data, &
-&                                                         parameters, &
-&                                                         parameters_d, &
-&                                                         options)
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, &
+&                                                input_data, parameters&
+&                                                , parameters_d, options&
+&                                               )
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_D(setup, mesh, &
+&                                                    input_data, &
+&                                                    parameters, &
+&                                                    parameters_d, &
+&                                                    options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_PARAMETERS_D(setup, mesh, parameters, &
@@ -8669,22 +8665,21 @@ CONTAINS
 &                                                   input_data, &
 &                                                   parameters, options)
       CALL PUSHCONTROL3B(3)
-    CASE ('multi-polynomial') 
+    CASE ('multi-power') 
       CALL PUSHREAL4ARRAY(parameters%rr_parameters%values, SIZE(&
 &                   parameters%rr_parameters%values, 1)*SIZE(parameters%&
 &                   rr_parameters%values, 2)*SIZE(parameters%&
 &                   rr_parameters%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
-&                                                   input_data, &
-&                                                   parameters, options)
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&                                              input_data, parameters, &
+&                                              options)
       CALL PUSHREAL4ARRAY(parameters%rr_initial_states%values, SIZE(&
 &                   parameters%rr_initial_states%values, 1)*SIZE(&
 &                   parameters%rr_initial_states%values, 2)*SIZE(&
 &                   parameters%rr_initial_states%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&                                                       mesh, input_data&
-&                                                       , parameters, &
-&                                                       options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&                                                  input_data, &
+&                                                  parameters, options)
       CALL PUSHCONTROL3B(4)
     CASE DEFAULT
       CALL PUSHCONTROL3B(0)
@@ -8789,21 +8784,19 @@ CONTAINS
 &                  parameters%rr_initial_states%values, 1)*SIZE(&
 &                  parameters%rr_initial_states%values, 2)*SIZE(&
 &                  parameters%rr_initial_states%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, &
-&                                                         mesh, &
-&                                                         input_data, &
-&                                                         parameters, &
-&                                                         parameters_b, &
-&                                                         options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS_B(setup, mesh, &
+&                                                    input_data, &
+&                                                    parameters, &
+&                                                    parameters_b, &
+&                                                    options)
       CALL POPREAL4ARRAY(parameters%rr_parameters%values, SIZE(&
 &                  parameters%rr_parameters%values, 1)*SIZE(parameters%&
 &                  rr_parameters%values, 2)*SIZE(parameters%&
 &                  rr_parameters%values, 3))
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh&
-&                                                     , input_data, &
-&                                                     parameters, &
-&                                                     parameters_b, &
-&                                                     options)
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS_B(setup, mesh, &
+&                                                input_data, parameters&
+&                                                , parameters_b, options&
+&                                               )
     END IF
   END SUBROUTINE FILL_PARAMETERS_B
 
@@ -8833,14 +8826,13 @@ CONTAINS
       CALL MULTI_LINEAR_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
 &                                                   input_data, &
 &                                                   parameters, options)
-    CASE ('multi-polynomial') 
-      CALL MULTI_POLYNOMIAL_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
-&                                                   input_data, &
-&                                                   parameters, options)
-      CALL MULTI_POLYNOMIAL_RR_INITIAL_STATES_FILL_PARAMETERS(setup, &
-&                                                       mesh, input_data&
-&                                                       , parameters, &
-&                                                       options)
+    CASE ('multi-power') 
+      CALL MULTI_POWER_RR_PARAMETERS_FILL_PARAMETERS(setup, mesh, &
+&                                              input_data, parameters, &
+&                                              options)
+      CALL MULTI_POWER_RR_INITIAL_STATES_FILL_PARAMETERS(setup, mesh, &
+&                                                  input_data, &
+&                                                  parameters, options)
     END SELECT
 ! Directly working with hyper parameters
     CALL SERR_MU_PARAMETERS_FILL_PARAMETERS(setup, mesh, parameters, &

--- a/smash/fcore/routine/mwd_parameters_manipulation.f90
+++ b/smash/fcore/routine/mwd_parameters_manipulation.f90
@@ -31,8 +31,8 @@
 !%      - distributed_rr_initial_states_get_control_size
 !%      - multi_linear_rr_parameters_get_control_size
 !%      - multi_linear_rr_initial_states_get_control_size
-!%      - multi_polynomial_rr_parameters_get_control_size
-!%      - multi_polynomial_rr_initial_states_get_control_size
+!%      - multi_power_rr_parameters_get_control_size
+!%      - multi_power_rr_initial_states_get_control_size
 !%      - serr_mu_parameters_get_control_size
 !%      - nn_parameters_get_control_size
 !%      - get_control_sizes
@@ -42,8 +42,8 @@
 !%      - distributed_rr_initial_states_fill_control
 !%      - multi_linear_rr_parameters_fill_control
 !%      - multi_linear_rr_initial_states_fill_control
-!%      - multi_polynomial_rr_parameters_fill_control
-!%      - multi_polynomial_rr_initial_states_fill_control
+!%      - multi_power_rr_parameters_fill_control
+!%      - multi_power_rr_initial_states_fill_control
 !%      - serr_mu_parameters_fill_control
 !%      - serr_sigma_parameters_fill_control
 !%      - nn_parameters_fill_control
@@ -54,8 +54,8 @@
 !%      - distributed_rr_initial_states_fill_parameters
 !%      - multi_linear_rr_parameters_fill_parameters
 !%      - multi_linear_rr_initial_states_fill_parameters
-!%      - multi_polynomial_rr_parameters_fill_parameters
-!%      - multi_polynomial_rr_initial_states_fill_parameters
+!%      - multi_power_rr_parameters_fill_parameters
+!%      - multi_power_rr_initial_states_fill_parameters
 !%      - serr_mu_parameters_fill_parameters
 !%      - serr_sigma_parameters_fill_parameters
 !%      - nn_parameters_fill_parameters
@@ -674,7 +674,7 @@ contains
 
     end subroutine multi_linear_rr_initial_states_get_control_size
 
-    subroutine multi_polynomial_rr_parameters_get_control_size(setup, options, n)
+    subroutine multi_power_rr_parameters_get_control_size(setup, options, n)
 
         implicit none
 
@@ -694,9 +694,9 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_parameters_get_control_size
+    end subroutine multi_power_rr_parameters_get_control_size
 
-    subroutine multi_polynomial_rr_initial_states_get_control_size(setup, options, n)
+    subroutine multi_power_rr_initial_states_get_control_size(setup, options, n)
 
         implicit none
 
@@ -716,7 +716,7 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_initial_states_get_control_size
+    end subroutine multi_power_rr_initial_states_get_control_size
 
     subroutine serr_mu_parameters_get_control_size(options, n)
 
@@ -789,10 +789,10 @@ contains
             call multi_linear_rr_parameters_get_control_size(setup, options, nbk(1))
             call multi_linear_rr_initial_states_get_control_size(setup, options, nbk(2))
 
-        case ("multi-polynomial")
+        case ("multi-power")
 
-            call multi_polynomial_rr_parameters_get_control_size(setup, options, nbk(1))
-            call multi_polynomial_rr_initial_states_get_control_size(setup, options, nbk(2))
+            call multi_power_rr_parameters_get_control_size(setup, options, nbk(1))
+            call multi_power_rr_initial_states_get_control_size(setup, options, nbk(2))
 
         case ("ann")
 
@@ -1057,7 +1057,7 @@ contains
 
     end subroutine multi_linear_rr_initial_states_fill_control
 
-    subroutine multi_polynomial_rr_parameters_fill_control(setup, mesh, parameters, options)
+    subroutine multi_power_rr_parameters_fill_control(setup, mesh, parameters, options)
 
         implicit none
 
@@ -1111,9 +1111,9 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_parameters_fill_control
+    end subroutine multi_power_rr_parameters_fill_control
 
-    subroutine multi_polynomial_rr_initial_states_fill_control(setup, mesh, parameters, options)
+    subroutine multi_power_rr_initial_states_fill_control(setup, mesh, parameters, options)
 
         implicit none
 
@@ -1167,7 +1167,7 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_initial_states_fill_control
+    end subroutine multi_power_rr_initial_states_fill_control
 
     subroutine serr_mu_parameters_fill_control(setup, mesh, parameters, options)
 
@@ -1368,10 +1368,10 @@ contains
             call multi_linear_rr_parameters_fill_control(setup, mesh, parameters, options)
             call multi_linear_rr_initial_states_fill_control(setup, mesh, parameters, options)
 
-        case ("multi-polynomial")
+        case ("multi-power")
 
-            call multi_polynomial_rr_parameters_fill_control(setup, mesh, parameters, options)
-            call multi_polynomial_rr_initial_states_fill_control(setup, mesh, parameters, options)
+            call multi_power_rr_parameters_fill_control(setup, mesh, parameters, options)
+            call multi_power_rr_initial_states_fill_control(setup, mesh, parameters, options)
 
         end select
 
@@ -1620,7 +1620,7 @@ contains
 
     end subroutine multi_linear_rr_initial_states_fill_parameters
 
-    subroutine multi_polynomial_rr_parameters_fill_parameters(setup, mesh, input_data, parameters, options)
+    subroutine multi_power_rr_parameters_fill_parameters(setup, mesh, input_data, parameters, options)
 
         implicit none
 
@@ -1667,9 +1667,9 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_parameters_fill_parameters
+    end subroutine multi_power_rr_parameters_fill_parameters
 
-    subroutine multi_polynomial_rr_initial_states_fill_parameters(setup, mesh, input_data, parameters, options)
+    subroutine multi_power_rr_initial_states_fill_parameters(setup, mesh, input_data, parameters, options)
 
         implicit none
 
@@ -1716,7 +1716,7 @@ contains
 
         end do
 
-    end subroutine multi_polynomial_rr_initial_states_fill_parameters
+    end subroutine multi_power_rr_initial_states_fill_parameters
 
     subroutine serr_mu_parameters_fill_parameters(setup, mesh, parameters, options)
 
@@ -1890,10 +1890,10 @@ contains
             call multi_linear_rr_parameters_fill_parameters(setup, mesh, input_data, parameters, options)
             call multi_linear_rr_initial_states_fill_parameters(setup, mesh, input_data, parameters, options)
 
-        case ("multi-polynomial")
+        case ("multi-power")
 
-            call multi_polynomial_rr_parameters_fill_parameters(setup, mesh, input_data, parameters, options)
-            call multi_polynomial_rr_initial_states_fill_parameters(setup, mesh, input_data, parameters, options)
+            call multi_power_rr_parameters_fill_parameters(setup, mesh, input_data, parameters, options)
+            call multi_power_rr_initial_states_fill_parameters(setup, mesh, input_data, parameters, options)
 
         end select
 

--- a/smash/tests/core/simulation/test_optimize.py
+++ b/smash/tests/core/simulation/test_optimize.py
@@ -150,7 +150,7 @@ def generic_custom_optimize(model: smash.Model, **kwargs) -> dict:
             },
         },
         {
-            "mapping": "multi-polynomial",
+            "mapping": "multi-power",
             "optimizer": "lbfgsb",
             "optimize_options": {
                 "parameters": ["cp", "kexc"],

--- a/smash/tests/diff_baseline.csv
+++ b/smash/tests/diff_baseline.csv
@@ -1,8 +1,17 @@
-commit 94a8d84d3749902ce67a60509d08d9908ca6c980
-Author: ngo-nghi-truyen.huynh <ngo-nghi-truyen.huynh@inrae.fr>
-Date:   Thu Mar 6 17:24:09 2025 +0100
+commit cc3987a0773d1b56cba0246af94c3aa7b6a0b09f
+Author: Francois Colleoni <110899888+inoelloc@users.noreply.github.com>
+Date:   Fri Jun 6 00:17:55 2025 +0200
 
-    FIX: fix the mahal distance calculation in case of distributed parameters
+    MAINT: Windows wheel (#445)
+    
+    * MAINT: Windows wheel update
+    
+    - Switch from Windows 2019 to 2022
+    - Add a new file to patch f2py C file on Windows. Include setjmp.h instead of setjmpex.h
+    
+    * fix windows arch name
+    
+    * Apply TH review
 
 TEST NAME                                                      |STATUS
 bbox_mesh.active_cell                                          |NON MODIFIED
@@ -1142,16 +1151,16 @@ model_io.rr_parameters.values                                  |NON MODIFIED
 model_io.setup.end_time                                        |NON MODIFIED
 model_io.setup.start_time                                      |NON MODIFIED
 model_io.setup.structure                                       |NON MODIFIED
-multiset_estimate.set_1.lcurve_multiset.alpha                  |MODIFIED
-multiset_estimate.set_1.lcurve_multiset.alpha_opt              |MODIFIED
-multiset_estimate.set_1.lcurve_multiset.cost                   |MODIFIED
-multiset_estimate.set_1.lcurve_multiset.mahal_dist             |MODIFIED
-multiset_estimate.set_1.sim_q                                  |MODIFIED
-multiset_estimate.set_2.lcurve_multiset.alpha                  |MODIFIED
-multiset_estimate.set_2.lcurve_multiset.alpha_opt              |MODIFIED
-multiset_estimate.set_2.lcurve_multiset.cost                   |MODIFIED
-multiset_estimate.set_2.lcurve_multiset.mahal_dist             |MODIFIED
-multiset_estimate.set_2.sim_q                                  |MODIFIED
+multiset_estimate.set_1.lcurve_multiset.alpha                  |NON MODIFIED
+multiset_estimate.set_1.lcurve_multiset.alpha_opt              |NON MODIFIED
+multiset_estimate.set_1.lcurve_multiset.cost                   |NON MODIFIED
+multiset_estimate.set_1.lcurve_multiset.mahal_dist             |NON MODIFIED
+multiset_estimate.set_1.sim_q                                  |NON MODIFIED
+multiset_estimate.set_2.lcurve_multiset.alpha                  |NON MODIFIED
+multiset_estimate.set_2.lcurve_multiset.alpha_opt              |NON MODIFIED
+multiset_estimate.set_2.lcurve_multiset.cost                   |NON MODIFIED
+multiset_estimate.set_2.lcurve_multiset.mahal_dist             |NON MODIFIED
+multiset_estimate.set_2.sim_q                                  |NON MODIFIED
 net_forward_pass.output                                        |NON MODIFIED
 net_init.bias_layer_1                                          |NON MODIFIED
 net_init.bias_layer_2                                          |NON MODIFIED
@@ -1168,8 +1177,10 @@ optimize.zero-gr4-kw.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr4-kw.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr4-kw.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr4-kw.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr4-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr4-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr4-kw.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr4-kw.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr4-kw.multi-power.control_vector                |ADDED
+optimize.zero-gr4-kw.multi-power.sim_q                         |ADDED
 optimize.zero-gr4-kw.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr4-kw.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr4-lag0.ann.control_vector                      |NON MODIFIED
@@ -1178,8 +1189,10 @@ optimize.zero-gr4-lag0.distributed.control_vector              |NON MODIFIED
 optimize.zero-gr4-lag0.distributed.sim_q                       |NON MODIFIED
 optimize.zero-gr4-lag0.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-gr4-lag0.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-gr4-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr4-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr4-lag0.multi-polynomial.control_vector         |DELETED
+optimize.zero-gr4-lag0.multi-polynomial.sim_q                  |DELETED
+optimize.zero-gr4-lag0.multi-power.control_vector              |ADDED
+optimize.zero-gr4-lag0.multi-power.sim_q                       |ADDED
 optimize.zero-gr4-lag0.uniform.control_vector                  |NON MODIFIED
 optimize.zero-gr4-lag0.uniform.sim_q                           |NON MODIFIED
 optimize.zero-gr4-lr.ann.control_vector                        |NON MODIFIED
@@ -1188,8 +1201,10 @@ optimize.zero-gr4-lr.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr4-lr.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr4-lr.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr4-lr.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr4-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr4-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr4-lr.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr4-lr.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr4-lr.multi-power.control_vector                |ADDED
+optimize.zero-gr4-lr.multi-power.sim_q                         |ADDED
 optimize.zero-gr4-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr4-lr.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr4_mlp-kw.ann.control_vector                    |NON MODIFIED
@@ -1198,8 +1213,10 @@ optimize.zero-gr4_mlp-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr4_mlp-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr4_mlp-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr4_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_mlp-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr4_mlp-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr4_mlp-kw.multi-power.control_vector            |ADDED
+optimize.zero-gr4_mlp-kw.multi-power.sim_q                     |ADDED
 optimize.zero-gr4_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_mlp-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr4_mlp-lag0.ann.control_vector                  |NON MODIFIED
@@ -1208,8 +1225,10 @@ optimize.zero-gr4_mlp-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-gr4_mlp-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-gr4_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-gr4_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr4_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr4_mlp-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-gr4_mlp-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-gr4_mlp-lag0.multi-power.control_vector          |ADDED
+optimize.zero-gr4_mlp-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-gr4_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-gr4_mlp-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-gr4_mlp-lr.ann.control_vector                    |NON MODIFIED
@@ -1218,8 +1237,10 @@ optimize.zero-gr4_mlp-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr4_mlp-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr4_mlp-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr4_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_mlp-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr4_mlp-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr4_mlp-lr.multi-power.control_vector            |ADDED
+optimize.zero-gr4_mlp-lr.multi-power.sim_q                     |ADDED
 optimize.zero-gr4_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_mlp-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr4_ode-kw.ann.control_vector                    |NON MODIFIED
@@ -1228,8 +1249,10 @@ optimize.zero-gr4_ode-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr4_ode-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr4_ode-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr4_ode-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr4_ode-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr4_ode-kw.multi-power.control_vector            |ADDED
+optimize.zero-gr4_ode-kw.multi-power.sim_q                     |ADDED
 optimize.zero-gr4_ode-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_ode-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr4_ode-lag0.ann.control_vector                  |NON MODIFIED
@@ -1238,8 +1261,10 @@ optimize.zero-gr4_ode-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-gr4_ode-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-gr4_ode-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-gr4_ode-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr4_ode-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-gr4_ode-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-gr4_ode-lag0.multi-power.control_vector          |ADDED
+optimize.zero-gr4_ode-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-gr4_ode-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-gr4_ode-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-gr4_ode-lr.ann.control_vector                    |NON MODIFIED
@@ -1248,8 +1273,10 @@ optimize.zero-gr4_ode-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr4_ode-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr4_ode-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr4_ode-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr4_ode-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr4_ode-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr4_ode-lr.multi-power.control_vector            |ADDED
+optimize.zero-gr4_ode-lr.multi-power.sim_q                     |ADDED
 optimize.zero-gr4_ode-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr4_ode-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.ann.control_vector                |NON MODIFIED
@@ -1258,8 +1285,10 @@ optimize.zero-gr4_ode_mlp-kw.distributed.control_vector        |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.distributed.sim_q                 |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.multi-linear.control_vector       |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.multi-linear.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-polynomial.control_vector   |NON MODIFIED
-optimize.zero-gr4_ode_mlp-kw.multi-polynomial.sim_q            |NON MODIFIED
+optimize.zero-gr4_ode_mlp-kw.multi-polynomial.control_vector   |DELETED
+optimize.zero-gr4_ode_mlp-kw.multi-polynomial.sim_q            |DELETED
+optimize.zero-gr4_ode_mlp-kw.multi-power.control_vector        |ADDED
+optimize.zero-gr4_ode_mlp-kw.multi-power.sim_q                 |ADDED
 optimize.zero-gr4_ode_mlp-kw.uniform.control_vector            |NON MODIFIED
 optimize.zero-gr4_ode_mlp-kw.uniform.sim_q                     |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lag0.ann.control_vector              |NON MODIFIED
@@ -1268,8 +1297,10 @@ optimize.zero-gr4_ode_mlp-lag0.distributed.control_vector      |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lag0.distributed.sim_q               |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lag0.multi-linear.control_vector     |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lag0.multi-linear.sim_q              |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.control_vector |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.sim_q          |NON MODIFIED
+optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.control_vector |DELETED
+optimize.zero-gr4_ode_mlp-lag0.multi-polynomial.sim_q          |DELETED
+optimize.zero-gr4_ode_mlp-lag0.multi-power.control_vector      |ADDED
+optimize.zero-gr4_ode_mlp-lag0.multi-power.sim_q               |ADDED
 optimize.zero-gr4_ode_mlp-lag0.uniform.control_vector          |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lag0.uniform.sim_q                   |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lr.ann.control_vector                |NON MODIFIED
@@ -1278,8 +1309,10 @@ optimize.zero-gr4_ode_mlp-lr.distributed.control_vector        |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lr.distributed.sim_q                 |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lr.multi-linear.control_vector       |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lr.multi-linear.sim_q                |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-polynomial.control_vector   |NON MODIFIED
-optimize.zero-gr4_ode_mlp-lr.multi-polynomial.sim_q            |NON MODIFIED
+optimize.zero-gr4_ode_mlp-lr.multi-polynomial.control_vector   |DELETED
+optimize.zero-gr4_ode_mlp-lr.multi-polynomial.sim_q            |DELETED
+optimize.zero-gr4_ode_mlp-lr.multi-power.control_vector        |ADDED
+optimize.zero-gr4_ode_mlp-lr.multi-power.sim_q                 |ADDED
 optimize.zero-gr4_ode_mlp-lr.uniform.control_vector            |NON MODIFIED
 optimize.zero-gr4_ode_mlp-lr.uniform.sim_q                     |NON MODIFIED
 optimize.zero-gr4_ri-kw.ann.control_vector                     |NON MODIFIED
@@ -1288,8 +1321,10 @@ optimize.zero-gr4_ri-kw.distributed.control_vector             |NON MODIFIED
 optimize.zero-gr4_ri-kw.distributed.sim_q                      |NON MODIFIED
 optimize.zero-gr4_ri-kw.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-gr4_ri-kw.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-gr4_ri-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr4_ri-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr4_ri-kw.multi-polynomial.control_vector        |DELETED
+optimize.zero-gr4_ri-kw.multi-polynomial.sim_q                 |DELETED
+optimize.zero-gr4_ri-kw.multi-power.control_vector             |ADDED
+optimize.zero-gr4_ri-kw.multi-power.sim_q                      |ADDED
 optimize.zero-gr4_ri-kw.uniform.control_vector                 |NON MODIFIED
 optimize.zero-gr4_ri-kw.uniform.sim_q                          |NON MODIFIED
 optimize.zero-gr4_ri-lag0.ann.control_vector                   |NON MODIFIED
@@ -1298,8 +1333,10 @@ optimize.zero-gr4_ri-lag0.distributed.control_vector           |NON MODIFIED
 optimize.zero-gr4_ri-lag0.distributed.sim_q                    |NON MODIFIED
 optimize.zero-gr4_ri-lag0.multi-linear.control_vector          |NON MODIFIED
 optimize.zero-gr4_ri-lag0.multi-linear.sim_q                   |NON MODIFIED
-optimize.zero-gr4_ri-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-gr4_ri-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-gr4_ri-lag0.multi-polynomial.control_vector      |DELETED
+optimize.zero-gr4_ri-lag0.multi-polynomial.sim_q               |DELETED
+optimize.zero-gr4_ri-lag0.multi-power.control_vector           |ADDED
+optimize.zero-gr4_ri-lag0.multi-power.sim_q                    |ADDED
 optimize.zero-gr4_ri-lag0.uniform.control_vector               |NON MODIFIED
 optimize.zero-gr4_ri-lag0.uniform.sim_q                        |NON MODIFIED
 optimize.zero-gr4_ri-lr.ann.control_vector                     |NON MODIFIED
@@ -1308,8 +1345,10 @@ optimize.zero-gr4_ri-lr.distributed.control_vector             |NON MODIFIED
 optimize.zero-gr4_ri-lr.distributed.sim_q                      |NON MODIFIED
 optimize.zero-gr4_ri-lr.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-gr4_ri-lr.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-gr4_ri-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr4_ri-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr4_ri-lr.multi-polynomial.control_vector        |DELETED
+optimize.zero-gr4_ri-lr.multi-polynomial.sim_q                 |DELETED
+optimize.zero-gr4_ri-lr.multi-power.control_vector             |ADDED
+optimize.zero-gr4_ri-lr.multi-power.sim_q                      |ADDED
 optimize.zero-gr4_ri-lr.uniform.control_vector                 |NON MODIFIED
 optimize.zero-gr4_ri-lr.uniform.sim_q                          |NON MODIFIED
 optimize.zero-gr5-kw.ann.control_vector                        |NON MODIFIED
@@ -1318,8 +1357,10 @@ optimize.zero-gr5-kw.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr5-kw.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr5-kw.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr5-kw.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr5-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr5-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr5-kw.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr5-kw.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr5-kw.multi-power.control_vector                |ADDED
+optimize.zero-gr5-kw.multi-power.sim_q                         |ADDED
 optimize.zero-gr5-kw.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr5-kw.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr5-lag0.ann.control_vector                      |NON MODIFIED
@@ -1328,8 +1369,10 @@ optimize.zero-gr5-lag0.distributed.control_vector              |NON MODIFIED
 optimize.zero-gr5-lag0.distributed.sim_q                       |NON MODIFIED
 optimize.zero-gr5-lag0.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-gr5-lag0.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-gr5-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr5-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr5-lag0.multi-polynomial.control_vector         |DELETED
+optimize.zero-gr5-lag0.multi-polynomial.sim_q                  |DELETED
+optimize.zero-gr5-lag0.multi-power.control_vector              |ADDED
+optimize.zero-gr5-lag0.multi-power.sim_q                       |ADDED
 optimize.zero-gr5-lag0.uniform.control_vector                  |NON MODIFIED
 optimize.zero-gr5-lag0.uniform.sim_q                           |NON MODIFIED
 optimize.zero-gr5-lr.ann.control_vector                        |NON MODIFIED
@@ -1338,8 +1381,10 @@ optimize.zero-gr5-lr.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr5-lr.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr5-lr.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr5-lr.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr5-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr5-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr5-lr.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr5-lr.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr5-lr.multi-power.control_vector                |ADDED
+optimize.zero-gr5-lr.multi-power.sim_q                         |ADDED
 optimize.zero-gr5-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr5-lr.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr5_mlp-kw.ann.control_vector                    |NON MODIFIED
@@ -1348,8 +1393,10 @@ optimize.zero-gr5_mlp-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr5_mlp-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr5_mlp-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr5_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr5_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr5_mlp-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr5_mlp-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr5_mlp-kw.multi-power.control_vector            |ADDED
+optimize.zero-gr5_mlp-kw.multi-power.sim_q                     |ADDED
 optimize.zero-gr5_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr5_mlp-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr5_mlp-lag0.ann.control_vector                  |NON MODIFIED
@@ -1358,8 +1405,10 @@ optimize.zero-gr5_mlp-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-gr5_mlp-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-gr5_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-gr5_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr5_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr5_mlp-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-gr5_mlp-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-gr5_mlp-lag0.multi-power.control_vector          |ADDED
+optimize.zero-gr5_mlp-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-gr5_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-gr5_mlp-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-gr5_mlp-lr.ann.control_vector                    |NON MODIFIED
@@ -1368,8 +1417,10 @@ optimize.zero-gr5_mlp-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr5_mlp-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr5_mlp-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr5_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr5_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr5_mlp-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr5_mlp-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr5_mlp-lr.multi-power.control_vector            |ADDED
+optimize.zero-gr5_mlp-lr.multi-power.sim_q                     |ADDED
 optimize.zero-gr5_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr5_mlp-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr5_ri-kw.ann.control_vector                     |NON MODIFIED
@@ -1378,8 +1429,10 @@ optimize.zero-gr5_ri-kw.distributed.control_vector             |NON MODIFIED
 optimize.zero-gr5_ri-kw.distributed.sim_q                      |NON MODIFIED
 optimize.zero-gr5_ri-kw.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-gr5_ri-kw.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-gr5_ri-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr5_ri-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr5_ri-kw.multi-polynomial.control_vector        |DELETED
+optimize.zero-gr5_ri-kw.multi-polynomial.sim_q                 |DELETED
+optimize.zero-gr5_ri-kw.multi-power.control_vector             |ADDED
+optimize.zero-gr5_ri-kw.multi-power.sim_q                      |ADDED
 optimize.zero-gr5_ri-kw.uniform.control_vector                 |NON MODIFIED
 optimize.zero-gr5_ri-kw.uniform.sim_q                          |NON MODIFIED
 optimize.zero-gr5_ri-lag0.ann.control_vector                   |NON MODIFIED
@@ -1388,8 +1441,10 @@ optimize.zero-gr5_ri-lag0.distributed.control_vector           |NON MODIFIED
 optimize.zero-gr5_ri-lag0.distributed.sim_q                    |NON MODIFIED
 optimize.zero-gr5_ri-lag0.multi-linear.control_vector          |NON MODIFIED
 optimize.zero-gr5_ri-lag0.multi-linear.sim_q                   |NON MODIFIED
-optimize.zero-gr5_ri-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-gr5_ri-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-gr5_ri-lag0.multi-polynomial.control_vector      |DELETED
+optimize.zero-gr5_ri-lag0.multi-polynomial.sim_q               |DELETED
+optimize.zero-gr5_ri-lag0.multi-power.control_vector           |ADDED
+optimize.zero-gr5_ri-lag0.multi-power.sim_q                    |ADDED
 optimize.zero-gr5_ri-lag0.uniform.control_vector               |NON MODIFIED
 optimize.zero-gr5_ri-lag0.uniform.sim_q                        |NON MODIFIED
 optimize.zero-gr5_ri-lr.ann.control_vector                     |NON MODIFIED
@@ -1398,8 +1453,10 @@ optimize.zero-gr5_ri-lr.distributed.control_vector             |NON MODIFIED
 optimize.zero-gr5_ri-lr.distributed.sim_q                      |NON MODIFIED
 optimize.zero-gr5_ri-lr.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-gr5_ri-lr.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-gr5_ri-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-gr5_ri-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-gr5_ri-lr.multi-polynomial.control_vector        |DELETED
+optimize.zero-gr5_ri-lr.multi-polynomial.sim_q                 |DELETED
+optimize.zero-gr5_ri-lr.multi-power.control_vector             |ADDED
+optimize.zero-gr5_ri-lr.multi-power.sim_q                      |ADDED
 optimize.zero-gr5_ri-lr.uniform.control_vector                 |NON MODIFIED
 optimize.zero-gr5_ri-lr.uniform.sim_q                          |NON MODIFIED
 optimize.zero-gr6-kw.ann.control_vector                        |NON MODIFIED
@@ -1408,8 +1465,10 @@ optimize.zero-gr6-kw.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr6-kw.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr6-kw.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr6-kw.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr6-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr6-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr6-kw.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr6-kw.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr6-kw.multi-power.control_vector                |ADDED
+optimize.zero-gr6-kw.multi-power.sim_q                         |ADDED
 optimize.zero-gr6-kw.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr6-kw.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr6-lag0.ann.control_vector                      |NON MODIFIED
@@ -1418,8 +1477,10 @@ optimize.zero-gr6-lag0.distributed.control_vector              |NON MODIFIED
 optimize.zero-gr6-lag0.distributed.sim_q                       |NON MODIFIED
 optimize.zero-gr6-lag0.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-gr6-lag0.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-gr6-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-gr6-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-gr6-lag0.multi-polynomial.control_vector         |DELETED
+optimize.zero-gr6-lag0.multi-polynomial.sim_q                  |DELETED
+optimize.zero-gr6-lag0.multi-power.control_vector              |ADDED
+optimize.zero-gr6-lag0.multi-power.sim_q                       |ADDED
 optimize.zero-gr6-lag0.uniform.control_vector                  |NON MODIFIED
 optimize.zero-gr6-lag0.uniform.sim_q                           |NON MODIFIED
 optimize.zero-gr6-lr.ann.control_vector                        |NON MODIFIED
@@ -1428,8 +1489,10 @@ optimize.zero-gr6-lr.distributed.control_vector                |NON MODIFIED
 optimize.zero-gr6-lr.distributed.sim_q                         |NON MODIFIED
 optimize.zero-gr6-lr.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-gr6-lr.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-gr6-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-gr6-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-gr6-lr.multi-polynomial.control_vector           |DELETED
+optimize.zero-gr6-lr.multi-polynomial.sim_q                    |DELETED
+optimize.zero-gr6-lr.multi-power.control_vector                |ADDED
+optimize.zero-gr6-lr.multi-power.sim_q                         |ADDED
 optimize.zero-gr6-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-gr6-lr.uniform.sim_q                             |NON MODIFIED
 optimize.zero-gr6_mlp-kw.ann.control_vector                    |NON MODIFIED
@@ -1438,8 +1501,10 @@ optimize.zero-gr6_mlp-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr6_mlp-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr6_mlp-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr6_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr6_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr6_mlp-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr6_mlp-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr6_mlp-kw.multi-power.control_vector            |ADDED
+optimize.zero-gr6_mlp-kw.multi-power.sim_q                     |ADDED
 optimize.zero-gr6_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr6_mlp-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.ann.control_vector                  |NON MODIFIED
@@ -1448,8 +1513,10 @@ optimize.zero-gr6_mlp-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-gr6_mlp-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-gr6_mlp-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-gr6_mlp-lag0.multi-power.control_vector          |ADDED
+optimize.zero-gr6_mlp-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-gr6_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-gr6_mlp-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-gr6_mlp-lr.ann.control_vector                    |NON MODIFIED
@@ -1458,8 +1525,10 @@ optimize.zero-gr6_mlp-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-gr6_mlp-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-gr6_mlp-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-gr6_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-gr6_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-gr6_mlp-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-gr6_mlp-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-gr6_mlp-lr.multi-power.control_vector            |ADDED
+optimize.zero-gr6_mlp-lr.multi-power.sim_q                     |ADDED
 optimize.zero-gr6_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-gr6_mlp-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-grc-kw.ann.control_vector                        |NON MODIFIED
@@ -1468,8 +1537,10 @@ optimize.zero-grc-kw.distributed.control_vector                |NON MODIFIED
 optimize.zero-grc-kw.distributed.sim_q                         |NON MODIFIED
 optimize.zero-grc-kw.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-grc-kw.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-grc-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grc-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grc-kw.multi-polynomial.control_vector           |DELETED
+optimize.zero-grc-kw.multi-polynomial.sim_q                    |DELETED
+optimize.zero-grc-kw.multi-power.control_vector                |ADDED
+optimize.zero-grc-kw.multi-power.sim_q                         |ADDED
 optimize.zero-grc-kw.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grc-kw.uniform.sim_q                             |NON MODIFIED
 optimize.zero-grc-lag0.ann.control_vector                      |NON MODIFIED
@@ -1478,8 +1549,10 @@ optimize.zero-grc-lag0.distributed.control_vector              |NON MODIFIED
 optimize.zero-grc-lag0.distributed.sim_q                       |NON MODIFIED
 optimize.zero-grc-lag0.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-grc-lag0.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-grc-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-grc-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-grc-lag0.multi-polynomial.control_vector         |DELETED
+optimize.zero-grc-lag0.multi-polynomial.sim_q                  |DELETED
+optimize.zero-grc-lag0.multi-power.control_vector              |ADDED
+optimize.zero-grc-lag0.multi-power.sim_q                       |ADDED
 optimize.zero-grc-lag0.uniform.control_vector                  |NON MODIFIED
 optimize.zero-grc-lag0.uniform.sim_q                           |NON MODIFIED
 optimize.zero-grc-lr.ann.control_vector                        |NON MODIFIED
@@ -1488,8 +1561,10 @@ optimize.zero-grc-lr.distributed.control_vector                |NON MODIFIED
 optimize.zero-grc-lr.distributed.sim_q                         |NON MODIFIED
 optimize.zero-grc-lr.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-grc-lr.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-grc-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grc-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grc-lr.multi-polynomial.control_vector           |DELETED
+optimize.zero-grc-lr.multi-polynomial.sim_q                    |DELETED
+optimize.zero-grc-lr.multi-power.control_vector                |ADDED
+optimize.zero-grc-lr.multi-power.sim_q                         |ADDED
 optimize.zero-grc-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grc-lr.uniform.sim_q                             |NON MODIFIED
 optimize.zero-grc_mlp-kw.ann.control_vector                    |NON MODIFIED
@@ -1498,8 +1573,10 @@ optimize.zero-grc_mlp-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-grc_mlp-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-grc_mlp-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-grc_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grc_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grc_mlp-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-grc_mlp-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-grc_mlp-kw.multi-power.control_vector            |ADDED
+optimize.zero-grc_mlp-kw.multi-power.sim_q                     |ADDED
 optimize.zero-grc_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-grc_mlp-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-grc_mlp-lag0.ann.control_vector                  |NON MODIFIED
@@ -1508,8 +1585,10 @@ optimize.zero-grc_mlp-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-grc_mlp-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-grc_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-grc_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-grc_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-grc_mlp-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-grc_mlp-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-grc_mlp-lag0.multi-power.control_vector          |ADDED
+optimize.zero-grc_mlp-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-grc_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-grc_mlp-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-grc_mlp-lr.ann.control_vector                    |NON MODIFIED
@@ -1518,8 +1597,10 @@ optimize.zero-grc_mlp-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-grc_mlp-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-grc_mlp-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-grc_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grc_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grc_mlp-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-grc_mlp-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-grc_mlp-lr.multi-power.control_vector            |ADDED
+optimize.zero-grc_mlp-lr.multi-power.sim_q                     |ADDED
 optimize.zero-grc_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-grc_mlp-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-grd-kw.ann.control_vector                        |NON MODIFIED
@@ -1528,8 +1609,10 @@ optimize.zero-grd-kw.distributed.control_vector                |NON MODIFIED
 optimize.zero-grd-kw.distributed.sim_q                         |NON MODIFIED
 optimize.zero-grd-kw.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-grd-kw.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-grd-kw.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grd-kw.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grd-kw.multi-polynomial.control_vector           |DELETED
+optimize.zero-grd-kw.multi-polynomial.sim_q                    |DELETED
+optimize.zero-grd-kw.multi-power.control_vector                |ADDED
+optimize.zero-grd-kw.multi-power.sim_q                         |ADDED
 optimize.zero-grd-kw.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grd-kw.uniform.sim_q                             |NON MODIFIED
 optimize.zero-grd-lag0.ann.control_vector                      |NON MODIFIED
@@ -1538,8 +1621,10 @@ optimize.zero-grd-lag0.distributed.control_vector              |NON MODIFIED
 optimize.zero-grd-lag0.distributed.sim_q                       |NON MODIFIED
 optimize.zero-grd-lag0.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-grd-lag0.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-grd-lag0.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-grd-lag0.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-grd-lag0.multi-polynomial.control_vector         |DELETED
+optimize.zero-grd-lag0.multi-polynomial.sim_q                  |DELETED
+optimize.zero-grd-lag0.multi-power.control_vector              |ADDED
+optimize.zero-grd-lag0.multi-power.sim_q                       |ADDED
 optimize.zero-grd-lag0.uniform.control_vector                  |NON MODIFIED
 optimize.zero-grd-lag0.uniform.sim_q                           |NON MODIFIED
 optimize.zero-grd-lr.ann.control_vector                        |NON MODIFIED
@@ -1548,8 +1633,10 @@ optimize.zero-grd-lr.distributed.control_vector                |NON MODIFIED
 optimize.zero-grd-lr.distributed.sim_q                         |NON MODIFIED
 optimize.zero-grd-lr.multi-linear.control_vector               |NON MODIFIED
 optimize.zero-grd-lr.multi-linear.sim_q                        |NON MODIFIED
-optimize.zero-grd-lr.multi-polynomial.control_vector           |NON MODIFIED
-optimize.zero-grd-lr.multi-polynomial.sim_q                    |NON MODIFIED
+optimize.zero-grd-lr.multi-polynomial.control_vector           |DELETED
+optimize.zero-grd-lr.multi-polynomial.sim_q                    |DELETED
+optimize.zero-grd-lr.multi-power.control_vector                |ADDED
+optimize.zero-grd-lr.multi-power.sim_q                         |ADDED
 optimize.zero-grd-lr.uniform.control_vector                    |NON MODIFIED
 optimize.zero-grd-lr.uniform.sim_q                             |NON MODIFIED
 optimize.zero-grd_mlp-kw.ann.control_vector                    |NON MODIFIED
@@ -1558,8 +1645,10 @@ optimize.zero-grd_mlp-kw.distributed.control_vector            |NON MODIFIED
 optimize.zero-grd_mlp-kw.distributed.sim_q                     |NON MODIFIED
 optimize.zero-grd_mlp-kw.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-grd_mlp-kw.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grd_mlp-kw.multi-polynomial.control_vector       |DELETED
+optimize.zero-grd_mlp-kw.multi-polynomial.sim_q                |DELETED
+optimize.zero-grd_mlp-kw.multi-power.control_vector            |ADDED
+optimize.zero-grd_mlp-kw.multi-power.sim_q                     |ADDED
 optimize.zero-grd_mlp-kw.uniform.control_vector                |NON MODIFIED
 optimize.zero-grd_mlp-kw.uniform.sim_q                         |NON MODIFIED
 optimize.zero-grd_mlp-lag0.ann.control_vector                  |NON MODIFIED
@@ -1568,8 +1657,10 @@ optimize.zero-grd_mlp-lag0.distributed.control_vector          |NON MODIFIED
 optimize.zero-grd_mlp-lag0.distributed.sim_q                   |NON MODIFIED
 optimize.zero-grd_mlp-lag0.multi-linear.control_vector         |NON MODIFIED
 optimize.zero-grd_mlp-lag0.multi-linear.sim_q                  |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |NON MODIFIED
-optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |NON MODIFIED
+optimize.zero-grd_mlp-lag0.multi-polynomial.control_vector     |DELETED
+optimize.zero-grd_mlp-lag0.multi-polynomial.sim_q              |DELETED
+optimize.zero-grd_mlp-lag0.multi-power.control_vector          |ADDED
+optimize.zero-grd_mlp-lag0.multi-power.sim_q                   |ADDED
 optimize.zero-grd_mlp-lag0.uniform.control_vector              |NON MODIFIED
 optimize.zero-grd_mlp-lag0.uniform.sim_q                       |NON MODIFIED
 optimize.zero-grd_mlp-lr.ann.control_vector                    |NON MODIFIED
@@ -1578,8 +1669,10 @@ optimize.zero-grd_mlp-lr.distributed.control_vector            |NON MODIFIED
 optimize.zero-grd_mlp-lr.distributed.sim_q                     |NON MODIFIED
 optimize.zero-grd_mlp-lr.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-grd_mlp-lr.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-grd_mlp-lr.multi-polynomial.control_vector       |DELETED
+optimize.zero-grd_mlp-lr.multi-polynomial.sim_q                |DELETED
+optimize.zero-grd_mlp-lr.multi-power.control_vector            |ADDED
+optimize.zero-grd_mlp-lr.multi-power.sim_q                     |ADDED
 optimize.zero-grd_mlp-lr.uniform.control_vector                |NON MODIFIED
 optimize.zero-grd_mlp-lr.uniform.sim_q                         |NON MODIFIED
 optimize.zero-loieau-kw.ann.control_vector                     |NON MODIFIED
@@ -1588,8 +1681,10 @@ optimize.zero-loieau-kw.distributed.control_vector             |NON MODIFIED
 optimize.zero-loieau-kw.distributed.sim_q                      |NON MODIFIED
 optimize.zero-loieau-kw.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-loieau-kw.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-loieau-kw.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-loieau-kw.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-loieau-kw.multi-polynomial.control_vector        |DELETED
+optimize.zero-loieau-kw.multi-polynomial.sim_q                 |DELETED
+optimize.zero-loieau-kw.multi-power.control_vector             |ADDED
+optimize.zero-loieau-kw.multi-power.sim_q                      |ADDED
 optimize.zero-loieau-kw.uniform.control_vector                 |NON MODIFIED
 optimize.zero-loieau-kw.uniform.sim_q                          |NON MODIFIED
 optimize.zero-loieau-lag0.ann.control_vector                   |NON MODIFIED
@@ -1598,8 +1693,10 @@ optimize.zero-loieau-lag0.distributed.control_vector           |NON MODIFIED
 optimize.zero-loieau-lag0.distributed.sim_q                    |NON MODIFIED
 optimize.zero-loieau-lag0.multi-linear.control_vector          |NON MODIFIED
 optimize.zero-loieau-lag0.multi-linear.sim_q                   |NON MODIFIED
-optimize.zero-loieau-lag0.multi-polynomial.control_vector      |NON MODIFIED
-optimize.zero-loieau-lag0.multi-polynomial.sim_q               |NON MODIFIED
+optimize.zero-loieau-lag0.multi-polynomial.control_vector      |DELETED
+optimize.zero-loieau-lag0.multi-polynomial.sim_q               |DELETED
+optimize.zero-loieau-lag0.multi-power.control_vector           |ADDED
+optimize.zero-loieau-lag0.multi-power.sim_q                    |ADDED
 optimize.zero-loieau-lag0.uniform.control_vector               |NON MODIFIED
 optimize.zero-loieau-lag0.uniform.sim_q                        |NON MODIFIED
 optimize.zero-loieau-lr.ann.control_vector                     |NON MODIFIED
@@ -1608,8 +1705,10 @@ optimize.zero-loieau-lr.distributed.control_vector             |NON MODIFIED
 optimize.zero-loieau-lr.distributed.sim_q                      |NON MODIFIED
 optimize.zero-loieau-lr.multi-linear.control_vector            |NON MODIFIED
 optimize.zero-loieau-lr.multi-linear.sim_q                     |NON MODIFIED
-optimize.zero-loieau-lr.multi-polynomial.control_vector        |NON MODIFIED
-optimize.zero-loieau-lr.multi-polynomial.sim_q                 |NON MODIFIED
+optimize.zero-loieau-lr.multi-polynomial.control_vector        |DELETED
+optimize.zero-loieau-lr.multi-polynomial.sim_q                 |DELETED
+optimize.zero-loieau-lr.multi-power.control_vector             |ADDED
+optimize.zero-loieau-lr.multi-power.sim_q                      |ADDED
 optimize.zero-loieau-lr.uniform.control_vector                 |NON MODIFIED
 optimize.zero-loieau-lr.uniform.sim_q                          |NON MODIFIED
 optimize.zero-loieau_mlp-kw.ann.control_vector                 |NON MODIFIED
@@ -1618,8 +1717,10 @@ optimize.zero-loieau_mlp-kw.distributed.control_vector         |NON MODIFIED
 optimize.zero-loieau_mlp-kw.distributed.sim_q                  |NON MODIFIED
 optimize.zero-loieau_mlp-kw.multi-linear.control_vector        |NON MODIFIED
 optimize.zero-loieau_mlp-kw.multi-linear.sim_q                 |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-polynomial.control_vector    |NON MODIFIED
-optimize.zero-loieau_mlp-kw.multi-polynomial.sim_q             |NON MODIFIED
+optimize.zero-loieau_mlp-kw.multi-polynomial.control_vector    |DELETED
+optimize.zero-loieau_mlp-kw.multi-polynomial.sim_q             |DELETED
+optimize.zero-loieau_mlp-kw.multi-power.control_vector         |ADDED
+optimize.zero-loieau_mlp-kw.multi-power.sim_q                  |ADDED
 optimize.zero-loieau_mlp-kw.uniform.control_vector             |NON MODIFIED
 optimize.zero-loieau_mlp-kw.uniform.sim_q                      |NON MODIFIED
 optimize.zero-loieau_mlp-lag0.ann.control_vector               |NON MODIFIED
@@ -1628,8 +1729,10 @@ optimize.zero-loieau_mlp-lag0.distributed.control_vector       |NON MODIFIED
 optimize.zero-loieau_mlp-lag0.distributed.sim_q                |NON MODIFIED
 optimize.zero-loieau_mlp-lag0.multi-linear.control_vector      |NON MODIFIED
 optimize.zero-loieau_mlp-lag0.multi-linear.sim_q               |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-polynomial.control_vector  |NON MODIFIED
-optimize.zero-loieau_mlp-lag0.multi-polynomial.sim_q           |NON MODIFIED
+optimize.zero-loieau_mlp-lag0.multi-polynomial.control_vector  |DELETED
+optimize.zero-loieau_mlp-lag0.multi-polynomial.sim_q           |DELETED
+optimize.zero-loieau_mlp-lag0.multi-power.control_vector       |ADDED
+optimize.zero-loieau_mlp-lag0.multi-power.sim_q                |ADDED
 optimize.zero-loieau_mlp-lag0.uniform.control_vector           |NON MODIFIED
 optimize.zero-loieau_mlp-lag0.uniform.sim_q                    |NON MODIFIED
 optimize.zero-loieau_mlp-lr.ann.control_vector                 |NON MODIFIED
@@ -1638,8 +1741,10 @@ optimize.zero-loieau_mlp-lr.distributed.control_vector         |NON MODIFIED
 optimize.zero-loieau_mlp-lr.distributed.sim_q                  |NON MODIFIED
 optimize.zero-loieau_mlp-lr.multi-linear.control_vector        |NON MODIFIED
 optimize.zero-loieau_mlp-lr.multi-linear.sim_q                 |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-polynomial.control_vector    |NON MODIFIED
-optimize.zero-loieau_mlp-lr.multi-polynomial.sim_q             |NON MODIFIED
+optimize.zero-loieau_mlp-lr.multi-polynomial.control_vector    |DELETED
+optimize.zero-loieau_mlp-lr.multi-polynomial.sim_q             |DELETED
+optimize.zero-loieau_mlp-lr.multi-power.control_vector         |ADDED
+optimize.zero-loieau_mlp-lr.multi-power.sim_q                  |ADDED
 optimize.zero-loieau_mlp-lr.uniform.control_vector             |NON MODIFIED
 optimize.zero-loieau_mlp-lr.uniform.sim_q                      |NON MODIFIED
 optimize.zero-vic3l-kw.ann.control_vector                      |NON MODIFIED
@@ -1648,8 +1753,10 @@ optimize.zero-vic3l-kw.distributed.control_vector              |NON MODIFIED
 optimize.zero-vic3l-kw.distributed.sim_q                       |NON MODIFIED
 optimize.zero-vic3l-kw.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-vic3l-kw.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-vic3l-kw.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-vic3l-kw.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-vic3l-kw.multi-polynomial.control_vector         |DELETED
+optimize.zero-vic3l-kw.multi-polynomial.sim_q                  |DELETED
+optimize.zero-vic3l-kw.multi-power.control_vector              |ADDED
+optimize.zero-vic3l-kw.multi-power.sim_q                       |ADDED
 optimize.zero-vic3l-kw.uniform.control_vector                  |NON MODIFIED
 optimize.zero-vic3l-kw.uniform.sim_q                           |NON MODIFIED
 optimize.zero-vic3l-lag0.ann.control_vector                    |NON MODIFIED
@@ -1658,8 +1765,10 @@ optimize.zero-vic3l-lag0.distributed.control_vector            |NON MODIFIED
 optimize.zero-vic3l-lag0.distributed.sim_q                     |NON MODIFIED
 optimize.zero-vic3l-lag0.multi-linear.control_vector           |NON MODIFIED
 optimize.zero-vic3l-lag0.multi-linear.sim_q                    |NON MODIFIED
-optimize.zero-vic3l-lag0.multi-polynomial.control_vector       |NON MODIFIED
-optimize.zero-vic3l-lag0.multi-polynomial.sim_q                |NON MODIFIED
+optimize.zero-vic3l-lag0.multi-polynomial.control_vector       |DELETED
+optimize.zero-vic3l-lag0.multi-polynomial.sim_q                |DELETED
+optimize.zero-vic3l-lag0.multi-power.control_vector            |ADDED
+optimize.zero-vic3l-lag0.multi-power.sim_q                     |ADDED
 optimize.zero-vic3l-lag0.uniform.control_vector                |NON MODIFIED
 optimize.zero-vic3l-lag0.uniform.sim_q                         |NON MODIFIED
 optimize.zero-vic3l-lr.ann.control_vector                      |NON MODIFIED
@@ -1668,8 +1777,10 @@ optimize.zero-vic3l-lr.distributed.control_vector              |NON MODIFIED
 optimize.zero-vic3l-lr.distributed.sim_q                       |NON MODIFIED
 optimize.zero-vic3l-lr.multi-linear.control_vector             |NON MODIFIED
 optimize.zero-vic3l-lr.multi-linear.sim_q                      |NON MODIFIED
-optimize.zero-vic3l-lr.multi-polynomial.control_vector         |NON MODIFIED
-optimize.zero-vic3l-lr.multi-polynomial.sim_q                  |NON MODIFIED
+optimize.zero-vic3l-lr.multi-polynomial.control_vector         |DELETED
+optimize.zero-vic3l-lr.multi-polynomial.sim_q                  |DELETED
+optimize.zero-vic3l-lr.multi-power.control_vector              |ADDED
+optimize.zero-vic3l-lr.multi-power.sim_q                       |ADDED
 optimize.zero-vic3l-lr.uniform.control_vector                  |NON MODIFIED
 optimize.zero-vic3l-lr.uniform.sim_q                           |NON MODIFIED
 precipitation_indices.d1                                       |NON MODIFIED


### PR DESCRIPTION
- Mapping name "multi-polynomial" is deprecated and replaced by "multi-power".
- Corresponding changes made for the baseline