### PR TITLE
MAINT: Update for ruff 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,8 @@ ignore = [
   "PLR0912",
   # Too many statements
   "PLR0915",
+  # Too many positional arguments
+  "PLR0917",
   # Redefined loop name
   "PLW2901",
   # Checks for else blocks that consist of a single if statement


### PR DESCRIPTION
Too many positional arguments is disable. It would require too much changes in the code base for not that much utility right now.