### PR TITLE
Maint update workflow dependency version

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,12 +20,12 @@ jobs:
         name: Code checks ubuntu-latest
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@latest
+        - uses: actions/checkout@v5
           with:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@latest
+          uses: actions/setup-python@v6
           with:
             python-version: "3.12"
 

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -20,12 +20,12 @@ jobs:
         name: Code checks ubuntu-latest
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@latest
           with:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@latest
           with:
             python-version: "3.12"
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,12 +20,12 @@ jobs:
         name: Documentation ubuntu-latest
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@latest
           with:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@latest
           with:
             python-version: '3.12'
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -20,12 +20,12 @@ jobs:
         name: Documentation ubuntu-latest
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@latest
+        - uses: actions/checkout@v5
           with:
             fetch-depth: 0
 
         - name: Set up Python
-          uses: actions/setup-python@latest
+          uses: actions/setup-python@v6
           with:
             python-version: '3.12'
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,12 +23,12 @@ jobs:
           matrix:
             python-version: ['3.9', '3.10', '3.11', '3.12']
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@latest
           with:
             fetch-depth: 0
 
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@latest
           with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,12 +23,12 @@ jobs:
           matrix:
             python-version: ['3.9', '3.10', '3.11', '3.12']
         steps:
-        - uses: actions/checkout@latest
+        - uses: actions/checkout@v5
           with:
             fetch-depth: 0
 
         - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@latest
+          uses: actions/setup-python@v6
           with:
             python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -43,6 +43,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      
+      - name: Set macOS deployment target (13)
+        if: ${{ matrix.buildplat[0] == 'macos-13' }}
+        run: echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+
+      - name: Set macOS deployment target (14)
+        if: ${{ matrix.buildplat[0] == 'macos-14' }}
+        run: echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -34,22 +34,22 @@ jobs:
         python-version: ['cp39', 'cp310', 'cp311', 'cp312']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@latest
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@latest
         with:
           python-version: '3.12'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0
+        uses: pypa/cibuildwheel@latest
         env:
           CIBW_BUILD: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@latest
         with:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -44,13 +44,15 @@ jobs:
         with:
           python-version: '3.12'
       
-      - name: Set macOS deployment target (13)
-        if: ${{ matrix.buildplat[0] == 'macos-13' }}
-        run: echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+      - name: Set macOS deployment target
+        if: startsWith(matrix.buildplat[0], 'macos-')
+        run: |
+          if [[ "${{ matrix.buildplat[0] }}" == "macos-13" ]]; then
+            echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=13.0" >> $GITHUB_ENV
+          elif [[ "${{ matrix.buildplat[0] }}" == "macos-14" ]]; then
+            echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
+          fi
 
-      - name: Set macOS deployment target (14)
-        if: ${{ matrix.buildplat[0] == 'macos-14' }}
-        run: echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -53,7 +53,6 @@ jobs:
             echo "CIBW_ENVIRONMENT_MACOS=MACOSX_DEPLOYMENT_TARGET=14.0" >> $GITHUB_ENV
           fi
 
-
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4
         env:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -34,22 +34,22 @@ jobs:
         python-version: ['cp39', 'cp310', 'cp311', 'cp312']
 
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@latest
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@latest
+        uses: pypa/cibuildwheel@v3
         env:
           CIBW_BUILD: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
 
-      - uses: actions/upload-artifact@latest
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}-${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: '3.12'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3
+        uses: pypa/cibuildwheel@v3.1.4
         env:
           CIBW_BUILD: ${{ matrix.python-version }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -24,6 +24,7 @@ jobs:
     name: Build wheel ${{ matrix.python-version }}-${{ matrix.buildplat[1] }} ${{ matrix.buildplat[2] }}
     runs-on: ${{ matrix.buildplat[0] }}
     strategy:
+      fail-fast: false
       matrix:
         buildplat:
         - [ubuntu-latest, manylinux, x86_64]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 before-build = "brew reinstall gfortran libomp && brew unlink gfortran && brew link gfortran"
-environment = { MACOSX_DEPLOYMENT_TARGET="14.0" }
+environment = { MACOSX_DEPLOYMENT_TARGET="13.0" }
 
 [tool.ruff]
 line-length = 110

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ tag_prefix = "v"
 parentdir_prefix = "smash-"
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-* cp38-* cp313-* pp* *_i686 *_ppc64le *_s390x"
+skip = "cp38-* cp313-* *_i686 *_ppc64le *_s390x"
 test-command = 'python -c "import smash; print(smash.__version__)"'
 build-verbosity = 3
 
@@ -94,6 +94,7 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 before-build = "brew reinstall gfortran libomp && brew unlink gfortran && brew link gfortran"
+environment = { MACOSX_DEPLOYMENT_TARGET="14.0" }
 
 [tool.ruff]
 line-length = 110

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,6 @@ repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 before-build = "brew reinstall gfortran libomp && brew unlink gfortran && brew link gfortran"
-environment = { MACOSX_DEPLOYMENT_TARGET="13.0" }
 
 [tool.ruff]
 line-length = 110


### PR DESCRIPTION
There is a change in the name of the wheels for manylinux to add glibc version in the name of the wheel. It is something that NumPy is using to create new wheels. With cibuildwheel v2, this new name was not the default one, this is why, during the wheel building process, NumPy was builded from source instead of downloading the wheel. With cibuildwheel v3, the issue is resolved but the MACOSX_DEPLOYMENT_TARGET env variable must be set to 13 or 14 depending on the macos version.