### PR TITLE
Fix: small bug when creating a mesh with a bbox. 

### DIFF
--- a/smash/tests/factory/test_mesh.py
+++ b/smash/tests/factory/test_mesh.py
@@ -64,31 +64,38 @@ def test_bbox_mesh():
 
 
 def test_bbox_padding():
+    # 1km resolution (xres = yres)
     flwdir = smash.factory.load_dataset("flwdir")
 
     bbox = (670_000, 770_000, 6_600_000, 6_700_000)
+    bbox_exp = (670_000, 770_000, 6_600_000, 6_700_000)
+
     bbox_loff = (670_100, 770_100, 6_600_100, 6_700_100)
+    bbox_loff_exp = (670_000, 770_000, 6_600_000, 6_700_000)
+
     bbox_roff = (670_900, 770_900, 6_600_900, 6_700_900)
+    bbox_roff_exp = (671_000, 771_000, 6_601_000, 6_701_000)
+
+    bbox_moff = (670_500, 770_500, 6_600_500, 6_700_500)
+    bbox_moff_exp = (671_000, 771_000, 6_601_000, 6_701_000)
 
     mesh = smash.factory.generate_mesh(flwdir, bbox=bbox, epsg=2154)
     mesh_loff = smash.factory.generate_mesh(flwdir, bbox=bbox_loff, epsg=2154)
     mesh_roff = smash.factory.generate_mesh(flwdir, bbox=bbox_roff, epsg=2154)
+    mesh_moff = smash.factory.generate_mesh(flwdir, bbox=bbox_moff, epsg=2154)
 
     # % Check bounding box padding
-    assert bbox[0] == mesh["xmin"], "overlap_read_data.nopad_xmin"
-    assert bbox[3] == mesh["ymax"], "overlap_read_data.nopad_ymax"
+    assert bbox_exp[0] == mesh["xmin"], "overlap_read_data.nopad_xmin"
+    assert bbox_exp[3] == mesh["ymax"], "overlap_read_data.nopad_ymax"
 
-    assert bbox_loff[0] != mesh_loff["xmin"], "overlap_read_data.loffpad_xmin"
-    assert bbox_loff[3] != mesh_loff["ymax"], "overlap_read_data.loffpad_ymax"
+    assert bbox_loff_exp[0] == mesh_loff["xmin"], "overlap_read_data.loffpad_xmin"
+    assert bbox_loff_exp[3] == mesh_loff["ymax"], "overlap_read_data.loffpad_ymax"
 
-    assert bbox_roff[0] != mesh_roff["xmin"], "overlap_read_data.uoffpad_xmin"
-    assert bbox_roff[3] != mesh_roff["ymax"], "overlap_read_data.uoffpad_ymax"
+    assert bbox_roff_exp[0] == mesh_roff["xmin"], "overlap_read_data.uoffpad_xmin"
+    assert bbox_roff_exp[3] == mesh_roff["ymax"], "overlap_read_data.uoffpad_ymax"
 
-    assert mesh_loff["xmin"] == mesh["xmin"], "overlap_read_data.loff_xmin_eq"
-    assert mesh_loff["ymax"] == mesh["ymax"], "overlap_read_data.loff_ymax_eq"
-
-    assert mesh_roff["xmin"] != mesh["xmin"], "overlap_read_data.uoff_xmin_neq"
-    assert mesh_roff["ymax"] != mesh["ymax"], "overlap_read_data.uoff_ymax_neq"
+    assert bbox_moff_exp[0] == mesh_moff["xmin"], "overlap_read_data.moffpad_xmin"
+    assert bbox_moff_exp[3] == mesh_moff["ymax"], "overlap_read_data.moffpad_ymax"
 
 
 def test_detect_sink():


### PR DESCRIPTION
NumPy rounds to the nearest even value. Thus 1.5 and 2.5 round to 2.0, -0.5 and 0.5 round to 0.0, etc.

This choice cause an issue with the mesh because for a given bounding box, the extend may vary randomly of about 1 pixel in any direction depending the value of xmin and ymax. The solution proposed here is to round manually with usual convention.

voir bug : #473