### PR TITLE
MAINT: Exclude mesh outlets based on surface error

### DIFF
--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -223,6 +223,23 @@ def _standardize_generate_mesh_epsg(epsg: AlphaNumeric | None) -> int | None:
     return epsg
 
 
+def _standardize_generate_mesh_area_error_th(
+    area_error_th: Numeric | None,
+) -> float | None:
+    if area_error_th is None:
+        pass
+
+    else:
+        if not isinstance(area_error_th, float):
+            raise TypeError(
+                "area_error_th argument must be of AlphaNumeric type (float)"
+            )
+
+        area_error_th = float(area_error_th)
+
+    return area_error_th
+
+
 def _standardize_generate_mesh_args(
     flwdir_path: FilePath,
     bbox: ListLike | None,
@@ -233,6 +250,7 @@ def _standardize_generate_mesh_args(
     shp_path: FilePath | None,
     max_depth: Numeric,
     epsg: AlphaNumeric | None,
+    area_error_th: Numeric | None,
 ) -> AnyTuple:
     flwdir_path = _standardize_generate_mesh_flwdir_path(flwdir_path)
 
@@ -257,4 +275,8 @@ def _standardize_generate_mesh_args(
 
     epsg = _standardize_generate_mesh_epsg(epsg)
 
-    return flwdir_dataset, bbox, x, y, area, code, shp_dataset, max_depth, epsg
+    area_error_th = _standardize_generate_mesh_area_error_th(
+        area_error_th
+    )
+
+    return flwdir_dataset, bbox, x, y, area, code, shp_dataset, max_depth, epsg, area_error_th

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -231,7 +231,7 @@ def _standardize_generate_mesh_area_error_th(
 
     else:
         if not isinstance(area_error_th, float):
-            raise TypeError("area_error_th argument must be of AlphaNumeric type (float)")
+            raise TypeError("area_error_th argument must be of Numeric type (float)")
 
         area_error_th = float(area_error_th)
 

--- a/smash/factory/mesh/_standardize.py
+++ b/smash/factory/mesh/_standardize.py
@@ -231,9 +231,7 @@ def _standardize_generate_mesh_area_error_th(
 
     else:
         if not isinstance(area_error_th, float):
-            raise TypeError(
-                "area_error_th argument must be of AlphaNumeric type (float)"
-            )
+            raise TypeError("area_error_th argument must be of AlphaNumeric type (float)")
 
         area_error_th = float(area_error_th)
 
@@ -275,8 +273,6 @@ def _standardize_generate_mesh_args(
 
     epsg = _standardize_generate_mesh_epsg(epsg)
 
-    area_error_th = _standardize_generate_mesh_area_error_th(
-        area_error_th
-    )
+    area_error_th = _standardize_generate_mesh_area_error_th(area_error_th)
 
     return flwdir_dataset, bbox, x, y, area, code, shp_dataset, max_depth, epsg, area_error_th

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -222,7 +222,7 @@ def generate_mesh(
         defined in the flow directions file. It is not necessary to provide the value of
         the ``EPSG``. On the other hand, if the projection is not well defined in the flow directions file
         (i.e. in ``ASCII`` file), the **epsg** argument must be filled in.
-    
+
     area_error_th: float or None, default None
         The threshold of the relative error between the modeled area and the observed area beyond which the
         outlets and the catchment will be excluded of the final mesh. The relative error is computed as folow:
@@ -230,7 +230,6 @@ def generate_mesh(
         Exemple: `area_error_th=0.2` means that all outlets where the surface error are higher than 0.2 (20%)
         will be excluded. If `area_error_th` is set to None (default), the compuation of the error on the
         area is ignored and all outlets are included in the mesh.
-        
 
     Returns
     -------
@@ -380,7 +379,9 @@ def generate_mesh(
     (1000.0, 906044, 0)
     """
 
-    args = _standardize_generate_mesh_args(flwdir_path, bbox, x, y, area, code, shp_path, max_depth, epsg, area_error_th)
+    args = _standardize_generate_mesh_args(
+        flwdir_path, bbox, x, y, area, code, shp_path, max_depth, epsg, area_error_th
+        )
 
     return _generate_mesh(*args)
 
@@ -630,4 +631,6 @@ def _generate_mesh(
     if bbox is not None:
         return _generate_mesh_from_bbox(flwdir_dataset, bbox, epsg)
     else:
-        return _generate_mesh_from_xy(flwdir_dataset, x, y, area, code, shp_dataset, max_depth, epsg, area_error_th)
+        return _generate_mesh_from_xy(
+            flwdir_dataset, x, y, area, code, shp_dataset, max_depth, epsg, area_error_th
+        )

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -153,7 +153,7 @@ def generate_mesh(
     shp_path: FilePath | None = None,
     max_depth: Numeric = 1,
     epsg: AlphaNumeric | None = None,
-    area_error_th: float | None = None,
+    area_error_th: Numeric | None = None,
 ) -> dict[str, Any]:
     # % TODO FC: Add advanced user guide
     """
@@ -223,7 +223,7 @@ def generate_mesh(
         the ``EPSG``. On the other hand, if the projection is not well defined in the flow directions file
         (i.e. in ``ASCII`` file), the **epsg** argument must be provided.
 
-    area_error_th: float or None, default None
+    area_error_th: `float` or None, default None
         The threshold of the relative error between the modeled area and the observed area beyond which the
         outlets and the catchment will be excluded from the final mesh. The relative error is computed as
         follows: :math:`error=(area_dln - area)/area`.

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -174,7 +174,7 @@ def generate_mesh(
         box does not overlap the flow direction, the bounding box is padded to the nearest overlapping cell.
 
         .. note::
-            If not given, **x**, **y** and **area** must be filled in.
+            If not given, **x**, **y** and **area** must be provided.
 
     x : `float`, `list[float, ...]` or None, default None
         The x-coordinate(s) of the catchment outlet(s) to mesh.
@@ -219,17 +219,20 @@ def generate_mesh(
 
     epsg : `str`, `int` or None, default None
         The ``EPSG`` value of the flow directions file. By default, if the projection is well
-        defined in the flow directions file. It is not necessary to provide the value of
+        defined in the flow directions file, it is not necessary to provide the value of
         the ``EPSG``. On the other hand, if the projection is not well defined in the flow directions file
-        (i.e. in ``ASCII`` file), the **epsg** argument must be filled in.
+        (i.e. in ``ASCII`` file), the **epsg** argument must be provided.
 
     area_error_th: float or None, default None
         The threshold of the relative error between the modeled area and the observed area beyond which the
-        outlets and the catchment will be excluded of the final mesh. The relative error is computed as folow:
-        :math:`error=(area_dln - area)/area`.
-        Exemple: `area_error_th=0.2` means that all outlets where the surface error are higher than 0.2 (20%)
-        will be excluded. If `area_error_th` is set to None (default), the compuation of the error on the
-        area is ignored and all outlets are included in the mesh.
+        outlets and the catchment will be excluded from the final mesh. The relative error is computed as
+        follows: :math:`error=(area_dln - area)/area`.
+        For example, `area_error_th=0.2` means that all outlets where the surface error is higher than 20%
+        will be excluded.
+
+        .. note::
+            If not given, the computation of the error on the area is ignored and all outlets are included
+            in the mesh.
 
     Returns
     -------
@@ -256,27 +259,26 @@ def generate_mesh(
 
         dx : `numpy.ndarray`
             An array of shape *(nrow, ncol)* containing X cell size.
-            If the projection unit is in degree, the value of ``dx`` is approximated in meter.
+            If the projection unit is in degrees, the value of ``dx`` is approximated in meters.
 
         dy : `numpy.ndarray`
             An array of shape *(nrow, ncol)* containing Y cell size.
-            If the projection unit is in degree, the value of ``dy`` is approximated in meter.
+            If the projection unit is in degrees, the value of ``dy`` is approximated in meters.
 
         flwdir : `numpy.ndarray`
             An array of shape *(nrow, ncol)* containing flow direction.
 
         flwdst : `numpy.ndarray`
             An array of shape *(nrow, ncol)* containing flow distance.
-            It corresponds to the distance in meter from each cell to the most downstream gauge.
-            If there are multiple non-nested downstream gauges, the flow distance are computed for each
-            gauge.
+            It corresponds to the distance in meters from each cell to the most downstream gauge.
+            If there are multiple non-nested downstream gauges, the flow distance are computed for each gauge.
 
         flwacc : `numpy.ndarray`
             An array of shape *(nrow, ncol)* containing flow accumulation. The unit is the square meter.
 
         npar : `int`
-            Number of partition. A partition delimits a set of independent cells on the drainage network. The
-            first partition represents all the most upstream cells and the last partition the gauge(s).
+            Number of partition. A partition delimits a set of independent cells on the drainage network.
+            The first partition represents all the most upstream cells and the last partition the gauge(s).
             It is possible to loop in parallel over all the cells in the same partition.
 
         ncpar : `numpy.ndarray`
@@ -381,7 +383,7 @@ def generate_mesh(
 
     args = _standardize_generate_mesh_args(
         flwdir_path, bbox, x, y, area, code, shp_path, max_depth, epsg, area_error_th
-        )
+    )
 
     return _generate_mesh(*args)
 
@@ -396,7 +398,7 @@ def _generate_mesh_from_xy(
     shp_dataset: gpd.GeoDataFrame | None,
     max_depth: int,
     epsg: int,
-    area_error_th: None | float = None,
+    area_error_th: float | None,
 ) -> dict:
     (xmin, _, xres, _, ymax, yres) = _get_transform(flwdir_dataset)
 
@@ -420,8 +422,6 @@ def _generate_mesh_from_xy(
     area_dln = np.zeros(shape=x.shape, dtype=np.float32)
     sink_dln = np.zeros(shape=x.shape, dtype=np.bool)
     mask_dln = np.zeros(shape=flwdir.shape, dtype=np.int32)
-
-    deleted_catchment = []
 
     deleted_catchment = []
 

--- a/smash/factory/mesh/mesh.py
+++ b/smash/factory/mesh/mesh.py
@@ -380,7 +380,7 @@ def generate_mesh(
     (1000.0, 906044, 0)
     """
 
-    args = _standardize_generate_mesh_args(flwdir_path, bbox, x, y, area, code, shp_path, max_depth, epsg)
+    args = _standardize_generate_mesh_args(flwdir_path, bbox, x, y, area, code, shp_path, max_depth, epsg, area_error_th)
 
     return _generate_mesh(*args)
 


### PR DESCRIPTION
Salut,
Une nouvelle et petite pull request qui ajoute une option à generate_mesh() permettant d'exclure des exutoires dont la surface modélisé est très différente de la surface réel. Pour cela un seuil est défini: area_error_th. 
L'erreur sur les surface est calculé par (Smodel-Sobs)/Sobs.
Si area_error_th est laissé à None, alors le test n'est pas réalisé et tous les exutoires sont ajoutés comme avant :)

Cette pull request s'ajoute à la pull request Regional_meshing #430.

Cette option est interessante car:
- Si la liste d'exutoire passée à Generate mesh est longue, cela permet de filtrer au besoin les exutoires qui sont ajoutés au mesh, sans avoir à le fair à la main et donc en limitant les calculs aux exutoires/domaine validé (par ex si la surface modélisé est de 5 km2 alors que la surface réel est de 40km2, alors autant exclure l'exutoire car on ne regardera jamais les débit. De plus ca ne sert à rien de faire les calculs sur les 5km2).
- Lorsque l'on travail avec des bounding box, c'est chouette de pourvoir passer une base de donnée d'exutoire sans réfléchir. La on peu filtrer les pb. Cela convient au fonctionnement prévus pour faire le lien entre SCHYPRE-GRAFFAS et SMASH.
- Elle est intégrer dans "EasySmash" un environnement pour faire des simu Smash et qui permet l'intègration SCHYPRE-GRAFFAS. Je vous le présenterais bientôt j'espère...
 
A ++
 
Merci
